### PR TITLE
Cherry-Picked New Lights

### DIFF
--- a/Resources/Prototypes/Catalog/Fills/Boxes/general.yml
+++ b/Resources/Prototypes/Catalog/Fills/Boxes/general.yml
@@ -61,6 +61,16 @@
       - LightBulb
 
 - type: entity
+  name: lightbulb box warm
+  parent: BoxLightbulb
+  id: BoxWarmLightbulb
+  components:
+  - type: StorageFill
+    contents:
+      - id: WarmLightBulb
+        amount: 12
+
+- type: entity
   name: lighttube box
   parent: BoxCardboard
   id: BoxLighttube

--- a/Resources/Prototypes/Entities/Objects/Power/lights.yml
+++ b/Resources/Prototypes/Entities/Objects/Power/lights.yml
@@ -160,6 +160,23 @@
     - Trash
 
 - type: entity
+  parent: BaseLightbulb
+  name: warm light bulb
+  id: WarmLightBulb
+  description: A warm light bulb for a more cozy atmosphere.
+  components:
+  - type: LightBulb
+    bulb: Bulb
+    color: "#ff9833" # 2200k color temp
+    lightEnergy: 1
+    lightRadius: 6
+    lightSoftness: 3
+  - type: Tag
+    tags:
+    - LightBulb
+    - Trash
+
+- type: entity
   parent: LightBulb
   name: old incandescent light bulb
   id: LightBulbOld

--- a/Resources/Prototypes/Entities/Objects/Power/lights.yml
+++ b/Resources/Prototypes/Entities/Objects/Power/lights.yml
@@ -143,6 +143,23 @@
     PowerUse: 6 #LEDs are more power efficient than incandescent bulbs
 
 - type: entity
+  parent: BaseLightbulb
+  name: dim light bulb
+  id: DimLightBulb
+  description: A dim light bulb for populating the darkness of maintenance.
+  components:
+  - type: LightBulb
+    bulb: Bulb
+    color: "#ba473f"
+    lightEnergy: 0.5
+    lightRadius: 5
+    lightSoftness: 3
+  - type: Tag
+    tags:
+    - LightBulb
+    - Trash
+
+- type: entity
   parent: LightBulb
   name: old incandescent light bulb
   id: LightBulbOld

--- a/Resources/Prototypes/Entities/Objects/Power/lights.yml
+++ b/Resources/Prototypes/Entities/Objects/Power/lights.yml
@@ -294,17 +294,25 @@
 
 - type: entity
   parent: BaseLightTube
-  name: cyan crystal light tube
+  name: crystal light tube
   description: A high power high energy bulb which has a small colored crystal inside.
-  id: LightTubeCrystalCyan
+  id: BaseLightTubeCrystal
+  abstract: true
   components:
   - type: LightBulb
-    color: "#47f8ff"
     lightEnergy: 3
     lightRadius: 8
     lightSoftness: 0.5
     BurningTemperature: 350
     PowerUse: 60
+
+- type: entity
+  parent: BaseLightTubeCrystal
+  name: cyan crystal light tube
+  id: LightTubeCrystalCyan
+  components:
+  - type: LightBulb
+    color: "#47f8ff"
   - type: Construction
     graph: CyanLight
     node: icon
@@ -314,17 +322,12 @@
     - id: ShardCrystalCyan
 
 - type: entity
-  parent: LightTubeCrystalCyan
+  parent: BaseLightTubeCrystal
   name: blue crystal light tube
   id: LightTubeCrystalBlue
   components:
   - type: LightBulb
     color: "#39a1ff"
-    lightEnergy: 3
-    lightRadius: 8
-    lightSoftness: 0.5
-    BurningTemperature: 350
-    PowerUse: 60
   - type: Construction
     graph: BlueLight
     node: icon
@@ -334,17 +337,12 @@
     - id: ShardCrystalBlue
 
 - type: entity
-  parent: LightTubeCrystalCyan
+  parent: BaseLightTubeCrystal
   name: pink crystal light tube
   id: LightTubeCrystalPink
   components:
   - type: LightBulb
     color: "#ff66cc"
-    lightEnergy: 3
-    lightRadius: 8
-    lightSoftness: 0.5
-    BurningTemperature: 350
-    PowerUse: 60
   - type: Construction
     graph: PinkLight
     node: icon
@@ -354,17 +352,12 @@
     - id: ShardCrystalPink
 
 - type: entity
-  parent: LightTubeCrystalCyan
+  parent: BaseLightTubeCrystal
   name: orange crystal light tube
   id: LightTubeCrystalOrange
   components:
   - type: LightBulb
     color: "#ff8227"
-    lightEnergy: 3
-    lightRadius: 8
-    lightSoftness: 0.5
-    BurningTemperature: 350
-    PowerUse: 60
   - type: Construction
     graph: OrangeLight
     node: icon
@@ -374,17 +367,12 @@
     - id: ShardCrystalOrange
 
 - type: entity
-  parent: LightTubeCrystalCyan
+  parent: BaseLightTubeCrystal
   name: red crystal light tube
   id: LightTubeCrystalRed
   components:
   - type: LightBulb
     color: "#fb4747"
-    lightEnergy: 3
-    lightRadius: 8
-    lightSoftness: 0.5
-    BurningTemperature: 350
-    PowerUse: 60
   - type: Construction
     graph: RedLight
     node: icon
@@ -400,15 +388,117 @@
   components:
   - type: LightBulb
     color: "#52ff39"
-    lightEnergy: 3
-    lightRadius: 8
-    lightSoftness: 0.5
-    BurningTemperature: 350
-    PowerUse: 60
   - type: Construction
     graph: GreenLight
     node: icon
   - type: WelderRefinable
+    refineResult:
+    - id: SheetGlass1
+    - id: ShardCrystalGreen
+
+
+- type: entity
+  parent: BaseLightbulb
+  name: crystal light bulb
+  description: A high power high energy bulb which has a small colored crystal inside.
+  id: BaseLightbulbCrystal
+  abstract: true
+  components:
+  - type: LightBulb
+    color: "#47f8ff"
+    lightEnergy: 1
+    lightRadius: 6
+    lightSoftness: 0.5
+    BurningTemperature: 350
+    PowerUse: 60
+    bulb: Bulb
+
+- type: entity
+  parent: BaseLightbulbCrystal
+  name: cyan crystal light bulb
+  id: LightBulbCrystalCyan
+  components:
+  - type: LightBulb
+    color: "#47f8ff"
+  - type: Construction
+    graph: CyanLightBulb
+    node: icon
+  - type: ToolRefinable
+    refineResult:
+    - id: SheetGlass1
+    - id: ShardCrystalCyan
+
+- type: entity
+  parent: BaseLightbulbCrystal
+  name: blue crystal light bulb
+  id: LightBulbCrystalBlue
+  components:
+  - type: LightBulb
+    color: "#39a1ff"
+  - type: Construction
+    graph: BlueLightBulb
+    node: icon
+  - type: ToolRefinable
+    refineResult:
+    - id: SheetGlass1
+    - id: ShardCrystalBlue
+
+- type: entity
+  parent: BaseLightbulbCrystal
+  name: pink crystal light bulb
+  id: LightBulbCrystalPink
+  components:
+  - type: LightBulb
+    color: "#ff66cc"
+  - type: Construction
+    graph: PinkLightBulb
+    node: icon
+  - type: ToolRefinable
+    refineResult:
+    - id: SheetGlass1
+    - id: ShardCrystalPink
+
+- type: entity
+  parent: BaseLightbulbCrystal
+  name: orange crystal light bulb
+  id: LightBulbCrystalOrange
+  components:
+  - type: LightBulb
+    color: "#ff8227"
+  - type: Construction
+    graph: OrangeLightBulb
+    node: icon
+  - type: ToolRefinable
+    refineResult:
+    - id: SheetGlass1
+    - id: ShardCrystalOrange
+
+- type: entity
+  parent: BaseLightbulbCrystal
+  name: red crystal light bulb
+  id: LightBulbCrystalRed
+  components:
+  - type: LightBulb
+    color: "#fb4747"
+  - type: Construction
+    graph: RedLightBulb
+    node: icon
+  - type: ToolRefinable
+    refineResult:
+    - id: SheetGlass1
+    - id: ShardCrystalRed
+
+- type: entity
+  parent: BaseLightbulbCrystal
+  name: green crystal light bulb
+  id: LightBulbCrystalGreen
+  components:
+  - type: LightBulb
+    color: "#52ff39"
+  - type: Construction
+    graph: GreenLightBulb
+    node: icon
+  - type: ToolRefinable
     refineResult:
     - id: SheetGlass1
     - id: ShardCrystalGreen

--- a/Resources/Prototypes/Entities/Objects/Power/lights.yml
+++ b/Resources/Prototypes/Entities/Objects/Power/lights.yml
@@ -154,10 +154,6 @@
     lightEnergy: 0.5
     lightRadius: 5
     lightSoftness: 3
-  - type: Tag
-    tags:
-    - LightBulb
-    - Trash
 
 - type: entity
   parent: BaseLightbulb
@@ -171,10 +167,6 @@
     lightEnergy: 1
     lightRadius: 6
     lightSoftness: 3
-  - type: Tag
-    tags:
-    - LightBulb
-    - Trash
 
 - type: entity
   parent: LightBulb
@@ -423,7 +415,7 @@
   - type: Construction
     graph: CyanLightBulb
     node: icon
-  - type: ToolRefinable
+  - type: WelderRefinable
     refineResult:
     - id: SheetGlass1
     - id: ShardCrystalCyan
@@ -438,7 +430,7 @@
   - type: Construction
     graph: BlueLightBulb
     node: icon
-  - type: ToolRefinable
+  - type: WelderRefinable
     refineResult:
     - id: SheetGlass1
     - id: ShardCrystalBlue
@@ -453,7 +445,7 @@
   - type: Construction
     graph: PinkLightBulb
     node: icon
-  - type: ToolRefinable
+  - type: WelderRefinable
     refineResult:
     - id: SheetGlass1
     - id: ShardCrystalPink
@@ -468,7 +460,7 @@
   - type: Construction
     graph: OrangeLightBulb
     node: icon
-  - type: ToolRefinable
+  - type: WelderRefinable
     refineResult:
     - id: SheetGlass1
     - id: ShardCrystalOrange
@@ -483,7 +475,7 @@
   - type: Construction
     graph: RedLightBulb
     node: icon
-  - type: ToolRefinable
+  - type: WelderRefinable
     refineResult:
     - id: SheetGlass1
     - id: ShardCrystalRed
@@ -498,7 +490,7 @@
   - type: Construction
     graph: GreenLightBulb
     node: icon
-  - type: ToolRefinable
+  - type: WelderRefinable
     refineResult:
     - id: SheetGlass1
     - id: ShardCrystalGreen

--- a/Resources/Prototypes/Entities/Structures/Lighting/base_lighting.yml
+++ b/Resources/Prototypes/Entities/Structures/Lighting/base_lighting.yml
@@ -334,6 +334,27 @@
         Heat: 1
 
 - type: entity
+  id: PoweredDimSmallLight
+  suffix: Dim
+  parent: PoweredSmallLightEmpty
+  components:
+  - type: Sprite
+    state: base
+  - type: PointLight
+    enabled: true
+    radius: 5
+    energy: 0.5
+    softness: 3
+    color: "#ba473f"
+  - type: PoweredLight
+    hasLampOnSpawn: DimLightBulb
+  - type: DamageOnInteract
+    damage:
+      types:
+        Heat: 1
+    popupText: powered-light-component-burn-hand
+
+- type: entity
   id: PoweredSmallLight
   suffix: ""
   parent: PoweredSmallLightEmpty

--- a/Resources/Prototypes/Entities/Structures/Lighting/base_lighting.yml
+++ b/Resources/Prototypes/Entities/Structures/Lighting/base_lighting.yml
@@ -355,6 +355,27 @@
     popupText: powered-light-component-burn-hand
 
 - type: entity
+  id: PoweredWarmSmallLight
+  suffix: Warm
+  parent: PoweredSmallLightEmpty
+  components:
+  - type: Sprite
+    state: base
+  - type: PointLight
+    enabled: true
+    radius: 6
+    energy: 1
+    softness: 3
+    color: "#FF8A0C"
+  - type: PoweredLight
+    hasLampOnSpawn: WarmLightBulb
+  - type: DamageOnInteract
+    damage:
+      types:
+        Heat: 2
+    popupText: powered-light-component-burn-hand
+
+- type: entity
   id: PoweredSmallLight
   suffix: ""
   parent: PoweredSmallLightEmpty

--- a/Resources/Prototypes/Entities/Structures/Lighting/base_lighting.yml
+++ b/Resources/Prototypes/Entities/Structures/Lighting/base_lighting.yml
@@ -348,7 +348,6 @@
     color: "#ba473f"
   - type: PoweredLight
     hasLampOnSpawn: DimLightBulb
-  - type: DamageOnInteract
     damage:
       types:
         Heat: 1
@@ -369,7 +368,6 @@
     color: "#FF8A0C"
   - type: PoweredLight
     hasLampOnSpawn: WarmLightBulb
-  - type: DamageOnInteract
     damage:
       types:
         Heat: 2

--- a/Resources/Prototypes/Entities/Structures/Lighting/base_lighting.yml
+++ b/Resources/Prototypes/Entities/Structures/Lighting/base_lighting.yml
@@ -351,7 +351,6 @@
     damage:
       types:
         Heat: 1
-    popupText: powered-light-component-burn-hand
 
 - type: entity
   id: PoweredWarmSmallLight
@@ -371,7 +370,6 @@
     damage:
       types:
         Heat: 2
-    popupText: powered-light-component-burn-hand
 
 - type: entity
   id: PoweredSmallLight

--- a/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
@@ -151,6 +151,7 @@
       - LightBulb
       - LedLightBulb
       - DimLightBulb
+      - WarmLightBulb
       - Bucket
       - DrinkMug
       - DrinkMugMetal

--- a/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
@@ -150,6 +150,7 @@
       - ExteriorLightTube
       - LightBulb
       - LedLightBulb
+      - DimLightBulb
       - Bucket
       - DrinkMug
       - DrinkMugMetal

--- a/Resources/Prototypes/Recipes/Construction/Graphs/utilities/lighting.yml
+++ b/Resources/Prototypes/Recipes/Construction/Graphs/utilities/lighting.yml
@@ -118,3 +118,124 @@
               doAfter: 1
     - node: icon
       entity: LightTubeCrystalGreen
+
+- type: constructionGraph
+  id: CyanLightBulb
+  start: start
+  graph:
+  - node: start
+    edges:
+    - to: icon
+      steps:
+      - material: Glass
+        amount: 1
+        doAfter: 1
+      - tag: CrystalCyan
+        name: cyan crystal shard
+        icon:
+          sprite: Objects/Materials/Shards/crystal.rsi
+          state: shard1
+          color: #52ff39
+        doAfter: 1
+  - node: icon
+    entity: LightBulbCrystalCyan
+
+- type: constructionGraph
+  id: BlueLightBulb
+  start: start
+  graph:
+  - node: start
+    edges:
+    - to: icon
+      steps:
+      - material: Glass
+        amount: 1
+        doAfter: 1
+      - tag: CrystalBlue
+        name: blue crystal shard
+        icon:
+          sprite: Objects/Materials/Shards/crystal.rsi
+          state: shard1
+        doAfter: 1
+  - node: icon
+    entity: LightBulbCrystalBlue
+
+- type: constructionGraph
+  id: PinkLightBulb
+  start: start
+  graph:
+  - node: start
+    edges:
+    - to: icon
+      steps:
+      - material: Glass
+        amount: 1
+        doAfter: 1
+      - tag: CrystalPink
+        name: pink crystal shard
+        icon:
+          sprite: Objects/Materials/Shards/crystal.rsi
+          state: shard1
+        doAfter: 1
+  - node: icon
+    entity: LightBulbCrystalPink
+
+- type: constructionGraph
+  id: OrangeLightBulb
+  start: start
+  graph:
+  - node: start
+    edges:
+    - to: icon
+      steps:
+      - material: Glass
+        amount: 1
+        doAfter: 1
+      - tag: CrystalOrange
+        name: orange crystal shard
+        icon:
+          sprite: Objects/Materials/Shards/crystal.rsi
+          state: shard1
+        doAfter: 1
+  - node: icon
+    entity: LightBulbCrystalOrange
+
+- type: constructionGraph
+  id: RedLightBulb
+  start: start
+  graph:
+  - node: start
+    edges:
+    - to: icon
+      steps:
+      - material: Glass
+        amount: 1
+        doAfter: 1
+      - tag: CrystalRed
+        name: red crystal shard
+        icon:
+          sprite: Objects/Materials/Shards/crystal.rsi
+          state: shard1
+        doAfter: 1
+  - node: icon
+    entity: LightBulbCrystalRed
+
+- type: constructionGraph
+  id: GreenLightBulb
+  start: start
+  graph:
+  - node: start
+    edges:
+    - to: icon
+      steps:
+      - material: Glass
+        amount: 1
+        doAfter: 1
+      - tag: CrystalGreen
+        name: green crystal shard
+        icon:
+          sprite: Objects/Materials/Shards/crystal.rsi
+          state: shard1
+        doAfter: 1
+  - node: icon
+    entity: LightBulbCrystalGreen

--- a/Resources/Prototypes/Recipes/Construction/lighting.yml
+++ b/Resources/Prototypes/Recipes/Construction/lighting.yml
@@ -5,7 +5,7 @@
   startNode: start
   targetNode: icon
   category: construction-category-utilities
-  description: A high powered light tube containing a cyan crystal
+  description: A high powered light tube containing a cyan crystal.
   icon: { sprite: Objects/Power/light_tube.rsi, state: normal }
   objectType: Item
 
@@ -16,7 +16,7 @@
   startNode: start
   targetNode: icon
   category: construction-category-utilities
-  description: A high powered light tube containing a blue crystal
+  description: A high powered light tube containing a blue crystal.
   icon: { sprite: Objects/Power/light_tube.rsi, state: normal }
   objectType: Item
 
@@ -27,7 +27,7 @@
   startNode: start
   targetNode: icon
   category: construction-category-utilities
-  description: A high powered light tube containing a pink crystal
+  description: A high powered light tube containing a pink crystal.
   icon: { sprite: Objects/Power/light_tube.rsi, state: normal }
   objectType: Item
 
@@ -38,7 +38,7 @@
   startNode: start
   targetNode: icon
   category: construction-category-utilities
-  description: A high powered light tube containing an orange crystal
+  description: A high powered light tube containing an orange crystal.
   icon: { sprite: Objects/Power/light_tube.rsi, state: normal }
   objectType: Item
 
@@ -49,7 +49,7 @@
   startNode: start
   targetNode: icon
   category: construction-category-utilities
-  description: A high powered light tube containing a red crystal
+  description: A high powered light tube containing a red crystal.
   icon: { sprite: Objects/Power/light_tube.rsi, state: normal }
   objectType: Item
 
@@ -60,6 +60,72 @@
   startNode: start
   targetNode: icon
   category: construction-category-utilities
-  description: A high powered light tube containing a green crystal
+  description: A high powered light tube containing a green crystal.
   icon: { sprite: Objects/Power/light_tube.rsi, state: normal }
+  objectType: Item
+
+- type: construction
+  name: cyan light bulb
+  id: CyanLightBulb
+  graph: CyanLightBulb
+  startNode: start
+  targetNode: icon
+  category: construction-category-utilities
+  description: A high powered light bulb containing a cyan crystal.
+  icon: { sprite: Objects/Power/light_bulb.rsi, state: normal }
+  objectType: Item
+
+- type: construction
+  name: blue light bulb
+  id: BlueLightBulb
+  graph: BlueLightBulb
+  startNode: start
+  targetNode: icon
+  category: construction-category-utilities
+  description: A high powered light bulb containing a blue crystal.
+  icon: { sprite: Objects/Power/light_bulb.rsi, state: normal }
+  objectType: Item
+
+- type: construction
+  name: pink light bulb
+  id: PinkLightBulb
+  graph: PinkLightBulb
+  startNode: start
+  targetNode: icon
+  category: construction-category-utilities
+  description: A high powered light bulb containing a pink crystal.
+  icon: { sprite: Objects/Power/light_bulb.rsi, state: normal }
+  objectType: Item
+
+- type: construction
+  name: orange light bulb
+  id: OrangeLightBulb
+  graph: OrangeLightBulb
+  startNode: start
+  targetNode: icon
+  category: construction-category-utilities
+  description: A high powered light bulb containing an orange crystal.
+  icon: { sprite: Objects/Power/light_bulb.rsi, state: normal }
+  objectType: Item
+
+- type: construction
+  name: red light bulb
+  id: RedLightBulb
+  graph: RedLightBulb
+  startNode: start
+  targetNode: icon
+  category: construction-category-utilities
+  description: A high powered light bulb containing a red crystal.
+  icon: { sprite: Objects/Power/light_bulb.rsi, state: normal }
+  objectType: Item
+
+- type: construction
+  name: green light bulb
+  id: GreenLightBulb
+  graph: GreenLightBulb
+  startNode: start
+  targetNode: icon
+  category: construction-category-utilities
+  description: A high powered light bulb containing a green crystal.
+  icon: { sprite: Objects/Power/light_bulb.rsi, state: normal }
   objectType: Item

--- a/Resources/Prototypes/Recipes/Lathes/misc.yml
+++ b/Resources/Prototypes/Recipes/Lathes/misc.yml
@@ -53,6 +53,15 @@
     Glass: 50
 
 - type: latheRecipe
+  id: DimLightBulb
+  result: DimLightBulb
+  category: Lights
+  completetime: 2
+  materials:
+    Steel: 50
+    Glass: 50
+
+- type: latheRecipe
   id: GlowstickRed
   result: GlowstickRed
   category: Lights

--- a/Resources/Prototypes/Recipes/Lathes/misc.yml
+++ b/Resources/Prototypes/Recipes/Lathes/misc.yml
@@ -70,9 +70,7 @@
     Steel: 50
     Glass: 50
 
-- type: latheRecipe
-  parent: BaseLightRecipe
-  id: GlowstickRed
+- type: latheRecipey
   result: GlowstickRed
   category: Lights
   completetime: 2

--- a/Resources/Prototypes/Recipes/Lathes/misc.yml
+++ b/Resources/Prototypes/Recipes/Lathes/misc.yml
@@ -62,6 +62,16 @@
     Glass: 50
 
 - type: latheRecipe
+  id: WarmLightBulb
+  result: WarmLightBulb
+  category: Lights
+  completetime: 2
+  materials:
+    Steel: 50
+    Glass: 50
+
+- type: latheRecipe
+  parent: BaseLightRecipe
   id: GlowstickRed
   result: GlowstickRed
   category: Lights

--- a/Resources/Prototypes/Recipes/Lathes/misc.yml
+++ b/Resources/Prototypes/Recipes/Lathes/misc.yml
@@ -70,7 +70,7 @@
     Steel: 50
     Glass: 50
 
-- type: latheRecipey
+- type: latheRecipe
   result: GlowstickRed
   category: Lights
   completetime: 2

--- a/Resources/Prototypes/Recipes/Lathes/misc.yml
+++ b/Resources/Prototypes/Recipes/Lathes/misc.yml
@@ -71,6 +71,7 @@
     Glass: 50
 
 - type: latheRecipe
+  id: GlowstickRed
   result: GlowstickRed
   category: Lights
   completetime: 2


### PR DESCRIPTION
# Description

Cherry Picked upstream PRs involving lighting. I've been hungry for these in RP situations. 

PRs Cherry-picked
- Dim Lightbulb PR - *Not linking since the author is a minor*
- https://github.com/space-wizards/space-station-14/pull/34324 (just the warm light bulbs)
- https://github.com/space-wizards/space-station-14/pull/35333

### Media

![image](https://github.com/user-attachments/assets/94dd157e-8f3d-4f4a-be30-1b5d1aa9be5b)

*From left to right*:
- Dim Light Bulb
- Warm Light Bulb
- Red Crystal Light Bulb
- Pink Crystal Light Bulb
- Orange Crystal Light Bulb
- Green Crystal Light Bulb
- Cyan Crystal Light Bulb
- Blue Crystal Light Bulb

# Changelog

<!--
You can add an author after the `:cl:` to change the name that appears in the changelog (ex: `:cl: Death`)
Leaving it blank will default to your GitHub display name
This includes all available types for the changelog
-->

:cl: Southbridge
- add: Added Dim, Warm, Red, Pink, Orange, Green, Cyan, and Blue Light Bulbs
