### PR TITLE
Adds the Handheld Radio to the Autolathe

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
@@ -199,6 +199,7 @@
       - ShockCollar # FloofStation
       - LeashBasic # FloofStation
       - ClothingEyesHypnoVisor # FloofStation
+      - ToolRadioHandheld # Floofstation
       - StationAnchorCircuitboard
   - type: EmagLatheRecipes
     emagStaticRecipes:

--- a/Resources/Prototypes/Floof/Recipes/Lathes/tools.yml
+++ b/Resources/Prototypes/Floof/Recipes/Lathes/tools.yml
@@ -14,3 +14,12 @@
   materials:
     Glass: 100
     Steel: 75
+
+- type: latheRecipe
+  id: ToolRadioHandheld
+  result: RadioHandheld
+  completetime: 3.5
+  materials:
+    Glass: 50
+    Steel: 100
+    Plastic: 50


### PR DESCRIPTION
# Description
This is a much-wanted Thing to happen. There is a minimal number of radios in the game. Sometimes not enough unless buying restocks (doesn't make anysense) 
---

# Media 
![image](https://github.com/user-attachments/assets/a538fb10-9cfe-4432-828b-4d66830c742b)
![image](https://github.com/user-attachments/assets/18032c21-d866-4f36-97e3-40d268d9fc8f)


---
# Changelog

:cl:
- add: Added the Handheld radio to the autolathe.
