### PR TITLE
Added New Colored Light Boxes

### DIFF
--- a/Resources/Prototypes/Floof/Catalog/Fills/Boxes/general.yml
+++ b/Resources/Prototypes/Floof/Catalog/Fills/Boxes/general.yml
@@ -1,0 +1,110 @@
+- type: entity
+  name: mixed color lightbulb box
+  parent: BoxCardboard
+  id: BoxLightbulbColorMixed
+  description: This box is shaped on the inside so that only light tubes and bulbs fit.
+  components:
+  - type: Sprite
+    layers:
+      - state: box
+      - state: light
+  - type: Storage
+    grid:
+    - 0,0,5,3
+    whitelist:
+      components:
+      - LightBulb
+  - type: StorageFill
+    contents:
+      - id: LightBulbCrystalCyan
+        amount: 2
+      - id: LightBulbCrystalBlue
+        amount: 2
+      - id: LightBulbCrystalGreen
+        amount: 2
+      - id: LightBulbCrystalPink
+        amount: 2
+      - id: LightBulbCrystalRed
+        amount: 2
+      - id: LightBulbCrystalOrange
+        amount: 2
+
+- type: entity
+  name: mixed color lighttube box
+  parent: BoxCardboard
+  id: BoxLighttubeColorMixed
+  description: This box is shaped on the inside so that only light tubes and bulbs fit.
+  components:
+  - type: Sprite
+    layers:
+      - state: box
+      - state: lighttube
+  - type: Storage
+    grid:
+    - 0,0,5,3
+    whitelist:
+      components:
+      - LightBulb
+  - type: StorageFill
+    contents:
+      - id: LightTubeCrystalCyan
+        amount: 2
+      - id: LightTubeCrystalBlue
+        amount: 2
+      - id: LightTubeCrystalGreen
+        amount: 2
+      - id: LightTubeCrystalPink
+        amount: 2
+      - id: LightTubeCrystalRed
+        amount: 2
+      - id: LightTubeCrystalOrange
+        amount: 2
+
+# Modified versions of the Nyanotrasen boxes
+- type: entity
+  name: mixed funky lighttube box
+  parent: BoxCardboard
+  id: BoxColoredLighttube
+  description: This box is shaped on the inside so that only light tubes and bulbs fit.
+  components:
+  - type: StorageFill
+    contents:
+      - id: ColoredLightTubeRed
+        amount: 4
+      - id: ColoredLightTubeFrostyBlue
+        amount: 4
+      - id: ColoredLightTubeBlackLight
+        amount: 4
+  - type: Sprite
+    layers:
+      - state: box
+      - state: lighttube
+  - type: Storage
+    maxItemSize: Small
+    grid:
+      - 0,0,5,3
+    whitelist:
+      components:
+      - LightBulb
+
+- type: entity
+  name: dim lightbulb box
+  parent: BoxCardboard
+  id: BoxMaintenanceLightbulb
+  description: This box is shaped on the inside so that only light tubes and bulbs fit.
+  components:
+  - type: StorageFill
+    contents:
+      - id: DimLightBulb
+        amount: 12
+  - type: Sprite
+    layers:
+      - state: box
+      - state: light
+  - type: Storage
+    maxItemSize: Small
+    grid:
+      - 0,0,5,3
+    whitelist:
+      components:
+      - LightBulb

--- a/Resources/Prototypes/Nyanotrasen/Catalog/Cargo/cargo_service.yml
+++ b/Resources/Prototypes/Nyanotrasen/Catalog/Cargo/cargo_service.yml
@@ -4,7 +4,7 @@
     sprite: Objects/Power/light_bulb.rsi
     state: normal
   product: CrateServiceReplacementColoredLights
-  cost: 600
+  cost: 1200 # Floof Station, increased the price here since we add more things to it.
   category: Service
   group: market
 

--- a/Resources/Prototypes/Nyanotrasen/Catalog/Fills/Boxes/general.yml
+++ b/Resources/Prototypes/Nyanotrasen/Catalog/Fills/Boxes/general.yml
@@ -1,52 +1,54 @@
-- type: entity
-  name: colored lighttube box
-  parent: BoxCardboard
-  id: BoxColoredLighttube
-  description: This box is shaped on the inside so that only light tubes and bulbs fit.
-  components:
-  - type: StorageFill
-    contents:
-      - id: ColoredLightTubeRed
-        amount: 4
-      - id: ColoredLightTubeFrostyBlue
-        amount: 4
-      - id: ColoredLightTubeBlackLight
-        amount: 4
-  - type: Sprite
-    layers:
-      - state: box
-      - state: lighttube
-  - type: Storage
-    maxItemSize: Small
-    grid:
-      - 0,0,4,4
-    whitelist:
-      components:
-      - LightBulb
+# Floof Station - Commenting these out since we reimplement them in our box fills
+#
+# - type: entity
+#   name: colored lighttube box
+#   parent: BoxCardboard
+#   id: BoxColoredLighttube
+#   description: This box is shaped on the inside so that only light tubes and bulbs fit.
+#   components:
+#   - type: StorageFill
+#     contents:
+#       - id: ColoredLightTubeRed
+#         amount: 4
+#       - id: ColoredLightTubeFrostyBlue
+#         amount: 4
+#       - id: ColoredLightTubeBlackLight
+#         amount: 4
+#   - type: Sprite
+#     layers:
+#       - state: box
+#       - state: lighttube
+#   - type: Storage
+#     maxItemSize: Small
+#     grid:
+#       - 0,0,4,4
+#     whitelist:
+#       components:
+#       - LightBulb
 
-- type: entity
-  name: maintenance lightbulb box
-  parent: BoxCardboard
-  id: BoxMaintenanceLightbulb
-  description: This box is shaped on the inside so that only light tubes and bulbs fit.
-  components:
-  - type: StorageFill
-    contents:
-      - id: LightBulbMaintenance
-        amount: 6
-      - id: LightBulbMaintenanceRed
-        amount: 6
-  - type: Sprite
-    layers:
-      - state: box
-      - state: light
-  - type: Storage
-    maxItemSize: Small
-    grid:
-      - 0,0,4,4
-    whitelist:
-      components:
-      - LightBulb
+# - type: entity
+#   name: maintenance lightbulb box
+#   parent: BoxCardboard
+#   id: BoxMaintenanceLightbulb
+#   description: This box is shaped on the inside so that only light tubes and bulbs fit.
+#   components:
+#   - type: StorageFill
+#     contents:
+#       - id: LightBulbMaintenance
+#         amount: 6
+#       - id: LightBulbMaintenanceRed
+#         amount: 6
+#   - type: Sprite
+#     layers:
+#       - state: box
+#       - state: light
+#   - type: Storage
+#     maxItemSize: Small
+#     grid:
+#       - 0,0,4,4
+#     whitelist:
+#       components:
+#       - LightBulb
 
 - type: entity
   name: holy water kit

--- a/Resources/Prototypes/Nyanotrasen/Catalog/Fills/Crates/service.yml
+++ b/Resources/Prototypes/Nyanotrasen/Catalog/Fills/Crates/service.yml
@@ -7,6 +7,8 @@
     contents:
       - id: BoxColoredLighttube
         amount: 2
+      - id: BoxLighttubeColorMixed # Floof Station
+      - id: BoxLightbulbColorMixed # Floof Station
 
 - type: entity
   id: CrateServiceReplacementMaintenanceLights


### PR DESCRIPTION
<!--
This is a semi-strict format, you can add/remove sections as needed but the order/format should be kept the same
Remove these comments before submitting
-->

# Description

- Added new mixed lights boxes which include the new light tubes and bulbs.
- Shifted the Nyanotrasen light boxes to Floof and made some modifications to them.
- Shifted the maintenance light box to instead use the dim lights from Wizden.
- Included the new light tube and bulb boxes to the colored lights crate order for cargo.

---
<details><summary><h1>Media</h1></summary>
<p>
### Video Demonstration

https://github.com/user-attachments/assets/9c0b7bca-522c-4bc0-be20-97a314661784
</p>
</details>

---

# Changelog

<!--
You can add an author after the `:cl:` to change the name that appears in the changelog (ex: `:cl: Death`)
Leaving it blank will default to your GitHub display name
This includes all available types for the changelog
-->

:cl: Southbridge
- add: Two new mixed-lights boxes are now available in the colored lights crate
