### PR TITLE
Natural Language Fixes

### DIFF
--- a/Content.Server/FloofStation/Traits/NaturalSpeakerTraitComponent.cs
+++ b/Content.Server/FloofStation/Traits/NaturalSpeakerTraitComponent.cs
@@ -5,8 +5,8 @@ using Robust.Shared.Prototypes;
 namespace Content.Server.FloofStation.Traits;
 
 /// <summary>
-///     When applied to a not-yet-spawned player entity, removes <see cref="BaseLanguage"/> from the lists of their languages
-///     and gives them a translator instead.
+///     When applied to a not-yet-spawned player entity, removes their natural language from the lists of their languages
+///     and gives them a replacement instead.
 /// </summary>
 [RegisterComponent]
 public sealed partial class NaturalSpeakerTraitComponent : Component

--- a/Content.Server/FloofStation/Traits/NaturalSpeakerTraitSystem.cs
+++ b/Content.Server/FloofStation/Traits/NaturalSpeakerTraitSystem.cs
@@ -28,7 +28,6 @@ public sealed partial class NaturalSpeakerTraitSystem : EntitySystem
 
     private void OnSpawn(Entity<NaturalSpeakerTraitComponent> entity, ref ComponentInit args)
     {
-
         if (!TryComp<LanguageKnowledgeComponent>(entity, out var knowledge))
         {
             Log.Warning($"Entity {entity.Owner} does not have a LanguageKnowledge but has a NaturalSpeakerTrait!");

--- a/Content.Server/Traits/TraitSystem.cs
+++ b/Content.Server/Traits/TraitSystem.cs
@@ -31,14 +31,27 @@ public sealed class TraitSystem : EntitySystem
     // When the player is spawned in, add all trait components selected during character creation
     private void OnPlayerSpawnComplete(PlayerSpawnCompleteEvent args)
     {
+        // Begin Floof: Sort traits by priority so we can specify some traits that may be reliant on other traits to properly function
+        var sortedTraits = new List<TraitPrototype>();
+
         foreach (var traitId in args.Profile.TraitPreferences)
         {
-            if (!_prototype.TryIndex<TraitPrototype>(traitId, out var traitPrototype))
+            if (_prototype.TryIndex<TraitPrototype>(traitId, out var traitPrototype))
+            {
+                sortedTraits.Add(traitPrototype);
+            }
+            else
             {
                 DebugTools.Assert($"No trait found with ID {traitId}!");
                 return;
             }
+        }
 
+        sortedTraits.Sort();
+
+        foreach (var traitPrototype in sortedTraits)
+        {
+            // Moved converting to prototypes to above loop in order to sort before applying them. End Floof modifications.
             if (!_characterRequirements.CheckRequirementsValid(
                 traitPrototype.Requirements,
                 _prototype.Index<JobPrototype>(args.JobId ?? _prototype.EnumeratePrototypes<JobPrototype>().First().ID),

--- a/Content.Shared/Traits/Prototypes/TraitPrototype.cs
+++ b/Content.Shared/Traits/Prototypes/TraitPrototype.cs
@@ -1,3 +1,4 @@
+using System;
 using Content.Shared.Customization.Systems;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Serialization.Manager;
@@ -10,7 +11,7 @@ namespace Content.Shared.Traits;
 ///     Describes a trait.
 /// </summary>
 [Prototype("trait")]
-public sealed partial class TraitPrototype : IPrototype
+public sealed partial class TraitPrototype : IPrototype, IComparable
 {
     [ViewVariables]
     [IdDataField]
@@ -34,6 +35,19 @@ public sealed partial class TraitPrototype : IPrototype
 
     [DataField(serverOnly: true)]
     public TraitFunction[] Functions { get; private set; } = Array.Empty<TraitFunction>();
+
+    /// <summary>
+    ///     Floof: Should this trait be loaded earlier/later than other traits?
+    /// </summary>
+    [DataField]
+    public int Priority = 0;
+    public int CompareTo(object? obj) // Compare function to allow for some traits to specify they need to load earlier than others
+    { 
+        if (obj is not TraitPrototype other)
+            return -1;
+
+        return Priority.CompareTo(other.Priority); // No need for total ordering, only care about things that want to be loaded earlier or later.
+    }
 }
 
 /// This serves as a hook for trait functions to modify a player character upon spawning in.

--- a/Resources/Prototypes/Floof/Traits/languages.yml
+++ b/Resources/Prototypes/Floof/Traits/languages.yml
@@ -16,6 +16,7 @@
   id: NaturalRatvarian
   category: TraitsSpeechLanguages
   points: -1
+  priority: -1
   requirements:
     - !type:CharacterItemGroupRequirement
       group: TraitsLanguagesNatural


### PR DESCRIPTION
# Description

Priority system for traits so they can specify they must be present before/after other traits.

Added negative priority to NaturalRatvarian trait so it will always be present before a foreigner trait, ensuring the foreigner trait can find the natural language replacement

Fixed summary of NaturalSpeakerTrait (was previously a copy of ForeignerTrait's summary)

---

# Changelog

:cl:
- fix: Natural Ratvarian + Foreigner should now deterministically give you a Ratvarian translator
