### PR TITLE
Remove Stamina Cost on the Mining Drill

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/pickaxe.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/pickaxe.yml
@@ -75,8 +75,8 @@
     heavyDamageBaseModifier: 1
    # heavyStaminaCost: 2 Floof change
     angle: 20
-  # type: DamageOtherOnHit
-  # staminaCost: 8
+  - type: DamageOtherOnHit
+    staminaCost: 8
   - type: ThrowingAngle
     angle: 270
 

--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/pickaxe.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/pickaxe.yml
@@ -73,7 +73,7 @@
     heavyRateModifier: 1
     heavyRangeModifier: 2
     heavyDamageBaseModifier: 1
-   # heavyStaminaCost: 2 Floof change
+   heavyStaminaCost: 0 # Floof change
     angle: 20
   - type: DamageOtherOnHit
     staminaCost: 8

--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/pickaxe.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/pickaxe.yml
@@ -73,7 +73,7 @@
     heavyRateModifier: 1
     heavyRangeModifier: 2
     heavyDamageBaseModifier: 1
-    heavyStaminaCost: 2
+   # heavyStaminaCost: 2 Floof change
     angle: 20
   - type: DamageOtherOnHit
     staminaCost: 8

--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/pickaxe.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/pickaxe.yml
@@ -75,8 +75,8 @@
     heavyDamageBaseModifier: 1
    # heavyStaminaCost: 2 Floof change
     angle: 20
-  - type: DamageOtherOnHit
-    staminaCost: 8
+  # type: DamageOtherOnHit
+  # staminaCost: 8
   - type: ThrowingAngle
     angle: 270
 

--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/pickaxe.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/pickaxe.yml
@@ -73,7 +73,7 @@
     heavyRateModifier: 1
     heavyRangeModifier: 2
     heavyDamageBaseModifier: 1
-   heavyStaminaCost: 0 # Floof change
+    heavyStaminaCost: 0 # Floof change
     angle: 20
   - type: DamageOtherOnHit
     staminaCost: 8


### PR DESCRIPTION

# Description
Removes the stamina cost to used the power drill. 
It was removed before the update I think this is just really a bug and EVERYONE hates that it has a stamina cost to the point they will just used the pickaxe


# Changelog

<!--
You can add an author after the `:cl:` to change the name that appears in the changelog (ex: `:cl: Death`)
Leaving it blank will default to your GitHub display name
This includes all available types for the changelog
-->

:cl:
- fix: Mining drill no longer used stamina
