### PR TITLE
Bloodpack Related Additions

### DIFF
--- a/Content.Shared/Kitchen/MicrowaveMealRecipePrototype.cs
+++ b/Content.Shared/Kitchen/MicrowaveMealRecipePrototype.cs
@@ -53,6 +53,7 @@ namespace Content.Shared.Kitchen
             return n;
         }
 
+        //Floofstation specific method - Start
         /// <summary>
         ///     Sums the quantity of reagents in a recipe for sorting the recipe list.
         ///     A fallback check if the IngredientCount is equal when sorting the
@@ -68,5 +69,6 @@ namespace Content.Shared.Kitchen
             }
             return n;
         }
+        //Floofstation specific method - End
     }
 }

--- a/Content.Shared/Kitchen/MicrowaveMealRecipePrototype.cs
+++ b/Content.Shared/Kitchen/MicrowaveMealRecipePrototype.cs
@@ -52,5 +52,21 @@ namespace Content.Shared.Kitchen
             }
             return n;
         }
+
+        /// <summary>
+        ///     Sums the quantity of reagents in a recipe for sorting the recipe list.
+        ///     A fallback check if the IngredientCount is equal when sorting the
+        ///     recipe list.
+        /// </summary>
+        /// <returns></returns>
+        public FixedPoint2 ReagentQuantity()
+        {
+            FixedPoint2 n = 0;
+            foreach (FixedPoint2 i in _ingsReagents.Values)
+            {
+                n += i;
+            }
+            return n;
+        }
     }
 }

--- a/Content.Shared/Kitchen/RecipeManager.cs
+++ b/Content.Shared/Kitchen/RecipeManager.cs
@@ -38,7 +38,15 @@ namespace Content.Shared.Kitchen
 
                 var nx = x.IngredientCount();
                 var ny = y.IngredientCount();
-                return -nx.CompareTo(ny);
+                if (-nx.CompareTo(ny) != 0)
+                {
+                    return -nx.CompareTo(ny);//If total solid ingredients and unique reagents are different, return result.
+                }
+
+                var vx = x.ReagentQuantity();
+                var vy = y.ReagentQuantity();
+
+                return -vx.CompareTo(vy);//Fallback result based on total amount of reagents.
             }
         }
     }

--- a/Content.Shared/Kitchen/RecipeManager.cs
+++ b/Content.Shared/Kitchen/RecipeManager.cs
@@ -38,6 +38,9 @@ namespace Content.Shared.Kitchen
 
                 var nx = x.IngredientCount();
                 var ny = y.IngredientCount();
+                //Floofstation - Start
+                //Added a fallback for recipes with the same results from IngredientCount
+                //Original: return -nx.CompareTo(ny)
                 if (-nx.CompareTo(ny) != 0)
                 {
                     return -nx.CompareTo(ny);//If total solid ingredients and unique reagents are different, return result.
@@ -47,6 +50,7 @@ namespace Content.Shared.Kitchen
                 var vy = y.ReagentQuantity();
 
                 return -vx.CompareTo(vy);//Fallback result based on total amount of reagents.
+                //Floofstation - End
             }
         }
     }

--- a/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
@@ -821,6 +821,7 @@
       - SpeedLoaderMagnumEmpty
       - MagazineMagnumEmpty #floof
       - MagazineMagnum #floof
+      - SterileBag #floof
       - Stunbaton
       - TargetClown
       - ClothingOuterArmorPlateCarrier
@@ -1074,6 +1075,7 @@
       - WhiteCane
       - HandheldGPSBasic # Floof - port to EE
       - HandheldStationMap # Floof - port to EE
+      - SterileBag # floof
     dynamicRecipes:
       - ChemicalPayload
       - CryostasisBeaker

--- a/Resources/Prototypes/Floof/Entities/Objects/Specific/Medical/healing.yml
+++ b/Resources/Prototypes/Floof/Entities/Objects/Specific/Medical/healing.yml
@@ -1,0 +1,26 @@
+- type: entity
+  id: Bloodpack1
+  parent: Bloodpack
+  suffix: Single
+  components:
+  - type: Stack
+    stackType: Bloodpack
+    count: 1
+
+- type: entity
+  id: Bloodpack5
+  parent: Bloodpack
+  suffix: 5
+  components:
+  - type: Stack
+    stackType: Bloodpack
+    count: 5
+
+- type: entity
+  id: Bloodpack10
+  parent: Bloodpack
+  suffix: 10
+  components:
+  - type: Stack
+    stackType: Bloodpack
+    count: 10

--- a/Resources/Prototypes/Floof/Entities/Objects/Specific/Medical/sterilebag.yml
+++ b/Resources/Prototypes/Floof/Entities/Objects/Specific/Medical/sterilebag.yml
@@ -1,0 +1,11 @@
+- type: entity
+  name: sterile bag
+  description: A sterile bag, ready to be filled.
+  parent: BaseItem
+  id: SterileBag
+  components:
+  - type: Sprite
+    sprite: Objects/Specific/Medical/medical.rsi
+    state: bloodpack-empty
+  - type: StaticPrice
+    price: 0

--- a/Resources/Prototypes/Floof/Recipes/Cooking/medical_recipes.yml
+++ b/Resources/Prototypes/Floof/Recipes/Cooking/medical_recipes.yml
@@ -1,0 +1,105 @@
+#Singular blood pack recipe
+- type: microwaveMealRecipe
+  id: RecipeBloodPack1
+  name: single blood pack recipe
+  result: Bloodpack1
+  time: 5
+  solids:
+    SterileBag: 1
+  reagents:
+    Blood: 30 #Bloodpacks are 30 per use.
+
+#Single hybrid blood pack recipe
+- type: microwaveMealRecipe
+  id: RecipeHybridBloodPack1
+  name: single hybrid blood pack recipe
+  result: Bloodpack1
+  time: 5
+  solids:
+    SterileBag: 1
+  reagents:
+    Blood: 15
+    Saline: 15
+
+#Five blood pack recipe
+- type: microwaveMealRecipe
+  id: RecipeBloodPack5
+  name: five blood pack recipe
+  result: Bloodpack5
+  time: 5
+  solids:
+    SterileBag: 1
+  reagents:
+    Blood: 150 #5 stack of 30 units per use.
+
+#Five hybrid blood pack recipe
+- type: microwaveMealRecipe
+  id: RecipeHybridBloodPack5
+  name: five hybrid blood pack recipe
+  result: Bloodpack5
+  time: 5
+  solids:
+    SterileBag: 1
+  reagents:
+    Blood: 75
+    Saline: 75
+
+#Ten blood pack recipe
+- type: microwaveMealRecipe
+  id: RecipeBloodPack10
+  name: ten blood pack recipe
+  result: Bloodpack10
+  time: 5
+  solids:
+    SterileBag: 1
+  reagents:
+    Blood: 300 #10 stack of 30 units per use.
+
+#Ten hybrid blood pack recipe
+- type: microwaveMealRecipe
+  id: RecipeHybridBloodPack10
+  name: ten hybrid blood pack recipe
+  result: Bloodpack10
+  time: 5
+  solids:
+    SterileBag: 1
+  reagents:
+    Blood: 150
+    Saline: 150
+
+#Full blood pack recipe
+- type: microwaveMealRecipe
+  id: RecipeBloodPack
+  name: full blood pack recipe
+  result: Bloodpack
+  time: 5
+  solids:
+    SterileBag: 1
+  reagents:
+    Blood: 450 #450 = 15 stack of 30 units per use.
+
+#Full hybrid blood pack recipe
+- type: microwaveMealRecipe
+  id: RecipeHybridBloodPack
+  name: full hybrid blood pack recipe
+  result: Bloodpack
+  time: 5
+  solids:
+    SterileBag: 1
+  reagents:
+    Blood: 225
+    Saline: 225
+
+#PFC based blood substitute recipe
+- type: microwaveMealRecipe
+  id: RecipePFCSubstitute
+  name: PFC blood substitute recipe
+  result: Bloodpack
+  time: 10
+  solids:
+    SterileBag: 1
+  reagents:
+    Nutriment: 30
+    Vitamin: 15
+    Saline: 50
+    Bleach: 5

--- a/Resources/Prototypes/Floof/Recipes/Lathes/medical.yml
+++ b/Resources/Prototypes/Floof/Recipes/Lathes/medical.yml
@@ -8,7 +8,7 @@
     Silver: 500
 
 - type: latheRecipe
-  id: SterileBag
+  id: MedSterileBag
   result: SterileBag
   completetime: 2
   materials:

--- a/Resources/Prototypes/Floof/Recipes/Lathes/medical.yml
+++ b/Resources/Prototypes/Floof/Recipes/Lathes/medical.yml
@@ -6,3 +6,10 @@
     PlasmaGlass: 500
     Plasteel: 500
     Silver: 500
+
+- type: latheRecipe
+  id: SterileBag
+  result: SterileBag
+  completetime: 2
+  materials:
+    Plastic: 50

--- a/Resources/Prototypes/Floof/Recipes/Lathes/medical.yml
+++ b/Resources/Prototypes/Floof/Recipes/Lathes/medical.yml
@@ -8,7 +8,7 @@
     Silver: 500
 
 - type: latheRecipe
-  id: MedSterileBag
+  id: SterileBag
   result: SterileBag
   completetime: 2
   materials:

--- a/Resources/Prototypes/Floof/Recipes/Lathes/security.yml
+++ b/Resources/Prototypes/Floof/Recipes/Lathes/security.yml
@@ -23,7 +23,7 @@
      Plastic: 500
 
 - type: latheRecipe
-  id: SterileBag
+  id: SecSterileBag
   result: SterileBag
   completetime: 2
   materials:

--- a/Resources/Prototypes/Floof/Recipes/Lathes/security.yml
+++ b/Resources/Prototypes/Floof/Recipes/Lathes/security.yml
@@ -21,3 +21,10 @@
   materials:
      Steel: 1000
      Plastic: 500
+
+- type: latheRecipe
+  id: SterileBag
+  result: SterileBag
+  completetime: 2
+  materials:
+    Plastic: 50

--- a/Resources/Prototypes/Floof/Recipes/Lathes/security.yml
+++ b/Resources/Prototypes/Floof/Recipes/Lathes/security.yml
@@ -21,10 +21,3 @@
   materials:
      Steel: 1000
      Plastic: 500
-
-- type: latheRecipe
-  id: SecSterileBag
-  result: SterileBag
-  completetime: 2
-  materials:
-    Plastic: 50

--- a/Resources/Prototypes/Floof/Recipes/Reactions/chemicals.yml
+++ b/Resources/Prototypes/Floof/Recipes/Reactions/chemicals.yml
@@ -29,7 +29,7 @@
       amount: 1
   products:
     SalicylicAcid: 3
-    
+
 - type: reaction
   id : Formaldehyde
   reactants:
@@ -39,3 +39,18 @@
       amount: 1
   products:
     Formaldehyde: 3
+
+- type: reaction
+  id : PFCBlood
+  minTemp: 310
+  reactants:
+    Nutriment:
+      amount: 6
+    Vitamin:
+      amount: 3
+    Saline:
+      amount: 10
+    Bleach:
+      amount: 1
+  products:
+    Blood: 20


### PR DESCRIPTION
# Description

Adds a sterile bag that can be printed from the medical and security techfabs.

Adds recipes for creating bloodpacks from sterile bags and blood, a blood and saline mix, or a perfluorocarbon based blood substitute.

Adds a chemical reaction for the production of blood.

Adds an extra section to the recipe sorter that ensures recipes with greater quantities of reagents are sorted higher than recipes with less. This only gets checked if the recipes use the same amount of solid and unique reagents.

---

# Changelog

:cl: sprkl
- add: Added sterile bags which can be processed into blood packs via a microwave.
- add: Added a recipe to synthesize blood.
