### PR TITLE
Security Socks Retrofit

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/Shoes/boots.yml
+++ b/Resources/Prototypes/Entities/Clothing/Shoes/boots.yml
@@ -67,6 +67,8 @@
     sprite: Clothing/Shoes/Boots/combatboots.rsi
   - type: Clothing
     sprite: Clothing/Shoes/Boots/combatboots.rsi
+  - type: ClothingSlowOnDamageModifier # Floof - M3739 - Strange this isn't on this, when the jackboots have them...
+    modifier: 0.5
 
 - type: entity
   parent: ClothingShoesMilitaryBase

--- a/Resources/Prototypes/Floof/Entities/Clothing/departmental_clothes.yml
+++ b/Resources/Prototypes/Floof/Entities/Clothing/departmental_clothes.yml
@@ -740,6 +740,8 @@
     sprite: Floof/Clothing/Departmental/Security/hossocks.rsi
   - type: Clothing
     sprite: Floof/Clothing/Departmental/Security/hossocks.rsi
+  - type: ClothingSlowOnDamageModifier
+    modifier: 0.5
 
 - type: entity
   parent: ClothingUniformBase
@@ -781,6 +783,8 @@
     sprite: Floof/Clothing/Departmental/Security/detectsocks.rsi
   - type: Clothing
     sprite: Floof/Clothing/Departmental/Security/detectsocks.rsi
+  - type: ClothingSlowOnDamageModifier
+    modifier: 0.5
 
 - type: entity
   parent: ClothingUniformBase
@@ -822,6 +826,8 @@
     sprite: Floof/Clothing/Departmental/Security/corpsmansocks.rsi
   - type: Clothing
     sprite: Floof/Clothing/Departmental/Security/corpsmansocks.rsi
+  - type: ClothingSlowOnDamageModifier
+    modifier: 0.5
 
 - type: entity
   parent: ClothingUniformBase

--- a/Resources/Prototypes/Floof/Entities/Clothing/departmental_clothes.yml
+++ b/Resources/Prototypes/Floof/Entities/Clothing/departmental_clothes.yml
@@ -697,6 +697,8 @@
     sprite: Floof/Clothing/Departmental/Security/secsocks.rsi
   - type: Clothing
     sprite: Floof/Clothing/Departmental/Security/secsocks.rsi
+  - type: ClothingSlowOnDamageModifier
+    modifier: 0.5
 
 - type: entity
   parent: ClothingUniformBase


### PR DESCRIPTION
<!--
This is a semi-strict format, you can add/remove sections as needed but the order/format should be kept the same
Remove these comments before submitting
-->

# Description

<!--
Explain this PR in as much detail as applicable

Some example prompts to consider:
How might this affect the game? The codebase?
What might be some alternatives to this?
How/Who does this benefit/hurt [the game/codebase]?
-->

This PR aims to retrofit the security thigh-highs to be consistent with Jackboots.

**This also includes the same for the combat boots.** Which is strange that EE didn't give combat boots the same treatment as the Jackboots. The combat boots update can be removed upon request.

---

# TODO

<!--
A list of everything you have to do before this PR is "complete"
You probably won't have to complete everything before merging but it's good to leave future references
-->

- [x] What TODO?
- [x] Its like, only 20 lines of code my guy, same 2 lines copied across 5 files
- [x] Merge my pr
- [x] trust

---

<!--
This is default collapsed, readers click to expand it and see all your media
The PR media section can get very large at times, so this is a good way to keep it clean
The title is written using HTML tags
The title must be within the <summary> tags or you won't see it
-->

<details><summary><h1>Media</h1></summary>
<p>

![image](https://github.com/user-attachments/assets/3eecbeaa-1aba-4241-828d-9dc2502e399a)

</p>
</details>

---

# Changelog

<!--
You can add an author after the `:cl:` to change the name that appears in the changelog (ex: `:cl: Death`)
Leaving it blank will default to your GitHub display name
This includes all available types for the changelog
-->

:cl: M3739
- fix: The security department's socks have been retrofitted to meet new footwear requirements.
