### PR TITLE
Add Brigging and Sec SOP Guidebook Entries

### DIFF
--- a/Resources/Locale/en-US/Floof/guidebook/guides.ftl
+++ b/Resources/Locale/en-US/Floof/guidebook/guides.ftl
@@ -12,3 +12,5 @@ guide-entry-commandhierarchy = Command Hierarchy
 guide-entry-alertprocedure = Alert Procedure
 guide-entry-epistemicsSOP = Epistemics SOP
 guide-entry-engineeringSOP = Engineering SOP
+guide-entry-securitySOP = Security SOP
+guide-entry-briggingSOP = Brigging SOP

--- a/Resources/Prototypes/Floof/Guidebook/sop.yml
+++ b/Resources/Prototypes/Floof/Guidebook/sop.yml
@@ -11,6 +11,8 @@
   - Alert Procedure
   - Epistemics SOP
   - Engineering SOP
+  - Security SOP
+  - Brigging SOP
 
 - type: guideEntry
   id: Company Policy
@@ -83,3 +85,13 @@
   id: Engineering SOP
   name: guide-entry-engineeringSOP
   text: "/ServerInfo/Floof/Guidebook/SOP/EngineeringStandardOperatingProcedure.xml"
+  
+- type: guideEntry
+  id: Security SOP
+  name: guide-entry-securitySOP
+  text: "/ServerInfo/Floof/Guidebook/SOP/SecurityStandardOperatingProcedure.xml"
+
+- type: guideEntry
+  id: Brigging SOP
+  name: guide-entry-briggingSOP
+  text: "/ServerInfo/Floof/Guidebook/SOP/BriggingStandardOperatingProcedure.xml"

--- a/Resources/ServerInfo/Floof/Guidebook/SOP/BriggingStandardOperatingProcedure.xml
+++ b/Resources/ServerInfo/Floof/Guidebook/SOP/BriggingStandardOperatingProcedure.xml
@@ -1,0 +1,53 @@
+<Document>
+# Brigging Standard Operating Procedure
+
+[head=3][color=#ff0000]Last Updated 29 MAR 2025. THE WIKI IS AUTHORITATIVE. This is intended as an in-game reference only and may be out of date.[/head][/color]
+
+[bold]The Brig area is under the authority of the Warden.[/bold]
+
+When confining someone inside of the brig, the suspect should be handed to the Warden for processing. It is then the responsibility of the Warden to search, confine, and process the suspect in alignment with sentencing procedures. If the suspect is awaiting trial, then they are to be transferred to the extended confinement area pending a trial. If the Warden is not available, then it is the responsibility of the arresting officer to process the suspect and handle evidence. 
+
+## Treatment of Prisoners
+
+Prisoners have certain rights that [bold]must[/bold] be upheld by security and command personnel. Prisoners must be provided with the following: 
+
+- Adequate medical care and moral, spiritual, or legal counseling if it is requested and available. 
+- [italic]These are rights, not grantees.[/italic]
+- Access their authorized radio encryption keys only. 
+- [italic]This right may be revoked should it be abused.[/italic]
+- Clothing, food, and water on request.
+- Habitable holding cells or permabrig. 
+- [italic]If the secureness and safety of the holding area become compromised, the prisoners must be relocated, until the holding cells or permabrig are returned to a serviceable state.[/italic]
+- Freedom of movement within their holding area. 
+- [italic]Unless there is an undue risk to life and limb.[/italic]
+
+[head=3]Extended Confinement Prisoners[/head]
+
+Additionally, prisoners in Extended Confinement have certain rights but also more firm restrictions that [bold]must[/bold] be upheld by law enforcement: 
+
+- Only Extended Confinement prisoners may receive visitors. 
+- [italic]A maximum of [bold]one individual[/bold] may be permitted to visit a single convict every [bold]10 minutes[/bold]; a reason must be provided for the visit, and the visitor must consent to a search of their belongings.[/italic]
+- [italic]Conjugal visits are permitted but limited to no longer than [bold]1 hour[/bold].[/italic]
+- Upon approval, prisoners may request supervised work release if the staffing is available.
+- Prisoners who intentionally and maliciously cause structural damage to the permabrig, to a degree that makes it unreasonable to hold prisoners within, are thereby guilty of a capital crime.
+- Prisoners who intentionally, maliciously, and repeatedly cause significant bodily harm to their fellow inmates, visitors, and/or security staff are thereby guilty of a capital crime.
+- Prisoners may request retrial for capital crimes; these requests may be refused depending on the discretion and availability of the court clerk, chief justice, or at the discretion of the warden or head of station security.
+- Prisoners may request or may otherwise be given parole with a hearing by the Chief Justice, Court Clerk, or in their absence, the Head of Security or [textlink="commanding officer" link="Command Hierarchy"].
+
+## Preservative Stasis
+
+Should prisoners repeatedly and maliciously antagonize law enforcement, to an extent where continued extended confinement becomes infeasible, two of the three authorized personnel; the Warden, Head of Security, or [textlink="Commanding Officer" link="Command Hierarchy"], may agree to [italic]temporarily[/italic] upgrade the relevant prisoners’ sentences to Preservative Stasis summarily.
+-[italic]For more information, check the Preservative Stasis section in Space Law.[/italic]
+
+## Paroles and Pardons
+
+Prisoners may be admitted for parole by the Warden or Head of Security, or may apply for parole at the discretion and availability of the aforementioned parties under the following conditions: 
+- Shows peaceful compliance and assists officers with their duties.
+- Displays clear signs of remorse concerning the committed crime and/or criminal behaviors.
+
+If parole is requested, they may receive a [textlink="parole hearing" link="Judicial SOP"] conducted by the Court Clerk or Chief Justice, where they will state their case on why they should be released; they may request legal counsel in this hearing, but [bold]must represent themselves.[/bold]
+
+The sentencing officer of an arrest, the judge or arbiter of a trial, or the Warden - for extended confinement prisoners, may pardon members accused or sentenced for crimes if deemed in the best interest of the crew and vessel, and when the circumstances of the defendant or offense warrant suspension of sentence. 
+
+
+</Document>

--- a/Resources/ServerInfo/Floof/Guidebook/SOP/Permits.xml
+++ b/Resources/ServerInfo/Floof/Guidebook/SOP/Permits.xml
@@ -1,7 +1,7 @@
 <Document>
 # Permits
 
-[head=3][color=#ff0000]Last Updated 16  FEB 2025. THE WIKI IS AUTHORITATIVE. This is intended as an in-game reference only and may be out of date.[/head][/color]
+[head=3][color=#ff0000]Last Updated 16 FEB 2025. THE WIKI IS AUTHORITATIVE. This is intended as an in-game reference only and may be out of date.[/head][/color]
 
 ## The Issuer
 

--- a/Resources/ServerInfo/Floof/Guidebook/SOP/SecurityStandardOperatingProcedure.xml
+++ b/Resources/ServerInfo/Floof/Guidebook/SOP/SecurityStandardOperatingProcedure.xml
@@ -1,0 +1,138 @@
+<Document>
+# Security Standard Operating Procedure
+
+[head=3][color=#ff0000]Last Updated 29 MAR 2025. THE WIKI IS AUTHORITATIVE. This is intended as an in-game reference only and may be out of date.[/head][/color]
+
+This section is [bold]meta-shielded.[/bold]
+
+This is property of NanoTrasen Sector Security. Only authorized personnel have access to this. The whole Criminal Justice department can see this procedure as a check and balance for Security. 
+
+## Force Escalation / Use of Force
+
+This simple, short chart dictates how to proceed with a general arrest. However, depending on what the individual encounters at the station, you can escalate it as needed. You utilize [bold]Force Escalation[/bold] and [bold]Rules of Engagement[/bold] hand-in-hand. 
+
+[bold]Verbal Commands -> Non-Lethal Methods of Apprehension -> Lethal Methods of Apprehension[/bold]
+
+It would be best if you prioritized initiating by declaring an order, i.e.: "Stop!" "Stop, or I will shoot you!" "Hey! Stop moving!" Any of these methods will allow you to upgrade your Force Escalation higher on the scale as you move up non-lethal methods (baton, disabler, rubber-tipped munitions). However, not all situations are perfect, sometimes you have to act before you speak. 
+
+[head=3]Excessive Force[/head]
+
+Under no circumstances should Security Forces, which is included, but not limited to: The Captain / Commanding Officer, Head of Security, Warden, Security Officers and Cadets, Corpsman, Prison Guards, and Emergency Rescue Team personnel, brutalize or beat captive individuals that are [bold]restrained[/bold] or [bold]incapacitated[/bold] in some way. There are methods to prevent someone from breaking out of cuffs by simply pulling on their wrists (Mechanically, you PULL or PUSH, not initiate combat mode and punch them, or shoot them, or abuse them in any capacity relating to physical or otherwise.) Unruly prisoners and captives are first, [bold]warned to cease[/bold], if they continue, brig them—secure the individual in a cell when it's readily available to prevent more attempts of breaking out. 
+
+## Use of Force Additions
+
+When you have exhausted your baton's charges or disabler shots. This does not mean you should take out your knife or utilize a powered-down baton to apprehend someone. You can use your [bold]Flash[/bold], or [bold]Flashbang grenades[/bold]. You [italic]may[/italic] upgrade to using your MK58 with [bold]Rubber-Tipped Munitions[/bold] when the situation is still not contained. Additional apprehension or dispersal tools can be used, such as [bold]Stingers, Truncheons,[/bold] and [bold]Tear Gas[/bold]. 
+
+## Rules of Engagement
+
+Security personnel hold unrestricted armaments licenses. They are authorized at all times [bold]to use lethal force to the extent necessary[/bold] to [bold]neutralize[/bold] adversaries under any of the following circumstances:
+
+- [italic]If the adversary’s number or strength leaves the officer at a severe tactical disadvantage.[/italic]
+- [italic]If the adversary exhibits a clear and present danger to the vessel by physical means.[/italic]
+- [italic]If the adversary poses a significant threat of severe bodily injury or death to the officer or others.[/italic]
+- [italic]If the adversary presents an existential threat to the chain of command by illegal means.[/italic]
+- [italic]If the adversary cannot be reasonably subdued through non-lethal means without great bodily harm to the officer. …wherein an “adversary” is an entity that demonstrates a hostile intent, commits or directly contributes to a hostile act that does not constitute an actual attack, or is actively attacking the vessel or its crew.[/italic]
+
+## Sentencing
+
+You [bold]must[/bold] have all the evidence necessary to sentence someone to the appropriate charges, and you [bold]must[/bold] give [bold]time served[/bold] if the individual or individuals have been sitting in the Brig for far too long. The Warden shall be the person who issues the sentencing; however, if they are not present, the arresting officer shall issue the sentence fit for the crime. 
+
+[italic]See Space Law for a comprehensive list of crimes, modifiers, and conditions with definitions.[/italic]
+
+## Search & Seizure
+
+You [bold]must[/bold] search and seize any object that is believed to be used in the commission of the crime. However, one should not [italic]seize[/italic] non-NT-aligned objects, such as non-standard branded clothing and paraphernalia, that pose little risk. It should be removed from the person, placed in an evidence locker, and returned to them. Any [italic]contraband[/italic] defined under the Contraband List, [italic]shall[/italic] be seized from the individual. 
+
+## Treatment of Prisoners
+
+Prisoners are given the bare necessities, such as food, water, and clothing. Furthermore, they [bold]should not[/bold] be mistreated or abused. 
+
+They [bold]must[/bold] be given medical treatment before serving their sentence and searched before they are uncuffed in their cell. And similarly, to a Permanent Confinement Prisoner, if they have a reasonable request, it should be granted to them. 
+
+## Handling of Permanent Confinement Prisoners
+
+They [bold]must[/bold] be given what they ask for, so long as their request is reasonable. They [italic]must not[/italic] be mistreated or ignored; they [italic]must[/italic] be removed from Permanent Confinement when there are exigent circumstances, i.e., immediate danger to the persons like station-wide disruption or dangerous creatures. 
+
+[italic]See [textlink="Brigging Standard Operating Procedure" link="Brigging SOP"] for more clarification on the treatment and handling of prisoners.[/italic]
+
+## Warrents
+
+(Adapted from wiki due to formatting limitations)
+
+All warrents should be written by security.
+
+Warrent: [bold]Implant Search[/bold]
+
+- Warrent signed or stamped by: [italic]Commanding Officer, Head of Security or Warden; and Chief Medical Officer[/italic]
+
+Warrent: [bold]Departmental Search[/bold]
+- Warrent signed or stamped by: [italic]Commanding Officer, Head of Security, Warden[/italic]
+
+Warrent: [bold]Individual, Full Search[/bold]
+- Warrent signed or stamped by: [italic]Commanding Officer, Head of Security, Warden[/italic]      
+
+[head=3]Implants[/head] 
+
+For any situation requiring an implant search, you [bold]must[/bold] have a warrant with [bold]evidence[/bold] such as the Implanter with the suspect's DNA; other evidence are admissible, articulating that being unable to find the object on the person and line of sight was not lost on the suspect. 
+- [italic]The Captain is presented with an implant search warrant, they see that it is lacking some details in relation to the articulation of the probable cause; meaning what evidence or line of thinking on Security's part, denying the warrant; expressing to them to write it better.[/italic]
+
+Then bring in trained medical personnel under supervision of the Head of Security or Chief Medical Officer; or, the Chief Medical Officer will perform the implant search themselves [italic]after[/italic] being shown the warrant— present the warrant to the suspect. 
+- [italic]Medical Intern Fluffs Stargazer is observed by the Head of Security Teeg Dougland to use the Implanter device on suspect Slab Bulkhead, they soon discover that a device is pulled into the implanter, thereby completing the implant search.[/italic]
+
+Additionally, an individual may consent to the implant search, thereby waiving the necessity for a warrant. 
+- [italic]A individual waived their rights because they'd rather get the situation over with and would rather exonerate themselves as soon as possible, saying that they [bold]give consent[/bold]. Upon the medical personnel's efforts to use the Implanter device on the suspect, they soon find that nothing got pulled into the device's chamber, clearing the suspect's name.[/italic]
+
+[head=3]Departments[/head]
+
+For any situation that requires a departmental search, provide Probable Cause for the warrant.
+
+- [italic]For example, two individuals broke into the Head of Personnel's room and stole some personal effects and ID cards.[/italic]
+- [italic]Probable Cause: John Security and Jane Warden witnessed two individuals run into Engineering, detaining them followed by a search, nothing was found on them in relation to the stolen goods; the stolen items were not on them and it is reasonable to believe they have stowed the items in the department.[/italic]
+
+You [bold]must[/bold] get it stamped or signed by the Captain, or Head of Security, or Warden. Present the warrant to the Departmental Head, who's department is getting searched— you may also present this to any of the workers they have. 
+
+[head=3]Individuals[/head]
+
+For a stringent search of a persons' effects [bold]write-up[/bold] a search warrant that can be signed off by the Head of Security, Warden, or Captain. Present the warrant to the suspect. This must be done when it is under Green Alert. 
+
+[head=3]Consented Search[/head]
+
+This method defeats all warrants, when the individual suspect gives consent of their own free will and volition, not coerced and forced to do so; nor any promise of a reward for providing consent.
+
+## Armoury Procedure
+
+When on station, the Warden is ultimately responsible for stocking the armoury and distributing and recording the collection of weapons. However, if they are absent, it falls on the Head of Security. 
+
+The distribution of weapons and munitions [italic]must[/italic] follow [bold]Force Escalation, Rules of Engagement,[/bold] and [bold]Alert Procedure[/bold]. Once the threat is dealt with, the Warden or Head of Security shall issue a recall for all weapons to be returned, and a restock should be in order. [bold]Non-Crew[/bold] shall [italic]not[/italic] be issued weapons from the armoury. 
+
+[head=3]Conditional Situations[/head]
+
+This does not mean that as Head of Security or the Warden, you can wander around the halls fully armed to the teeth for all circumstances.
+
+For example, the Warden and Head of Security may carry one (1) long rifle such as a Laser Rifle or Lecter or Drozd, or Antique weaponry, then wear their assigned Hard Suit, and common apprehension tools.
+
+However, security officers and cadets should only be assigned similar kits when applicable to the alert level. 
+
+## Reasonable Suspicion
+
+A security officer can justify searching someone and detaining someone if and when they encounter someone that they reasonably believe to be committing, involved in committing or conspiring to commit a crime. This is referred to as Reasonable Suspicion. Three example scenarios of Reasonable Suspicion would be, but not limited to:
+
+-[italic]The security officer receives reasonable reports of someone with a lethal weapon.[/italic]
+-[italic]The security officer spots someone with an otherwise unusual or suspicious item: (chief examples of this not covered above would be makeshift cuffs & unpermitted clothing, such as command uniforms)[/italic]
+-[italic]The security officer observes someone acting out-of-ordinary or obscuring their identifiable features around restricted areas or scenes of crime, fleeing unusually from the crime scene, or fitting the description presented at the scene of a crime set by fellow officers or witnesses[/italic]
+
+## Probable Cause
+
+Probable Cause is an escalation of Reasonable Suspicion, wherein the security officer obtains sufficient and near-irrefutable evidence to support that someone is involved in or going to be involved in committing a criminal act. Often, this requires the officer's direct view. Three example scenarios of Probable Cause would be, but not limited to:
+
+-[italic]The security officer undeniably spots someone quickly pull out a lethal, non-permitted weapon.[/italic]
+-[italic]The security officer watches someone flee from an area with stolen items.[/italic]
+-[italic]The security officer sees someone breaking open an area in which they are restricted from accessing.[/italic]
+
+## Fleeing Individual
+
+When Security is enacting a detainment to possibly arrest a wanted person, and the individual begins to [bold]flee[/bold], Security can utilize ranged non-lethal apprehension methods. 
+
+There [bold]must[/bold] be probable cause to utilize Lethal Force if the officer can articulates that the fleeing individual will cause serious harm to the officers or the station and crew at large or continually slipped out of cuffs or readily escaped their Brig cell. 
+
+</Document>


### PR DESCRIPTION
<!--
This is a semi-strict format, you can add/remove sections as needed but the order/format should be kept the same
Remove these comments before submitting
-->

# Description

<!--
Explain this PR in as much detail as applicable

Some example prompts to consider:
How might this affect the game? The codebase?
What might be some alternatives to this?
How/Who does this benefit/hurt [the game/codebase]?
-->

Adds the Floof Brigging SOP and Security SOPs from the wiki to the in-game guidebook. Part of my slow project to get certain wiki content available in-game and kept up to date.

I may expand the scope of this PR to include the judicial SOP, but I'm not sure yet.

---

# TODO

<!--
A list of everything you have to do before this PR is "complete"
You probably won't have to complete everything before merging but it's good to leave future references
-->

- [x] Finish PR (determine scope, get screenshots, etc) - eh, don't feel like doing more guidebook stuff for the moment.
- [x] Add Brigging SOP
- [x] Add Security SOP

---

<!--
This is default collapsed, readers click to expand it and see all your media
The PR media section can get very large at times, so this is a good way to keep it clean
The title is written using HTML tags
The title must be within the <summary> tags or you won't see it
-->

<details><summary><h1>Media</h1></summary>
<p>

![image](https://github.com/user-attachments/assets/f9a0ca11-1e63-4eee-ab2c-905bc37ba4c5)
![image](https://github.com/user-attachments/assets/fbe25be0-0732-47ec-90d3-472bf5a85818)


</p>
</details>

---

# Changelog

<!--
You can add an author after the `:cl:` to change the name that appears in the changelog (ex: `:cl: Death`)
Leaving it blank will default to your GitHub display name
This includes all available types for the changelog
-->

:cl:
- add: Added Security and Brigging SOPs to the guidebook.
