### PR TITLE
Cherry-Pick Less Transparent Slime People

### DIFF
--- a/Resources/Prototypes/Species/slime.yml
+++ b/Resources/Prototypes/Species/slime.yml
@@ -98,7 +98,7 @@
 - type: humanoidBaseSprite
   id: MobSlimeMarkingFollowSkin
   markingsMatchSkin: true
-  layerAlpha: 0.5
+  layerAlpha: 0.72
 
 - type: humanoidBaseSprite
   id: MobSlimeHead


### PR DESCRIPTION
# Description

Just cherry-picked https://github.com/space-wizards/space-station-14/pull/35158 from WizDen because Karin begged for it. Makes slime people less transparent so you can't see their scalp through their hair it looked weird.

---


# Changelog

<!--
You can add an author after the `:cl:` to change the name that appears in the changelog (ex: `:cl: Death`)
Leaving it blank will default to your GitHub display name
This includes all available types for the changelog
-->

:cl: LaCumbiaDelCoronavirus
- tweak: Slime people look a bit less bald now.
