### PR TITLE
Tiny Trait Hotfix 2

### DIFF
--- a/Content.Shared/HeightAdjust/HeightAdjustSystem.cs
+++ b/Content.Shared/HeightAdjust/HeightAdjustSystem.cs
@@ -58,12 +58,8 @@ public sealed class HeightAdjustSystem : EntitySystem
         else
             succeeded = false;
         
-        if (restricted && EntityManager.HasComponent<HumanoidAppearanceComponent>(uid)) // Floofstation - if restricted is true assume unmodified behavior
-            _appearance.SetScale(uid, scale);
-        else if (EntityManager.HasComponent<HumanoidAppearanceComponent>(uid)) // Floofstation - if restricted is false use adjusted scale and passthrough restricted flag
-            _appearance.SetScale(uid, adjScale, restricted: restricted); 
-        else
-            succeeded = false;
+        // Floofstation - removed EntityManager.HasComponent<HumanoidAppearanceComponent>(uid) gate due to addition of EnsureComponent earlier
+        _appearance.SetScale(uid, restricted ? scale : adjScale, restricted: restricted); // Floofstation - if restricted is true fallback to default scaling, otherwise use adjusted scaling based on current size
 
         RaiseLocalEvent(uid, new HeightAdjustedEvent { NewScale = scale });
 

--- a/Content.Shared/HeightAdjust/HeightAdjustSystem.cs
+++ b/Content.Shared/HeightAdjust/HeightAdjustSystem.cs
@@ -41,7 +41,7 @@ public sealed class HeightAdjustSystem : EntitySystem
         var appearance = EntityManager.EnsureComponent<HumanoidAppearanceComponent>(uid);
         float height = appearance.Height * scale.Y;
         float width = appearance.Width * scale.X;
-        var adjScale = new Vector2(height, width);
+        var adjScale = new Vector2(width, height);
         // Floofstation end
         
         var succeeded = true;
@@ -58,8 +58,10 @@ public sealed class HeightAdjustSystem : EntitySystem
         else
             succeeded = false;
         
-        if (EntityManager.HasComponent<HumanoidAppearanceComponent>(uid))
-            _appearance.SetScale(uid, adjScale, restricted: restricted); // Floofstation - added restricted flag and switched to using adjusted scale
+        if (restricted && EntityManager.HasComponent<HumanoidAppearanceComponent>(uid)) // Floofstation - if restricted is true assume unmodified behavior
+            _appearance.SetScale(uid, scale);
+        else if (EntityManager.HasComponent<HumanoidAppearanceComponent>(uid)) // Floofstation - if restricted is false use adjusted scale and passthrough restricted flag
+            _appearance.SetScale(uid, adjScale, restricted: restricted); 
         else
             succeeded = false;
 

--- a/Resources/Prototypes/Floof/Traits/physical.yml
+++ b/Resources/Prototypes/Floof/Traits/physical.yml
@@ -115,9 +115,9 @@
     - MedicalBorg
     - Captain # Balance, sorry for the tiny captains out there!
   - !type:CharacterHeightRequirement
-    max: 140 # Minimum size +8 for humans/standard humanoids, to give people more leeway on how skinny they appear when tiny
+    max: 136 # Minimum size +4 for humans/standard humanoids, to give people more leeway on how skinny they appear when tiny
   - !type:CharacterWidthRequirement
-    max: 32 # Minimum size +4 for humans/standard humanoids
+    max: 30 # Minimum size +2 for humans/standard humanoids
   - !type:CharacterTraitRequirement
     inverted: true
     traits:

--- a/Resources/Prototypes/Floof/Traits/physical.yml
+++ b/Resources/Prototypes/Floof/Traits/physical.yml
@@ -117,7 +117,7 @@
   - !type:CharacterHeightRequirement
     max: 140 # Minimum size +8 for humans/standard humanoids, to give people more leeway on how skinny they appear when tiny
   - !type:CharacterWidthRequirement
-    max: 29 # Minimum size +1 for humans/standard humanoids
+    max: 32 # Minimum size +4 for humans/standard humanoids
   - !type:CharacterTraitRequirement
     inverted: true
     traits:


### PR DESCRIPTION
<!--
This is a semi-strict format, you can add/remove sections as needed but the order/format should be kept the same
Remove these comments before submitting
-->

# Description

<!--
Explain this PR in as much detail as applicable

Some example prompts to consider:
How might this affect the game? The codebase?
What might be some alternatives to this?
How/Who does this benefit/hurt [the game/codebase]?
-->

Height/width was swapped ALSO apparently I made a bad assumption about the default height/width of the HumanoidAppearanceComponent (or something else I dunno this is a HOTFIX).

Fixed the width/height swap, tweaked the size maximums (they were somewhat based off bad scaling apparently), and reverted to exactly old behavior for HeightAdjustSystem.SetScale when the new restricted flag isn't set. 

THIS SHOULD WORK HOPEFULLY... I'm tired and need to sleep soon and want to make sure the fix is ready asap... it seems to be working properly now in testing...

---

# TODO

<!--
A list of everything you have to do before this PR is "complete"
You probably won't have to complete everything before merging but it's good to leave future references
-->

- [x] Fix things!!
- [x] Re-validate to make sure I didn't screw anything else up, maybe see if there's a more elegant solution to the fix

---

<!--
This is default collapsed, readers click to expand it and see all your media
The PR media section can get very large at times, so this is a good way to keep it clean
The title is written using HTML tags
The title must be within the <summary> tags or you won't see it
-->

<details><summary><h1>Media</h1></summary>
<p>

![image](https://github.com/user-attachments/assets/88391239-14ab-416e-812f-15002956cb8d)

</p>
</details>

---

# Changelog

<!--
You can add an author after the `:cl:` to change the name that appears in the changelog (ex: `:cl: Death`)
Leaving it blank will default to your GitHub display name
This includes all available types for the changelog
-->

:cl:
- fix: Scaling definitely wasn't messed up - it was all a dream
