### PR TITLE
Rebalance Mousetraps

### DIFF
--- a/Content.Server/Mousetrap/MousetrapSystem.cs
+++ b/Content.Server/Mousetrap/MousetrapSystem.cs
@@ -53,7 +53,7 @@ public sealed class MousetrapSystem : EntitySystem
         // Small - big damage,
         // Large - small damage
         // Yes, I punched numbers into a calculator until the graph looked right
-        var scaledDamage = -50 * MathF.Atan(physics.Mass - component.MassBalance) + 25 * MathF.PI;
+        var scaledDamage = -30 * MathF.Atan((physics.Mass - component.MassBalance) / 4) + 15 * MathF.PI; // Floof - rebalanced
         args.Damage *= scaledDamage;
     }
 

--- a/Resources/Prototypes/Entities/Objects/Devices/mousetrap.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/mousetrap.yml
@@ -22,7 +22,7 @@
     - type: DamageUserOnTrigger
       damage:
         types:
-          Blunt: 2 # base damage, scales based on mass
+          Blunt: 1 # base damage, scales based on mass
     - type: EmitSoundOnUse
       sound: "/Audio/Items/Handcuffs/cuff_end.ogg"
     - type: EmitSoundOnTrigger


### PR DESCRIPTION
# Description
Changes the mousetrap damage equation to this (X axis represents mass in kg and Y represents damage): 
![image](https://github.com/user-attachments/assets/42821443-b906-42d3-bcd6-8016d405bc7f)

instead of this:
![image](https://github.com/user-attachments/assets/bd708440-c053-47ae-9646-37b0035177d0)

Making them less deadly to min size rodentia, and slightly more harmful to species of larger size (70 kg humans still won't feel it, but it will be quite a pinch to them 12-20 kg folk)


# Changelog
:cl:
- tweak: Adjusted the damage scaling of mousetraps, making them less deadly to minimum size rodentia and felinids, but more dangerous to mid-small species.
