### PR TITLE
Post-Update Fixes

### DIFF
--- a/Content.Client/Administration/UI/CustomControls/PlayerListControl.xaml.cs
+++ b/Content.Client/Administration/UI/CustomControls/PlayerListControl.xaml.cs
@@ -21,7 +21,7 @@ public sealed partial class PlayerListControl : BoxContainer
 
     private readonly IEntityManager _entManager;
     private readonly IUserInterfaceManager _uiManager;
-    
+
     private PlayerInfo? _selectedPlayer;
 
     private List<PlayerInfo> _playerList = new();
@@ -111,7 +111,7 @@ public sealed partial class PlayerListControl : BoxContainer
             _sortedPlayerList.Sort((a, b) => Comparison(a, b));
 
         // Ensure pinned players are always at the top
-        _sortedPlayerList.Sort((a, b) => a.IsPinned != b.IsPinned && a.IsPinned ? -1 : 1);
+        _sortedPlayerList.Sort((a, b) => -a.IsPinned.CompareTo(b.IsPinned)); // Floofstation - fix unstable sorting
 
         PlayerListContainer.PopulateList(_sortedPlayerList.Select(info => new PlayerListData(info)).ToList());
         if (_selectedPlayer != null)

--- a/Content.Client/Lobby/UI/LoadoutPreferenceSelector.xaml.cs
+++ b/Content.Client/Lobby/UI/LoadoutPreferenceSelector.xaml.cs
@@ -237,11 +237,17 @@ public sealed partial class LoadoutPreferenceSelector : Control
         });
         PreferenceButton.OnToggled += args =>
         {
+            if (args.Pressed == _preference.Selected) // Floofstation
+                return;
+
             _preference.Selected = args.Pressed;
             PreferenceChanged?.Invoke(Preference);
         };
         HeirloomButton.OnToggled += args =>
         {
+            if (args.Pressed == _preference.Selected) // Floofstation
+                return;
+
             _preference.CustomHeirloom = args.Pressed ? true : null;
             PreferenceChanged?.Invoke(Preference);
         };


### PR DESCRIPTION
# Description
- Fixed unstable player sorting in the ahelp menu
- Fixed loadouts being impossible to select if you have less than 2x or update if you have less than 1x their loadout point cost

# Changelog
:cl:
- fix: Fixed loadouts being unusable unless you have 2x their loadout point cost.