### PR TITLE
Add Corpsman Longcoat to Loadout

### DIFF
--- a/Resources/Prototypes/CharacterItemGroups/Jobs/Security/corpsman.yml
+++ b/Resources/Prototypes/CharacterItemGroups/Jobs/Security/corpsman.yml
@@ -67,11 +67,13 @@
     - type: loadout
       id: LoadoutMaskCorpsmanBreathMedicalSecurity
 
-#- type: characterItemGroup
-#  id: LoadoutCorpsmanOuter
-#  maxItems: 1
-#  items:
-#
+- type: characterItemGroup
+  id: LoadoutCorpsmanOuter
+  maxItems: 1
+  items:
+    - type: loadout
+      id: ClothingLongcoatBrigmedic
+
 #- type: characterItemGroup
 #  id: LoadoutCorpsmanShoes
 #  maxItems: 1

--- a/Resources/Prototypes/Floof/Loadouts/Jobs/Security/corpsman.yml
+++ b/Resources/Prototypes/Floof/Loadouts/Jobs/Security/corpsman.yml
@@ -75,6 +75,19 @@
 
 
 # Outer
+- type: loadout
+  id: LoadoutCorpsmanLongcoat
+  category: JobsSecurityCorpsman
+  cost: 0
+  exclusive: true
+  items:
+    - ClothingLongcoatBrigmedic
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: LoadoutCorpsmanOuter
+    - !type:CharacterJobRequirement
+      jobs:
+        - Brigmedic
 
 # Shoes
 


### PR DESCRIPTION
Adds the Corpsman Armored Longcoat to the Loadout options for Corpsman.

# Description

Add the corpsman longcoat to the corpsman loadout. This removes the worry of a previous corpsman cryoing with the one and only copy of the coat from the locker.

---

# Changelog

<!--
You can add an author after the `:cl:` to change the name that appears in the changelog (ex: `:cl: Death`)
Leaving it blank will default to your GitHub display name
This includes all available types for the changelog
-->

:cl:sprkl
- add: Corpsman Longcoat to loadout options
