### PR TITLE
Add More Things to the Botanist Filled BELT

### DIFF
--- a/Resources/Prototypes/Catalog/Fills/Items/belt.yml
+++ b/Resources/Prototypes/Catalog/Fills/Items/belt.yml
@@ -141,6 +141,11 @@
     - id: HydroponicsToolMiniHoe
     - id: HydroponicsToolSpade
     - id: RobustHarvestChemistryBottle
+    - id: HydroponicsToolClippers #floof
+    - id: HydroponicsToolHatchet #floof
+    - id: EZNutrientChemistryBottle #floof
+    - id: PlantBGoneSpray #floof
+
 
 - type: entity
   id: ClothingBeltSheathFilled

--- a/Resources/Prototypes/Catalog/Fills/Items/belt.yml
+++ b/Resources/Prototypes/Catalog/Fills/Items/belt.yml
@@ -140,9 +140,9 @@
     contents:
     - id: HydroponicsToolMiniHoe
     - id: HydroponicsToolSpade
-    - id: RobustHarvestChemistryBottle
     - id: HydroponicsToolClippers #floof
     - id: HydroponicsToolHatchet #floof
+    - id: RobustHarvestChemistryBottle
     - id: EZNutrientChemistryBottle #floof
     - id: PlantBGoneSpray #floof
 


### PR DESCRIPTION

# Description
this PR adds the Clippers hatchet EZ nutrients and Plant be gone to the botanist belt no reason why it shouldn't be in the belt. Like they are a gardener they should have that stuff on hand
---

# Changelog

:cl:
- add: Clippers, hatchet, ez nutrients, and Plant be gone added to the Botanist filled belt
