### PR TITLE
Examine Tooltip for Players Persists Thru Walls

### DIFF
--- a/Content.Shared/Examine/ExamineSystemShared.cs
+++ b/Content.Shared/Examine/ExamineSystemShared.cs
@@ -112,7 +112,10 @@ namespace Content.Shared.Examine
 
             // Floofstation edit - if the examined thing is a player, just return true
             if (examined != null)
-                if (EntityManager.TryGetComponent<ActorComponent>(examined, out var _))
+                if (EntityManager.TryGetComponent<ActorComponent>(examined, out var _)
+                    && examined.HasValue
+                    && Transform(examiner).Coordinates.TryDistance(EntityManager, _transform, Transform(examined.Value).Coordinates, out var distance)
+                    && distance <= GetExaminerRange(examiner))
                     return true;
 
             return InRangeUnOccluded(

--- a/Content.Shared/Examine/ExamineSystemShared.cs
+++ b/Content.Shared/Examine/ExamineSystemShared.cs
@@ -326,6 +326,9 @@ namespace Content.Shared.Examine
             _hasDescription = hasDescription;
         }
 
+        /// <summary>
+        ///     Returns <see cref="Message"/> with all <see cref="Parts"/> appended according to their priority.
+        /// </summary>
         public FormattedMessage GetTotalMessage()
         {
             int Comparison(ExamineMessagePart a, ExamineMessagePart b)

--- a/Content.Shared/Examine/ExamineSystemShared.cs
+++ b/Content.Shared/Examine/ExamineSystemShared.cs
@@ -110,7 +110,7 @@ namespace Content.Shared.Examine
             if (EntityManager.GetComponent<TransformComponent>(examiner).MapID != target.MapId)
                 return false;
 
-            // if the examined thing is a player, just return true
+            // Floofstation edit - if the examined thing is a player, just return true
             if (examined != null)
                 if (EntityManager.TryGetComponent<ActorComponent>(examined, out var _))
                     return true;

--- a/Content.Shared/Examine/ExamineSystemShared.cs
+++ b/Content.Shared/Examine/ExamineSystemShared.cs
@@ -11,6 +11,7 @@ using Robust.Shared.Containers;
 using Robust.Shared.Map;
 using Robust.Shared.Physics;
 using Robust.Shared.Utility;
+using Robust.Shared.Player;
 using static Content.Shared.Interaction.SharedInteractionSystem;
 
 namespace Content.Shared.Examine
@@ -108,6 +109,11 @@ namespace Content.Shared.Examine
 
             if (EntityManager.GetComponent<TransformComponent>(examiner).MapID != target.MapId)
                 return false;
+
+            // if the examined thing is a player, just return true
+            if (examined != null)
+                if (EntityManager.TryGetComponent<ActorComponent>(examined, out var _))
+                    return true;
 
             return InRangeUnOccluded(
                 _transform.GetMapCoordinates(examiner),
@@ -320,9 +326,6 @@ namespace Content.Shared.Examine
             _hasDescription = hasDescription;
         }
 
-        /// <summary>
-        ///     Returns <see cref="Message"/> with all <see cref="Parts"/> appended according to their priority.
-        /// </summary>
         public FormattedMessage GetTotalMessage()
         {
             int Comparison(ExamineMessagePart a, ExamineMessagePart b)

--- a/Content.Shared/Examine/ExamineSystemShared.cs
+++ b/Content.Shared/Examine/ExamineSystemShared.cs
@@ -112,7 +112,7 @@ namespace Content.Shared.Examine
 
             // Floofstation edit - if the examined thing is a player, just return true
             if (examined != null)
-                if (EntityManager.TryGetComponent<ActorComponent>(examined, out var _)
+                if (TryComp<ActorComponent>(examined, out var _)
                     && examined.HasValue
                     && Transform(examiner).Coordinates.TryDistance(EntityManager, _transform, Transform(examined.Value).Coordinates, out var distance)
                     && distance <= GetExaminerRange(examiner))


### PR DESCRIPTION
# Description

When you examine someone, the tooltip should still show up even if they hide behind a wall. Still obeys max distance though, so it'll disappear if they run too far away.

Whole point of this is to make it a bit easier to read peoples' flavortexts.

---

# Changelog

:cl:
- tweak: Player examine tooltips will persist even if they go out of line of sight.