### PR TITLE
Make It Where the Logiboard Can Be Link to the Cargo Pad 

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Misc/paper.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/paper.yml
@@ -740,6 +740,10 @@
     damage:
       types:
         Blunt: 10
+  - type: DeviceLinkSource #Floof
+    range: 200
+    ports:
+      - OrderSender
   - type: StealTarget
     stealGroup: BoxFolderQmClipboard
 


### PR DESCRIPTION
# Description

It make no sense why the COMPUTER can be linked to the pad but not the digiboard, so this pr allows the  Digiboard to be link to the cargo pad 

![image](https://github.com/user-attachments/assets/30b6e482-0e02-411c-929d-71e6dcfa5bc8)

# Changelog

:cl:
- tweak: Logistics DigiBoard can now be linked to the cargo telepad.

