### PR TITLE
Check-Out Interaction Tweaks

### DIFF
--- a/Resources/Prototypes/Interactions/noop_interactions.yml
+++ b/Resources/Prototypes/Interactions/noop_interactions.yml
@@ -55,19 +55,18 @@
   action:
     !type:NoOpAction
 
+# Floofstation - TODO: move to floofstation namespace
 - type: Interaction
   id: CheckOut
   parent: BaseGlobal
-  priority: 4
+  priority: -100 # Very specific ERP meaning, should be at the bottom
   requiresHands: false
   requiresCanInteract: false
   contactInteraction: false
-  allowSelfInteract: true
   icon: /Textures/Interface/Actions/eyeopen.png
   range: {max: 20}
   effectSuccess:
-    popup: Obvious
+    popup: Subtle
     sound: {path: /Audio/Floof/Lewd/blush.ogg}
-    soundPerceivedByOthers: false # Can be used to attract attention, but not to spam sounds or chat
   action:
     !type:NoOpAction

--- a/Resources/Prototypes/Interactions/noop_interactions.yml
+++ b/Resources/Prototypes/Interactions/noop_interactions.yml
@@ -70,3 +70,7 @@
     sound: {path: /Audio/Floof/Lewd/blush.ogg}
   action:
     !type:NoOpAction
+  hideByRequirement: true
+  requirement:
+    !type:MobStateRequirement # Don't check out a wall
+    inverted: true


### PR DESCRIPTION
# Description
Lowers it to the bottom of the verb list as an ERP emote, makes it imperceptible to others (only to the user and target), adds a comment about needing to be transferred to the floof namespace, removes redundant lines, and adds a mob state requirement.

# Changelog
No cl no fun
