### PR TITLE
Give Cargo Techs Order Access by Default

### DIFF
--- a/Resources/Prototypes/Roles/Jobs/Cargo/cargo_technician.yml
+++ b/Resources/Prototypes/Roles/Jobs/Cargo/cargo_technician.yml
@@ -10,9 +10,10 @@
   access:
   - Cargo
   - Maintenance
+  - Orders # Floof - made standard
   extendedAccess:
   - Salvage
-  - Orders # DeltaV - Orders, see Resources/Prototypes/DeltaV/Access/cargo.yml
+  # - Orders # DeltaV - Orders, see Resources/Prototypes/DeltaV/Access/cargo.yml # Floof - made standard
 
 - type: startingGear
   id: CargoTechGear


### PR DESCRIPTION
# Description
A change seemingly demanded by the playerbase, makes orders a standard access for cargo techs rather than extended (low-pop).

# Changelog
:cl:
- tweak: Cargo technicians now get orders access by default.