### PR TITLE
Restore Engineering Belts to Lockers

### DIFF
--- a/Resources/Prototypes/Catalog/Fills/Lockers/engineer.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/engineer.yml
@@ -99,6 +99,7 @@
       - id: RCDAmmo
       - id: LunchboxEngineeringFilledRandom # Delta-V Lunchboxes!
         prob: 0.3
+      - id: ClothingBeltUtilityAtmos # Floofstation
 
 - type: entity
   id: LockerAtmosphericsFilled
@@ -118,6 +119,7 @@
       - id: RCDAmmo
       - id: LunchboxEngineeringFilledRandom # Delta-V Lunchboxes!
         prob: 0.3
+      - id: ClothingBeltUtilityAtmos # Floofstation
 
 - type: entity
   id: LockerEngineerFilledHardsuit
@@ -134,6 +136,7 @@
       - id: RCDAmmo
       - id: LunchboxEngineeringFilledRandom # Delta-V Lunchboxes!
         prob: 0.3
+      - id: ClothingBeltUtilityEngineering # Floofstation
 
 - type: entity
   id: LockerEngineerFilled
@@ -149,6 +152,7 @@
       - id: RCDAmmo
       - id: LunchboxEngineeringFilledRandom # Delta-V Lunchboxes!
         prob: 0.3
+      - id: ClothingBeltUtilityEngineering # Floofstation
 
 - type: entity
   id: ClosetRadiationSuitFilled

--- a/Resources/Prototypes/Catalog/Fills/Lockers/heads.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/heads.yml
@@ -133,6 +133,7 @@
     contents:
       - id: ClothingOuterHardsuitEngineeringWhite
       - id: ClothingLongcoatCE # Floofstation
+      - id: ClothingBeltChiefEngineerFilled # Floofstation
       - id: ClothingMaskBreath
       - id: ClothingEyesGlassesMeson
       - id: ClothingShoesBootsMagAdv


### PR DESCRIPTION
<!--
This is a semi-strict format, you can add/remove sections as needed but the order/format should be kept the same
Remove these comments before submitting
-->

# Description

<!--
Explain this PR in as much detail as applicable

Some example prompts to consider:
How might this affect the game? The codebase?
What might be some alternatives to this?
How/Who does this benefit/hurt [the game/codebase]?
-->

Adds the CE belt back to the CE hardsuit locker as requested. Also added the engineering belts to their lockers, requested by a player.

---

# TODO

<!--
A list of everything you have to do before this PR is "complete"
You probably won't have to complete everything before merging but it's good to leave future references
-->

- [x] Add the filled belt to the filled hardsuit locker
- [x] Add engineering and atmos belts to their lockers

---

<!--
This is default collapsed, readers click to expand it and see all your media
The PR media section can get very large at times, so this is a good way to keep it clean
The title is written using HTML tags
The title must be within the <summary> tags or you won't see it
-->

<details><summary><h1>Media</h1></summary>
<p>

Took a screenshot of the wrong locker but I did look at both and it's there...

![image](https://github.com/user-attachments/assets/1c7c47e7-2d57-4598-87ce-0bea0884d4f9)
![image](https://github.com/user-attachments/assets/4f33afa9-c83c-467d-a1ec-cf6ba55affa8)


</p>
</details>

---

# Changelog

<!--
You can add an author after the `:cl:` to change the name that appears in the changelog (ex: `:cl: Death`)
Leaving it blank will default to your GitHub display name
This includes all available types for the changelog
-->

:cl:
- fix: Returned the lost engineering belts to their rightful place in the engineering lockers.
