### PR TITLE
Warden Loadout Changes

### DIFF
--- a/Resources/Prototypes/CharacterItemGroups/Jobs/Security/warden.yml
+++ b/Resources/Prototypes/CharacterItemGroups/Jobs/Security/warden.yml
@@ -35,6 +35,8 @@
   items:
     - type: loadout
       id: LoadoutClothingHeadHatBeretWarden
+    - type: loadout # Floof - Add missing warden loadouts
+      id: LoadoutClothingHeadHatWarden
 
 #- type: characterItemGroup
 #  id: LoadoutWardenId
@@ -57,12 +59,20 @@
   items:
     - type: loadout
       id: LoadoutClothingOuterCoatWarden
+# Floof region - Add missing warden loadouts
+    - type: loadout
+      id: LoadoutClothingOuterWinterWarden
+    - type: loadout
+      id: LoadoutClothingOuterLongcoatWarden
+# Floof region end
 
-#- type: characterItemGroup
-#  id: LoadoutWardenShoes
-#  maxItems: 1
-#  items:
-#
+- type: characterItemGroup
+  id: LoadoutWardenShoes
+  maxItems: 1
+  items:
+    - type: loadout # Floof - Add missing warden loadouts
+      id: LoadoutWardenShoesBootsWinter
+
 - type: characterItemGroup
   id: LoadoutWardenUniforms
   maxItems: 1

--- a/Resources/Prototypes/Floof/Loadouts/Jobs/Security/warden.yml
+++ b/Resources/Prototypes/Floof/Loadouts/Jobs/Security/warden.yml
@@ -1,0 +1,79 @@
+# Warden
+# Backpacks
+
+# Belt
+
+# Ears
+
+# Equipment
+
+# Eyes
+
+# Gloves
+
+# Head
+- type: loadout
+  id: LoadoutClothingHeadHatWarden
+  category: JobsSecurityWarden
+  cost: 0
+  exclusive: true
+  items:
+    - ClothingHeadHatWarden
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: LoadoutWardenHead
+    - !type:CharacterJobRequirement
+      jobs:
+        - Warden
+
+# Id
+
+# Neck
+
+# Mask
+
+# Outer
+- type: loadout
+  id: LoadoutClothingOuterWinterWarden
+  category: JobsSecurityWarden
+  cost: 0
+  exclusive: true
+  items:
+    - ClothingOuterWinterWarden
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: LoadoutWardenOuter
+    - !type:CharacterJobRequirement
+      jobs:
+        - Warden
+
+- type: loadout
+  id: LoadoutClothingOuterLongcoatWarden
+  category: JobsSecurityWarden
+  cost: 0
+  exclusive: true
+  items:
+    - ClothingLongcoatWarden
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: LoadoutWardenOuter
+    - !type:CharacterJobRequirement
+      jobs:
+        - Warden
+
+# Shoes
+- type: loadout
+  id: LoadoutWardenShoesBootsWinter
+  category: JobsSecurityWarden
+  cost: 0
+  exclusive: true
+  items:
+    - ClothingShoesBootsWinterWarden
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: LoadoutWardenShoes
+    - !type:CharacterJobRequirement
+      jobs:
+        - Warden
+
+# Uniforms

--- a/Resources/Prototypes/Roles/Jobs/Security/warden.yml
+++ b/Resources/Prototypes/Roles/Jobs/Security/warden.yml
@@ -34,7 +34,7 @@
     eyes: ClothingEyesGlassesSunglasses
     outerClothing: ClothingOuterCoatWarden
     id: WardenPDA
-    ears: ClothingHeadsetSecurity
+    ears: ClothingHeadsetAltSecurity # Floof - Warden spawns with HoS's headset
     belt: ClothingBeltSecurityFilled
   innerClothingSkirt: ClothingUniformJumpskirtWarden
   satchel: ClothingBackpackSatchelSecurity


### PR DESCRIPTION
# Description

Adds the missing warden's cap, longcoat, winter coat, and winter boots to loadout.

The warden now spawns with the HoS's headset. Prior to this change, the warden spawns with a regular security headset, but can (and often does) immediately grab the HoS's headset from their locker, which does not appear to be unexpected or unwanted behaviour. This should be resolved in one direction or the other. It's entirely conceivable that the warden having access to command comms is a mistake, and the headset should be removed from the locker. I am happy to change my PR in that direction at the maintainers' request. I have chosen to resolve it in the other direction, making the warden spawn with the radio channel they appear to be expected to use.

---

<details><summary><h1>Media</h1></summary>
<h3>The warden's new loadouts</h3>

![wardendrip](https://github.com/user-attachments/assets/5ef2e9a9-2679-4f57-8761-8b63eba2e893)

<h3>The warden spawning with their new headset</h3>

![spawnheadset](https://github.com/user-attachments/assets/8048978a-fc58-46c7-b76f-95bf45e1617b)

</details>

---

# Changelog

:cl:
- add: Added loadouts for the warden's cap, longcoat, and winter coat and boots.
- tweak: The warden spawns with the head of security's headset.
