### PR TITLE
Reduce Power Cell Draw of Translators

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Devices/translators.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/translators.yml
@@ -37,7 +37,7 @@
   parent: [ TranslatorUnpowered, PowerCellSlotMediumItem ]
   components:
   - type: PowerCellDraw
-    drawRate: 1
+    drawRate: 0.666 # Floofstation - reduced to 2/3 the normal rate
   - type: ItemSlots
     slots:
       cell_slot:


### PR DESCRIPTION
# Description
Title, lowers it to 2/3 of the current rate. After numerous complaints and 1.5 thousand hours of personal experience I can say it's a much needed change.

# Changelog
:cl:
- tweak: Handheld translators now use 1.5 times less power.