### PR TITLE
Add Search Filter Box for Round End Summary

### DIFF
--- a/Content.Client/RoundEnd/RoundEndSummaryWindow.cs
+++ b/Content.Client/RoundEnd/RoundEndSummaryWindow.cs
@@ -49,7 +49,7 @@ namespace Content.Client.RoundEnd
             };
 
             // <summary>
-            // Search filter Box
+            // Floofstation Search filter Box
             // Search container for round end text
             // </summary>
             var searchContainer = new BoxContainer
@@ -77,7 +77,7 @@ namespace Content.Client.RoundEnd
             searchContainer.AddChild(searchLabel);
             searchContainer.AddChild(searchInput);
             roundEndSummaryTab.AddChild(searchContainer);
-            // of Search container
+            // Floofstation End of Search container
 
             var roundEndSummaryContainerScrollbox = new ScrollContainer
             {
@@ -106,7 +106,7 @@ namespace Content.Client.RoundEnd
                                                    ("seconds", roundDuration.Seconds)));
             roundEndSummaryContainer.AddChild(roundTimeLabel);
 
-            //Round end text
+            // Floofstation Round end text
             if (!string.IsNullOrEmpty(roundEnd))
             {
                 var roundEndLabel = new RichTextLabel();
@@ -136,7 +136,7 @@ namespace Content.Client.RoundEnd
         }
 
         // <summary>
-        // Search filter Box
+        // Floofstation Search filter Box
         // This adds the filter input box. Skip this part if you only want to know how the list gets populated.
         // </summary>
         private bool UpdateRoundEndTextForSearch(RichTextLabel label, string fullText, string searchTerm)
@@ -172,7 +172,7 @@ namespace Content.Client.RoundEnd
                 return true;
             }
         }
-        // End of Search filter Box
+        // Floofstation End of Search filter Box
 
         private BoxContainer MakePlayerManifestTab(RoundEndMessageEvent.RoundEndPlayerInfo[] playersInfo)
         {
@@ -224,7 +224,7 @@ namespace Content.Client.RoundEnd
             searchContainer.AddChild(searchInput);
 
             playerManifestTab.AddChild(searchContainer);
-            // End of search box
+            // Floofstation End of search box
 
             populatePlayManifestList(playerInfoContainer, playersInfo);
 
@@ -291,6 +291,7 @@ namespace Content.Client.RoundEnd
             }
         }
 
+        // Floofstation OnSearchTextChanged
         private void OnSearchTextChanged(LineEdit.LineEditEventArgs searchTerm, BoxContainer playerInfoContainer, RoundEndMessageEvent.RoundEndPlayerInfo[] playersInfo)
         {
             // Empty the result box when we star typing
@@ -315,6 +316,7 @@ namespace Content.Client.RoundEnd
             // Populate the player list with filtered results
             populatePlayManifestList(playerInfoContainer, filteredPlayersInfo);
         }
+        // Floofstation End of OnSearchTextChanged
     }
 
 }

--- a/Content.Client/RoundEnd/RoundEndSummaryWindow.cs
+++ b/Content.Client/RoundEnd/RoundEndSummaryWindow.cs
@@ -48,6 +48,37 @@ namespace Content.Client.RoundEnd
                 Name = Loc.GetString("round-end-summary-window-round-end-summary-tab-title")
             };
 
+            // <summary>
+            // Search filter Box
+            // Search container for round end text
+            // </summary>
+            var searchContainer = new BoxContainer
+            {
+                Orientation = LayoutOrientation.Horizontal,
+                Margin = new Thickness(10, 10, 10, 5),
+                VerticalExpand = false,
+                HorizontalExpand = true
+            };
+
+            var searchLabel = new Label
+            {
+                Text = Loc.GetString("round-end-summary-window-search-label"),
+                MinSize = new Vector2(80, 0),
+                VerticalAlignment = VAlignment.Center
+            };
+
+            var searchInput = new LineEdit
+            {
+                PlaceHolder = Loc.GetString("round-end-summary-window-search-placeholder"),
+                HorizontalExpand = true,
+                MinHeight = 30
+            };
+
+            searchContainer.AddChild(searchLabel);
+            searchContainer.AddChild(searchInput);
+            roundEndSummaryTab.AddChild(searchContainer);
+            // of Search container
+
             var roundEndSummaryContainerScrollbox = new ScrollContainer
             {
                 VerticalExpand = true,
@@ -79,8 +110,23 @@ namespace Content.Client.RoundEnd
             if (!string.IsNullOrEmpty(roundEnd))
             {
                 var roundEndLabel = new RichTextLabel();
-                roundEndLabel.SetMarkup(roundEnd);
+                UpdateRoundEndTextForSearch(roundEndLabel, roundEnd, "");
                 roundEndSummaryContainer.AddChild(roundEndLabel);
+
+                // Add dynamic search functionality
+                searchInput.OnTextChanged += (args) =>
+                {
+                    var isSearchDone = UpdateRoundEndTextForSearch(roundEndLabel, roundEnd, args.Text);
+                    // the return value is only interesting for us to know if the two labels should be visible or not
+                    if (isSearchDone)
+                    {
+                        gamemodeLabel.Visible = false;
+                        roundTimeLabel.Visible = false;
+                    } else {
+                        gamemodeLabel.Visible = true;
+                        roundTimeLabel.Visible = true;
+                    }
+                };
             }
 
             roundEndSummaryContainerScrollbox.AddChild(roundEndSummaryContainer);
@@ -88,6 +134,45 @@ namespace Content.Client.RoundEnd
 
             return roundEndSummaryTab;
         }
+
+        // <summary>
+        // Search filter Box
+        // This adds the filter input box. Skip this part if you only want to know how the list gets populated.
+        // </summary>
+        private bool UpdateRoundEndTextForSearch(RichTextLabel label, string fullText, string searchTerm)
+        {
+            if (string.IsNullOrWhiteSpace(searchTerm))
+            {
+                // If no search term, show all text
+                label.SetMarkup(fullText);
+                return false;
+            }
+
+            // In the player manifest it's fine to split by every line but
+            // in the round end summary it's better to give context to the search term
+            // so we split by double newlines to provide the whole paragraph of text
+            var blocks = fullText.Split(new[] { "\n\n" }, StringSplitOptions.RemoveEmptyEntries);
+
+            // Filter blocks that contain the search term
+            var matchingBlocks = blocks.Where(block =>
+                block.ToLowerInvariant().Contains(searchTerm.ToLowerInvariant()));
+
+            // Join matching blocks back together
+            var filteredText = string.Join("\n\n", matchingBlocks);
+
+            if (string.IsNullOrEmpty(filteredText))
+            {
+                // If no matches found, don't show anything
+                label.SetMarkup("");
+                return true;
+            }
+            else
+            {
+                label.SetMarkup(filteredText);
+                return true;
+            }
+        }
+        // End of Search filter Box
 
         private BoxContainer MakePlayerManifestTab(RoundEndMessageEvent.RoundEndPlayerInfo[] playersInfo)
         {
@@ -107,6 +192,50 @@ namespace Content.Client.RoundEnd
                 Orientation = LayoutOrientation.Vertical
             };
 
+            // <summary>
+            // Search filter Box
+            // This adds the filter input box. Skip this part if you only want to know how the list gets populated.
+            // </summary>
+            var searchContainer = new BoxContainer
+            {
+                Orientation = LayoutOrientation.Horizontal,
+                Margin = new Thickness(10, 10, 10, 5),
+                VerticalExpand = false,
+                HorizontalExpand = true
+            };
+
+            var searchLabel = new Label
+            {
+                Text = Loc.GetString("round-end-summary-window-search-label"),
+                MinSize = new Vector2(80, 0),
+                VerticalAlignment = VAlignment.Center
+            };
+
+            var searchInput = new LineEdit
+            {
+                PlaceHolder = Loc.GetString("round-end-summary-window-search-placeholder"),
+                HorizontalExpand = true,
+                MinHeight = 30
+            };
+
+            searchInput.OnTextChanged += (args) => OnSearchTextChanged(args, playerInfoContainer, playersInfo);
+
+            searchContainer.AddChild(searchLabel);
+            searchContainer.AddChild(searchInput);
+
+            playerManifestTab.AddChild(searchContainer);
+            // End of search box
+
+            populatePlayManifestList(playerInfoContainer, playersInfo);
+
+            playerInfoContainerScrollbox.AddChild(playerInfoContainer);
+            playerManifestTab.AddChild(playerInfoContainerScrollbox);
+
+            return playerManifestTab;
+        }
+
+        private void populatePlayManifestList(BoxContainer playerInfoContainer, RoundEndMessageEvent.RoundEndPlayerInfo[] playersInfo)
+        {
             //Put observers at the bottom of the list. Put antags on top.
             var sortedPlayersInfo = playersInfo.OrderBy(p => p.Observer).ThenBy(p => !p.Antag);
 
@@ -127,12 +256,12 @@ namespace Content.Client.RoundEnd
                 if (playerInfo.PlayerNetEntity != null)
                 {
                     hBox.AddChild(new SpriteView(playerInfo.PlayerNetEntity.Value, _entityManager)
-                        {
-                            OverrideDirection = Direction.South,
-                            VerticalAlignment = VAlignment.Center,
-                            SetSize = new Vector2(32, 32),
-                            VerticalExpand = true,
-                        });
+                    {
+                        OverrideDirection = Direction.South,
+                        VerticalAlignment = VAlignment.Center,
+                        SetSize = new Vector2(32, 32),
+                        VerticalExpand = true,
+                    });
                 }
 
                 if (playerInfo.PlayerICName != null)
@@ -160,11 +289,31 @@ namespace Content.Client.RoundEnd
                 hBox.AddChild(playerInfoText);
                 playerInfoContainer.AddChild(hBox);
             }
+        }
 
-            playerInfoContainerScrollbox.AddChild(playerInfoContainer);
-            playerManifestTab.AddChild(playerInfoContainerScrollbox);
+        private void OnSearchTextChanged(LineEdit.LineEditEventArgs searchTerm, BoxContainer playerInfoContainer, RoundEndMessageEvent.RoundEndPlayerInfo[] playersInfo)
+        {
+            // Empty the result box when we star typing
+            playerInfoContainer.RemoveAllChildren();
 
-            return playerManifestTab;
+            string newText = searchTerm.Text;
+            if (string.IsNullOrWhiteSpace(newText))
+            {
+                // If search is empty, show all text and all players
+                populatePlayManifestList(playerInfoContainer, playersInfo);
+                return;
+            }
+
+            // Filter the player list based on search term
+            // Searches: Player OOC Name, Player IC Name, and Player Role
+            var filteredPlayersInfo = playersInfo.Where(player =>
+                player.PlayerOOCName.ToLowerInvariant().Contains(newText.ToLowerInvariant()) ||
+                (player.PlayerICName != null && player.PlayerICName.ToLowerInvariant().Contains(newText.ToLowerInvariant())) ||
+                Loc.GetString(player.Role).ToLowerInvariant().Contains(newText.ToLowerInvariant())
+            ).ToArray();
+
+            // Populate the player list with filtered results
+            populatePlayManifestList(playerInfoContainer, filteredPlayersInfo);
         }
     }
 

--- a/Resources/Locale/en-US/round-end/round-end-summary-window.ftl
+++ b/Resources/Locale/en-US/round-end/round-end-summary-window.ftl
@@ -6,3 +6,5 @@ round-end-summary-window-gamemode-name-label = The game mode was [color=white]{$
 round-end-summary-window-duration-label = It lasted for [color=yellow]{$hours} hours, {$minutes} minutes, and {$seconds} seconds.
 round-end-summary-window-player-info-if-observer-text = [color=gray]{$playerOOCName}[/color] was [color=lightblue]{$playerICName}[/color], an observer.
 round-end-summary-window-player-info-if-not-observer-text = [color=gray]{$playerOOCName}[/color] was [color={$icNameColor}]{$playerICName}[/color] playing role of [color=orange]{$playerRole}[/color].
+round-end-summary-window-search-label = Search:
+round-end-summary-window-search-placeholder = Filter by player...


### PR DESCRIPTION
# Description

This feature adds a search box with functionality included in the Round End window
It is two different functionalities, each for one tab

Reasoning: When having a big player count it's a hassle to try to find out who was a certain role. This way it can be easily searched and filtered. I found myself many times in the past already scrolling through the list manually multiple times

It is a convenience feature, no gameplay affected
It doesn't affect other parts of the game
It is tested locally, see the video attached

---

# TODO

<!--
A list of everything you have to do before this PR is "complete"
You probably won't have to complete everything before merging but it's good to leave future references
-->

- [x] Full implementation

---


# Media

https://github.com/user-attachments/assets/cc7fa01c-2c79-400e-b9f5-9e2837f03235


---

# Changelog

:cl: B1773rm4n
- add: Implement search box for the Player Manifest Tab search at Round End
- add: Implement search box for the Round Information Tab search at Round End
