### PR TITLE
Try Fix RGBee (Wizden Commit #28741)

### DIFF
--- a/Content.Client/Light/RgbLightControllerSystem.cs
+++ b/Content.Client/Light/RgbLightControllerSystem.cs
@@ -207,8 +207,11 @@ namespace Content.Client.Light
 
         public static Color GetCurrentRgbColor(TimeSpan curTime, TimeSpan offset, Entity<RgbLightControllerComponent> rgb)
         {
+            var delta = (float)(curTime - offset).TotalSeconds;
+            var entOffset = Math.Abs(rgb.Owner.Id * 0.09817f);
+            var hue = (delta * rgb.Comp.CycleRate + entOffset) % 1;
             return Color.FromHsv(new Vector4(
-                (float) (((curTime.TotalSeconds - offset.TotalSeconds) * rgb.Comp.CycleRate + Math.Abs(rgb.Owner.Id * 0.1)) % 1),
+                MathF.Abs(hue),
                 1.0f,
                 1.0f,
                 1.0f


### PR DESCRIPTION
# Description

Fix for the RgbLightController system producing errors for some users and causing the lights to show up black instead of rainbow, cherry-picked from wizden

---

# Changelog

:cl: ElectroJr
- fix: Fixed RGB lights & eswords sometimes not working and showing up as black.
