### PR TITLE
Give the Security Quad a Chainsaw

### DIFF
--- a/Resources/Prototypes/Floof/Entities/Objects/Specific/Robotics/Borgmodules.yml
+++ b/Resources/Prototypes/Floof/Entities/Objects/Specific/Robotics/Borgmodules.yml
@@ -85,7 +85,7 @@
     - state: icon-Advmeasures
   - type: ItemBorgModule
     items:
-    - BorgWeaponRifleLecter
+    - BorgWeaponEnergyShotgun
     - BorgWeaponXrayCannon
   - type: GuideHelp
     guides:

--- a/Resources/Prototypes/Floof/Entities/Objects/Specific/Robotics/Borgmodules.yml
+++ b/Resources/Prototypes/Floof/Entities/Objects/Specific/Robotics/Borgmodules.yml
@@ -46,8 +46,8 @@
   - type: ItemBorgModule
     items:
     - WeaponAdvancedLaser
-    - WeaponborgPistolMk58
-    - CombatKnife
+    - BorgWeaponPistolMk58
+    - BorgChainsaw
   - type: GuideHelp
     guides:
     - Quadborgs
@@ -85,7 +85,7 @@
     - state: icon-Advmeasures
   - type: ItemBorgModule
     items:
-    - WeaponBorgEnergyShotgun
+    - BorgWeaponRifleLecter
     - BorgWeaponXrayCannon
   - type: GuideHelp
     guides:

--- a/Resources/Prototypes/Floof/Entities/Objects/Weapons/Melee.yml
+++ b/Resources/Prototypes/Floof/Entities/Objects/Weapons/Melee.yml
@@ -91,3 +91,39 @@
   - type: BatterySelfRecharger
     autoRecharge: true
     autoRechargeRate: 40
+
+- type: entity
+  name: chainsaw
+  suffix: Robot
+  parent: BaseItem
+  id: BorgChainsaw
+  description: I may analyze my orders, but I may not disobey them.
+  components:
+  - type: Sharp
+  - type: Sprite
+    sprite: Objects/Weapons/Melee/chainsaw.rsi
+    state: icon
+  - type: MeleeWeapon
+    autoAttack: true
+    wideAnimationRotation: -135
+    attackRate: 4
+    damage:
+      types:
+        Slash: 4
+        Piercing: 3
+        Structural: 10
+    heavyRateModifier: 1
+    heavyDamageBaseModifier: 1.0
+    heavyStaminaCost: 15
+    maxTargets: 3
+    angle: 45
+    soundHit:
+      path: /Audio/Weapons/chainsaw.ogg
+      params:
+        volume: -3
+  - type: Item
+    size: Normal
+    sprite: Objects/Weapons/Melee/chainsaw.rsi
+  - type: DisarmMalus
+  - type: UseDelay
+    delay: 1

--- a/Resources/Prototypes/Floof/Entities/Objects/Weapons/guns.yml
+++ b/Resources/Prototypes/Floof/Entities/Objects/Weapons/guns.yml
@@ -93,7 +93,7 @@
   parent: BaseWeaponBatterySmall
   suffix: Robot, energy based
   id: BorgWeaponPistolMk58
-  description: A cheap, ubiquitous sidearm, produced by a NanoTrasen subsidiary. Uses .35 auto ammo.
+  description: Cyborg-mounted version of the basic mk 58 pistol, it reloads over time from a internal ammo fabricator.
   components:
   - type: Sprite
     sprite: Objects/Weapons/Guns/Pistols/mk58.rsi
@@ -118,31 +118,56 @@
     startingCharge: 1000
 
 - type: entity
-  name: lecter ROW
-  parent: BaseWeaponBatterySmall
-  suffix: Robot, energy based
-  id: BorgWeaponRifleLecter
-  description: Cyborg adaptation of Nanotrasen's popular combat rifle. Reloads over time from a internal ammo fabricator.
+  name: energy shotgun
+  parent: BaseWeaponBattery
+  id: BaseWeaponEnergyShotgun
+  abstract: true
+  description: A one-of-a-kind prototype energy weapon that uses various shotgun configurations. It offers the possibility of both lethal and non-lethal shots, making it a versatile weapon.
   components:
   - type: Sprite
-    sprite: Objects/Weapons/Guns/Rifles/lecter.rsi
+    sprite: Objects/Weapons/Guns/Battery/energy_shotgun.rsi
     layers:
     - state: base
-      map: [ "enum.GunVisualLayers.Base" ]
+      map: ["enum.GunVisualLayers.Base"]
+    - state: mag-unshaded-4
+      map: ["enum.GunVisualLayers.MagUnshaded"]
+      shader: unshaded
+  - type: Clothing
+    sprite: Objects/Weapons/Guns/Battery/energy_shotgun.rsi
   - type: Gun
-    fireRate: 5
-    selectedMode: FullAuto
-    availableModes:
-    - FullAuto
+    fireRate: 2
     soundGunshot:
-      path: /Audio/Weapons/Guns/Gunshots/ltrifle.ogg
-    fireOnDropChance: 0.5
+      path: /Audio/Weapons/Guns/Gunshots/laser_cannon.ogg
   - type: ProjectileBatteryAmmoProvider
-    proto: CartridgeRifle
-    fireCost: 100
+    proto: eShellShotgun
+    fireCost: 150
+  - type: Item
+    size: Large
+    shape:
+    - 0,0,3,1
+    sprite: Objects/Weapons/Guns/Battery/inhands_64x.rsi
+    heldPrefix: energy
+  - type: Battery
+    maxCharge: 1200
+    startingCharge: 1200
   - type: BatterySelfRecharger
     autoRecharge: true
-    autoRechargeRate: 30
-  - type: Battery
-    maxCharge: 5000
-    startingCharge: 5000
+    autoRechargeRate: 24
+
+- type: entity
+  name: energy shotgun
+  parent: BaseWeaponEnergyShotgun
+  id: WeaponEnergyShotgun
+  components:
+  - type: GunRequiresWield
+  - type: Wieldable
+  - type: Tag
+    tags:
+    - HighRiskItem
+  - type: StealTarget
+    stealGroup: WeaponEnergyShotgun
+
+- type: entity
+  suffix: Robot
+  parent: BaseWeaponEnergyShotgun
+  id: BorgWeaponEnergyShotgun

--- a/Resources/Prototypes/Floof/Entities/Objects/Weapons/guns.yml
+++ b/Resources/Prototypes/Floof/Entities/Objects/Weapons/guns.yml
@@ -59,11 +59,31 @@
     autoRechargeRate: 30
 
 - type: entity
-  parent: WeaponXrayCannon
+  name: x-ray cannon
   suffix: Robot
+  parent: BaseWeaponBattery
   id: BorgWeaponXrayCannon
-  description: A weapon that is almost as infamous as its users.
+  description: Cyborg-mounted version of the experimental x-ray cannon, automatically recharging from the cyborg's power supply.
   components:
+  - type: Sprite
+    sprite: Objects/Weapons/Guns/Battery/xray.rsi
+    layers:
+    - state: base
+      map: [ "enum.GunVisualLayers.Base" ]
+    - state: mag-unshaded-0
+      map: [ "enum.GunVisualLayers.MagUnshaded" ]
+      shader: unshaded
+  - type: Gun
+    soundGunshot:
+      path: /Audio/Weapons/Guns/Gunshots/laser3.ogg
+  - type: HitscanBatteryAmmoProvider
+    proto: XrayLaser
+    fireCost: 100
+  - type: MagazineVisuals
+    magState: mag
+    steps: 5
+    zeroVisible: true
+  - type: Appearance
   - type: BatterySelfRecharger
     autoRecharge: true
     autoRechargeRate: 30
@@ -72,7 +92,7 @@
   name: mk 58
   parent: BaseWeaponBatterySmall
   suffix: Robot, energy based
-  id: WeaponborgPistolMk58
+  id: BorgWeaponPistolMk58
   description: A cheap, ubiquitous sidearm, produced by a NanoTrasen subsidiary. Uses .35 auto ammo.
   components:
   - type: Sprite
@@ -98,56 +118,31 @@
     startingCharge: 1000
 
 - type: entity
-  name: energy shotgun
-  parent: BaseWeaponBattery
-  id: BaseWeaponEnergyShotgun
-  abstract: true
-  description: A one-of-a-kind prototype energy weapon that uses various shotgun configurations. It offers the possibility of both lethal and non-lethal shots, making it a versatile weapon.
+  name: lecter ROW
+  parent: BaseWeaponBatterySmall
+  suffix: Robot, energy based
+  id: BorgWeaponRifleLecter
+  description: Cyborg adaptation of Nanotrasen's popular combat rifle. Reloads over time from a internal ammo fabricator.
   components:
   - type: Sprite
-    sprite: Objects/Weapons/Guns/Battery/energy_shotgun.rsi
+    sprite: Objects/Weapons/Guns/Rifles/lecter.rsi
     layers:
-      - state: base
-        map: ["enum.GunVisualLayers.Base"]
-      - state: mag-unshaded-4
-        map: ["enum.GunVisualLayers.MagUnshaded"]
-        shader: unshaded
-  - type: Clothing
-    sprite: Objects/Weapons/Guns/Battery/energy_shotgun.rsi
+    - state: base
+      map: [ "enum.GunVisualLayers.Base" ]
   - type: Gun
-    fireRate: 2
+    fireRate: 5
+    selectedMode: FullAuto
+    availableModes:
+    - FullAuto
     soundGunshot:
-      path: /Audio/Weapons/Guns/Gunshots/laser_cannon.ogg
+      path: /Audio/Weapons/Guns/Gunshots/ltrifle.ogg
+    fireOnDropChance: 0.5
   - type: ProjectileBatteryAmmoProvider
-    proto: eShellShotgun
-    fireCost: 150
-  - type: Item
-    size: Large
-    shape:
-    - 0,0,3,1
-    sprite: Objects/Weapons/Guns/Battery/inhands_64x.rsi
-    heldPrefix: energy
-  - type: Battery
-    maxCharge: 1200
-    startingCharge: 1200
+    proto: CartridgeRifle
+    fireCost: 100
   - type: BatterySelfRecharger
     autoRecharge: true
-    autoRechargeRate: 24
-
-- type: entity
-  name: energy shotgun
-  parent: BaseWeaponEnergyShotgun
-  id: WeaponEnergyShotgun
-  components:
-  - type: GunRequiresWield
-  - type: Wieldable
-  - type: Tag
-    tags:
-    - HighRiskItem
-  - type: StealTarget
-    stealGroup: WeaponEnergyShotgun
-
-- type: entity
-  suffix: Robot
-  parent: BaseWeaponEnergyShotgun
-  id: WeaponBorgEnergyShotgun
+    autoRechargeRate: 30
+  - type: Battery
+    maxCharge: 5000
+    startingCharge: 5000


### PR DESCRIPTION
<!--
This is a semi-strict format, you can add/remove sections as needed but the order/format should be kept the same
Remove these comments before submitting
-->

# Description

<!--
Explain this PR in as much detail as applicable

Some example prompts to consider:
How might this affect the game? The codebase?
What might be some alternatives to this?
How/Who does this benefit/hurt [the game/codebase]?
-->

Replaces the Security Quad's combat knife with a chainsaw (Metal Gear Rising reference). The chainsaw has slightly higher DPS than a combat knife, as well as some structural damage for breaching doors, making the quad a bit more versatile.
In addition, I've fixed the accuracy of the X-Ray cannon in the advanced weapons module.

---

<!--
This is default collapsed, readers click to expand it and see all your media
The PR media section can get very large at times, so this is a good way to keep it clean
The title is written using HTML tags
The title must be within the <summary> tags or you won't see it
-->

<details><summary><h1>Media</h1></summary>
<p>

https://github.com/user-attachments/assets/8d7b6499-e5fb-4c8b-b8fc-277a1c757d16

</p>
</details>

---

# Changelog

<!--
You can add an author after the `:cl:` to change the name that appears in the changelog (ex: `:cl: Death`)
Leaving it blank will default to your GitHub display name
This includes all available types for the changelog
-->

:cl: Nox38, FrostRibbon
- tweak: replaced security quad's combat knife with a chainsaw.