### PR TITLE
Non-Mandatory Underwear

### DIFF
--- a/Resources/Prototypes/DeltaV/Species/rodentia.yml
+++ b/Resources/Prototypes/DeltaV/Species/rodentia.yml
@@ -49,10 +49,9 @@
   points:
     Underwear:
       points: 1
-      required: true
-      defaultMarkings: [ UnderwearBoxers ]
+      required: false # Floof, add underwear
     Undershirt:
-      points: 1
+      points: 1 # Floof, add underwear
       required: false
     Hair:
       points: 1

--- a/Resources/Prototypes/DeltaV/Species/vulpkanin.yml
+++ b/Resources/Prototypes/DeltaV/Species/vulpkanin.yml
@@ -42,10 +42,9 @@
   points:
     Underwear:
       points: 1
-      required: true
-      defaultMarkings: [ UnderwearBoxers ]
+      required: false # Floof, add underwear
     Undershirt:
-      points: 1
+      points: 1 # Floof, add underwear
       required: false
     Hair:
       points: 1

--- a/Resources/Prototypes/Species/arachnid.yml
+++ b/Resources/Prototypes/Species/arachnid.yml
@@ -49,8 +49,7 @@
   points:
     Underwear:
       points: 1
-      required: true
-      defaultMarkings: [ UnderwearBoxers ] # Floof, add underwear
+      required: false # Floof, add underwear
     Undershirt:
       points: 1
       required: false # Floof, add underwear

--- a/Resources/Prototypes/Species/diona.yml
+++ b/Resources/Prototypes/Species/diona.yml
@@ -41,8 +41,7 @@
   points:
     Underwear:
       points: 1
-      required: true
-      defaultMarkings: [ UnderwearBoxers ] # Floof, add underwear
+      required: false # Floof, add underwear
     Undershirt:
       points: 1
       required: false # Floof, add underwear

--- a/Resources/Prototypes/Species/harpy.yml
+++ b/Resources/Prototypes/Species/harpy.yml
@@ -45,8 +45,7 @@
   points:
     Underwear:
       points: 1
-      required: true
-      defaultMarkings: [ UnderwearBoxers ] # Floof, add underwear
+      required: false # Floof, add underwear
     Undershirt:
       points: 1 # Floof, add underwear
       required: false

--- a/Resources/Prototypes/Species/human.yml
+++ b/Resources/Prototypes/Species/human.yml
@@ -44,8 +44,7 @@
   points:
     Underwear:
       points: 1
-      required: true
-      defaultMarkings: [ UnderwearBoxers ] # Floof, add underwear
+      required: false # Floof, add underwear
     Undershirt:
       points: 1
       required: false # Floof, add underwear

--- a/Resources/Prototypes/Species/ipc.yml
+++ b/Resources/Prototypes/Species/ipc.yml
@@ -49,6 +49,12 @@
 - type: markingPoints
   id: MobIPCMarkingLimits
   points:
+    Underwear:
+      points: 1
+      required: false # Floof, add underwear
+    Undershirt:
+      points: 1 # Floof, add underwear
+      required: false
     Head:
       points: 1
       required: true

--- a/Resources/Prototypes/Species/moth.yml
+++ b/Resources/Prototypes/Species/moth.yml
@@ -46,8 +46,7 @@
   points:
     Underwear:
       points: 1
-      required: true
-      defaultMarkings: [ UnderwearBoxers ] # Floof, add underwear
+      required: false # Floof, add underwear
     Undershirt:
       points: 1 # Floof, add underwear
       required: false

--- a/Resources/Prototypes/Species/reptilian.yml
+++ b/Resources/Prototypes/Species/reptilian.yml
@@ -47,8 +47,7 @@
   points:
     Underwear:
       points: 1
-      required: true
-      defaultMarkings: [ UnderwearBoxers ] # Floof, add underwear
+      required: false # Floof, add underwear
     Undershirt:
       points: 1 # Floof, add underwear
       required: false

--- a/Resources/Prototypes/Species/shadowkin.yml
+++ b/Resources/Prototypes/Species/shadowkin.yml
@@ -52,8 +52,7 @@
   points:
     Underwear:
       points: 1
-      required: true
-      defaultMarkings: [ UnderwearBoxers ] # Floof, add underwear
+      required: false # Floof, add underwear
     Undershirt:
       points: 1
       required: false # Floof, add underwear

--- a/Resources/Prototypes/Species/slime.yml
+++ b/Resources/Prototypes/Species/slime.yml
@@ -39,8 +39,7 @@
   points:
     Underwear:
       points: 1
-      required: true
-      defaultMarkings: [ UnderwearBoxers ] # Floof, add underwear
+      required: false # Floof, add underwear
     Undershirt:
       points: 1
       required: false # Floof, add underwear


### PR DESCRIPTION
# Description
Makes underwear markings optional as we have plenty of clothing that contradict the use of those markings: thongs, nudity permits, etc. Also added underwear marking slots to IPCs.

Used ctrl-shift-R to make most of the changes

# Changelog
:cl:
- tweak: Underwear markings are now fully optional.
