### PR TITLE
Disable Hunger Mechanic for Now

### DIFF
--- a/Content.Server/FloofStation/Traits/LewdTraitSystem.cs
+++ b/Content.Server/FloofStation/Traits/LewdTraitSystem.cs
@@ -279,15 +279,12 @@ public sealed class LewdTraitSystem : EntitySystem
 
             containerCum.NextGrowth = now + containerCum.GrowthDelay;
 
-            if (_mobState.IsDead(uid))
-                continue;
-
             if (EntityManager.TryGetComponent(uid, out HungerComponent? hunger))
             {
                 if (_hunger.GetHungerThreshold(hunger) < HungerThreshold.Okay)
                     continue;
 
-                _hunger.ModifyHunger(uid, -containerCum.HungerUsage, hunger);
+                //_hunger.ModifyHunger(uid, -containerCum.HungerUsage, hunger);
             }
 
             if (!_solutionContainer.ResolveSolution(uid, containerCum.SolutionName, ref containerCum.Solution))
@@ -303,15 +300,12 @@ public sealed class LewdTraitSystem : EntitySystem
 
             containerMilk.NextGrowth = now + containerMilk.GrowthDelay;
 
-            if (_mobState.IsDead(uid))
-                continue;
-
             if (EntityManager.TryGetComponent(uid, out HungerComponent? hunger))
             {
                 if (_hunger.GetHungerThreshold(hunger) < HungerThreshold.Okay)
                     continue;
 
-                _hunger.ModifyHunger(uid, -containerMilk.HungerUsage, hunger);
+                //_hunger.ModifyHunger(uid, -containerMilk.HungerUsage, hunger);
             }
 
             if (!_solutionContainer.ResolveSolution(uid, containerMilk.SolutionName, ref containerMilk.Solution))

--- a/Content.Server/FloofStation/Traits/LewdTraitSystem.cs
+++ b/Content.Server/FloofStation/Traits/LewdTraitSystem.cs
@@ -279,6 +279,9 @@ public sealed class LewdTraitSystem : EntitySystem
 
             containerCum.NextGrowth = now + containerCum.GrowthDelay;
 
+            if (_mobState.IsDead(uid))
+                continue;
+
             if (EntityManager.TryGetComponent(uid, out HungerComponent? hunger))
             {
                 if (_hunger.GetHungerThreshold(hunger) < HungerThreshold.Okay)
@@ -299,6 +302,9 @@ public sealed class LewdTraitSystem : EntitySystem
                 continue;
 
             containerMilk.NextGrowth = now + containerMilk.GrowthDelay;
+
+            if (_mobState.IsDead(uid))
+                continue;
 
             if (EntityManager.TryGetComponent(uid, out HungerComponent? hunger))
             {


### PR DESCRIPTION
# Description

Disables the hunger inducing part of the code temporarily until a proper check is in place for if the solution is filled.

---

# Changelog

:cl:
- tweak: Cum/Milk regeneration doesn't use hunger.
