### PR TITLE
Chitinid Revision No. 1

### DIFF
--- a/Resources/Locale/en-US/chemistry/components/injector-component.ftl
+++ b/Resources/Locale/en-US/chemistry/components/injector-component.ftl
@@ -28,3 +28,4 @@ injector-component-injecting-user = You start injecting the needle.
 injector-component-drawing-target = {CAPITALIZE(THE($user))} is trying to use a needle to draw from you!
 injector-component-injecting-target = {CAPITALIZE(THE($user))} is trying to inject a needle into you!
 injector-component-deny-chitinid = {CAPITALIZE(THE($target))}'s exoskeleton is too thick for the needle to pierce.
+# Floof - M3739 - Chitinid-Revision - For some god awful reason, it isn't even processing the $target of deny-chitinid. Thanks EE.

--- a/Resources/Locale/en-US/chemistry/components/injector-component.ftl
+++ b/Resources/Locale/en-US/chemistry/components/injector-component.ftl
@@ -28,4 +28,4 @@ injector-component-injecting-user = You start injecting the needle.
 injector-component-drawing-target = {CAPITALIZE(THE($user))} is trying to use a needle to draw from you!
 injector-component-injecting-target = {CAPITALIZE(THE($user))} is trying to inject a needle into you!
 injector-component-deny-chitinid = {CAPITALIZE(THE($target))}'s exoskeleton is too thick for the needle to pierce.
-# Floof - M3739 - Chitinid-Revision - For some god awful reason, it isn't even processing the $target of deny-chitinid. Thanks EE.
+# Floof - M3739 - #726 - For some god awful reason, it isn't even processing the $target of deny-chitinid. Thanks EE.

--- a/Resources/Prototypes/DeltaV/Entities/Mobs/Species/chitinid.yml
+++ b/Resources/Prototypes/DeltaV/Entities/Mobs/Species/chitinid.yml
@@ -167,7 +167,7 @@
       - CanPilot
       - FootstepSound
       - DoorBumpOpener
-      - ChitinidEmotes # Floof - M3739 - Chitinid-Revision
+      - ChitinidEmotes # Floof - M3739 - #726
 
 - type: entity
   parent: BaseSpeciesDummy

--- a/Resources/Prototypes/DeltaV/Entities/Mobs/Species/chitinid.yml
+++ b/Resources/Prototypes/DeltaV/Entities/Mobs/Species/chitinid.yml
@@ -162,6 +162,12 @@
     - TauCetiBasic
     - Chittin
     naturalLanguage: Chittin # Floof: explicitly stated natural languages
+  - type: Tag
+    tags:
+      - CanPilot
+      - FootstepSound
+      - DoorBumpOpener
+      - ChitinidEmotes # Floof - M3739
 
 - type: entity
   parent: BaseSpeciesDummy

--- a/Resources/Prototypes/DeltaV/Entities/Mobs/Species/chitinid.yml
+++ b/Resources/Prototypes/DeltaV/Entities/Mobs/Species/chitinid.yml
@@ -167,7 +167,7 @@
       - CanPilot
       - FootstepSound
       - DoorBumpOpener
-      - ChitinidEmotes # Floof - M3739
+      - ChitinidEmotes # Floof - M3739 - Chitinid-Revision
 
 - type: entity
   parent: BaseSpeciesDummy

--- a/Resources/Prototypes/DeltaV/Species/chitinid.yml
+++ b/Resources/Prototypes/DeltaV/Species/chitinid.yml
@@ -23,6 +23,7 @@
     HeadTop: MobHumanoidAnyMarking
     HeadSide: MobHumanoidAnyMarking
     Tail: MobHumanoidAnyMarking
+    Wings: MobHumanoidAnyMarking # Floof - M3739 - Chitinid-Revision
     Eyes: MobChitinidEyes
     LArm: MobChitinidLArm
     RArm: MobChitinidRArm
@@ -59,6 +60,9 @@
       points: 1
       required: true
       defaultMarkings: [ ChitinidWingsDefault ]
+    Wings: # Floof - M3739 - Chitinid-Revision
+      points: 1
+      required: false
     Snout:
       points: 1
       required: false

--- a/Resources/Prototypes/DeltaV/Species/chitinid.yml
+++ b/Resources/Prototypes/DeltaV/Species/chitinid.yml
@@ -11,6 +11,7 @@
   maleFirstNames: NamesChitinidFirstMale
   femaleFirstNames: NamesChitinidFirstFemale
   naming: First
+  customName: true # Floof - M3739 - #726
 
 - type: speciesBaseSprites
   id: MobChitinidSprites

--- a/Resources/Prototypes/DeltaV/Species/chitinid.yml
+++ b/Resources/Prototypes/DeltaV/Species/chitinid.yml
@@ -23,7 +23,7 @@
     HeadTop: MobHumanoidAnyMarking
     HeadSide: MobHumanoidAnyMarking
     Tail: MobHumanoidAnyMarking
-    Wings: MobHumanoidAnyMarking # Floof - M3739 - Chitinid-Revision
+    Wings: MobHumanoidAnyMarking # Floof - M3739 - #726
     Eyes: MobChitinidEyes
     LArm: MobChitinidLArm
     RArm: MobChitinidRArm
@@ -60,7 +60,7 @@
       points: 1
       required: true
       defaultMarkings: [ ChitinidWingsDefault ]
-    Wings: # Floof - M3739 - Chitinid-Revision
+    Wings: # Floof - M3739 - #726
       points: 1
       required: false
     Snout:

--- a/Resources/Prototypes/DeltaV/Voice/speech_emote_sounds.yml
+++ b/Resources/Prototypes/DeltaV/Voice/speech_emote_sounds.yml
@@ -242,6 +242,10 @@
       path: /Audio/Voice/Arachnid/arachnid_click.ogg
     Crying:
       collection: FemaleCry
+    Hiss: # Delta-V - M3739 - Not too sure how this wasn't retained in the port. Did we begin the process before it merged?
+      path: /Audio/Animals/snake_hiss.ogg
+    Weh: # Floof - M3739 - the wehpocalypse claims the ants
+      collection: Weh
 
 - type: emoteSounds
   id: MaleFeroxi

--- a/Resources/Prototypes/Entities/Mobs/Species/arachnid.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/arachnid.yml
@@ -25,7 +25,7 @@
     - FootstepSound
     - DoorBumpOpener
     - SpiderCraft
-    - ArachnidEmotes
+    - ArachnidEmotes # Floof - M3739 - #631
   - type: Butcherable
     butcheringType: Spike
     spawned:

--- a/Resources/Prototypes/Entities/Mobs/Species/diona.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/diona.yml
@@ -135,7 +135,7 @@
       - CanPilot
       - FootstepSound
       - DoorBumpOpener
-      - DionaEmotes
+      - DionaEmotes # Floof - M3739 - #631
 
 - type: entity
   parent: BaseSpeciesDummy

--- a/Resources/Prototypes/Entities/Mobs/Species/moth.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/moth.yml
@@ -126,7 +126,7 @@
       - CanPilot
       - FootstepSound
       - DoorBumpOpener
-      - MothEmotes
+      - MothEmotes # Floof - M3739 - #631
 
 - type: entity
   parent: BaseSpeciesDummy

--- a/Resources/Prototypes/Nyanotrasen/Voice/speech_emotes.yml
+++ b/Resources/Prototypes/Nyanotrasen/Voice/speech_emotes.yml
@@ -10,6 +10,7 @@
     - HarpyEmotes
     - ShadowkinEmotes
     - UnathiEmotes
+    - ChitinidEmotes
   blacklist:
     tags:
       - SiliconEmotes

--- a/Resources/Prototypes/Nyanotrasen/Voice/speech_emotes.yml
+++ b/Resources/Prototypes/Nyanotrasen/Voice/speech_emotes.yml
@@ -10,7 +10,7 @@
     - HarpyEmotes
     - ShadowkinEmotes
     - UnathiEmotes
-    - ChitinidEmotes # Floof - M3739 - Chitinid-Revision
+    - ChitinidEmotes # Floof - M3739 - #726
   blacklist:
     tags:
       - SiliconEmotes

--- a/Resources/Prototypes/Nyanotrasen/Voice/speech_emotes.yml
+++ b/Resources/Prototypes/Nyanotrasen/Voice/speech_emotes.yml
@@ -10,7 +10,7 @@
     - HarpyEmotes
     - ShadowkinEmotes
     - UnathiEmotes
-    - ChitinidEmotes
+    - ChitinidEmotes # Floof - M3739 - Chitinid-Revision
   blacklist:
     tags:
       - SiliconEmotes

--- a/Resources/Prototypes/Voice/disease_emotes.yml
+++ b/Resources/Prototypes/Voice/disease_emotes.yml
@@ -20,6 +20,7 @@
       - DionaEmotes
       - ArachnidEmotes
       - MothEmotes
+      - ChitinidEmotes
     components:
     - BorgChassis
   chatTriggers:
@@ -64,6 +65,7 @@
       - ArachnidEmotes
       - DionaEmotes
       - MothEmotes
+      - ChitinidEmotes
      # Floof - M3739 - I was going to blacklist the Unathi from yawning, but as it turns out IRL lizards can in fact yawn, albeit, silently.
     components:
     - BorgChassis

--- a/Resources/Prototypes/Voice/disease_emotes.yml
+++ b/Resources/Prototypes/Voice/disease_emotes.yml
@@ -16,11 +16,11 @@
   blacklist:
     tags:
       - SiliconEmotes
-      - UnathiEmotes # Floof - M3739 - Lizards cannot cough. At all.
-      - DionaEmotes
-      - ArachnidEmotes
-      - MothEmotes
-      - ChitinidEmotes
+      - UnathiEmotes # Floof - M3739 - #631 - Lizards cannot cough. At all.
+      - DionaEmotes # Floof - M3739 - #631
+      - ArachnidEmotes # Floof - M3739 - #631
+      - MothEmotes # Floof - M3739 - #631
+      - ChitinidEmotes # Floof - M3739 - Chitinid-Revision
     components:
     - BorgChassis
   chatTriggers:
@@ -62,10 +62,10 @@
   blacklist:
     tags:
       - SiliconEmotes
-      - ArachnidEmotes
-      - DionaEmotes
-      - MothEmotes
-      - ChitinidEmotes
+      - ArachnidEmotes # Floof - M3739 - #631
+      - DionaEmotes # Floof - M3739 - #631
+      - MothEmotes # Floof - M3739 - #631
+      - ChitinidEmotes # Floof - M3739 - Chitinid-Revision
      # Floof - M3739 - I was going to blacklist the Unathi from yawning, but as it turns out IRL lizards can in fact yawn, albeit, silently.
     components:
     - BorgChassis

--- a/Resources/Prototypes/Voice/disease_emotes.yml
+++ b/Resources/Prototypes/Voice/disease_emotes.yml
@@ -20,7 +20,7 @@
       - DionaEmotes # Floof - M3739 - #631
       - ArachnidEmotes # Floof - M3739 - #631
       - MothEmotes # Floof - M3739 - #631
-      - ChitinidEmotes # Floof - M3739 - Chitinid-Revision
+      - ChitinidEmotes # Floof - M3739 - #726
     components:
     - BorgChassis
   chatTriggers:
@@ -65,7 +65,7 @@
       - ArachnidEmotes # Floof - M3739 - #631
       - DionaEmotes # Floof - M3739 - #631
       - MothEmotes # Floof - M3739 - #631
-      - ChitinidEmotes # Floof - M3739 - Chitinid-Revision
+      - ChitinidEmotes # Floof - M3739 - #726
      # Floof - M3739 - I was going to blacklist the Unathi from yawning, but as it turns out IRL lizards can in fact yawn, albeit, silently.
     components:
     - BorgChassis

--- a/Resources/Prototypes/Voice/speech_emotes.yml
+++ b/Resources/Prototypes/Voice/speech_emotes.yml
@@ -38,6 +38,7 @@
     tags:
       - ArachnidEmotes
       - MothEmotes
+      - ChitinidEmotes
   chatMessages: ["chat-emote-msg-honk"]
   chatTriggers:
     - honks
@@ -56,6 +57,7 @@
       - UnathiEmotes
       - ArachnidEmotes
       - MothEmotes
+      - ChitinidEmotes
   chatMessages: ["chat-emote-msg-sigh"]
   chatTriggers:
     - sighs
@@ -73,6 +75,7 @@
       - DionaEmotes
       - ArachnidEmotes
       - MothEmotes
+      - ChitinidEmotes
   chatMessages: ["chat-emote-msg-whistle"]
   chatTriggers:
     - whistles
@@ -90,6 +93,7 @@
       - DionaEmotes
       - ArachnidEmotes
       - MothEmotes
+      - ChitinidEmotes
   chatMessages: ["chat-emote-msg-crying"]
   chatTriggers:
     - cries

--- a/Resources/Prototypes/Voice/speech_emotes.yml
+++ b/Resources/Prototypes/Voice/speech_emotes.yml
@@ -36,9 +36,9 @@
   icon: Interface/Emotes/honk.png
   blacklist:
     tags:
-      - ArachnidEmotes
-      - MothEmotes
-      - ChitinidEmotes
+      - ArachnidEmotes # Floof - M3739 - #631
+      - MothEmotes # Floof - M3739 - #631
+      - ChitinidEmotes # Floof - M3739 - Chitinid-Revision
   chatMessages: ["chat-emote-msg-honk"]
   chatTriggers:
     - honks
@@ -53,11 +53,11 @@
     - Vocal
   blacklist:
     tags:
-      - DionaEmotes
+      - DionaEmotes # Floof - M3739 - #631
       - UnathiEmotes
-      - ArachnidEmotes
-      - MothEmotes
-      - ChitinidEmotes
+      - ArachnidEmotes # Floof - M3739 - #631
+      - MothEmotes # Floof - M3739 - #631
+      - ChitinidEmotes # Floof - M3739 - Chitinid-Revision
   chatMessages: ["chat-emote-msg-sigh"]
   chatTriggers:
     - sighs
@@ -72,10 +72,10 @@
     - Vocal
   blacklist:
     tags:
-      - DionaEmotes
-      - ArachnidEmotes
-      - MothEmotes
-      - ChitinidEmotes
+      - DionaEmotes # Floof - M3739 - #631
+      - ArachnidEmotes # Floof - M3739 - #631
+      - MothEmotes # Floof - M3739 - #631
+      - ChitinidEmotes # Floof - M3739 - Chitinid-Revision
   chatMessages: ["chat-emote-msg-whistle"]
   chatTriggers:
     - whistles
@@ -90,10 +90,10 @@
     - Vocal
   blacklist:
     tags:
-      - DionaEmotes
-      - ArachnidEmotes
-      - MothEmotes
-      - ChitinidEmotes
+      - DionaEmotes # Floof - M3739 - #631
+      - ArachnidEmotes # Floof - M3739 - #631
+      - MothEmotes # Floof - M3739 - #631
+      - ChitinidEmotes # Floof - M3739 - Chitinid-Revision
   chatMessages: ["chat-emote-msg-crying"]
   chatTriggers:
     - cries

--- a/Resources/Prototypes/Voice/speech_emotes.yml
+++ b/Resources/Prototypes/Voice/speech_emotes.yml
@@ -38,7 +38,7 @@
     tags:
       - ArachnidEmotes # Floof - M3739 - #631
       - MothEmotes # Floof - M3739 - #631
-      - ChitinidEmotes # Floof - M3739 - Chitinid-Revision
+      - ChitinidEmotes # Floof - M3739 - #726
   chatMessages: ["chat-emote-msg-honk"]
   chatTriggers:
     - honks
@@ -57,7 +57,7 @@
       - UnathiEmotes
       - ArachnidEmotes # Floof - M3739 - #631
       - MothEmotes # Floof - M3739 - #631
-      - ChitinidEmotes # Floof - M3739 - Chitinid-Revision
+      - ChitinidEmotes # Floof - M3739 - #726
   chatMessages: ["chat-emote-msg-sigh"]
   chatTriggers:
     - sighs
@@ -75,7 +75,7 @@
       - DionaEmotes # Floof - M3739 - #631
       - ArachnidEmotes # Floof - M3739 - #631
       - MothEmotes # Floof - M3739 - #631
-      - ChitinidEmotes # Floof - M3739 - Chitinid-Revision
+      - ChitinidEmotes # Floof - M3739 - #726
   chatMessages: ["chat-emote-msg-whistle"]
   chatTriggers:
     - whistles
@@ -93,7 +93,7 @@
       - DionaEmotes # Floof - M3739 - #631
       - ArachnidEmotes # Floof - M3739 - #631
       - MothEmotes # Floof - M3739 - #631
-      - ChitinidEmotes # Floof - M3739 - Chitinid-Revision
+      - ChitinidEmotes # Floof - M3739 - #726
   chatMessages: ["chat-emote-msg-crying"]
   chatTriggers:
     - cries

--- a/Resources/Prototypes/tags.yml
+++ b/Resources/Prototypes/tags.yml
@@ -1393,7 +1393,7 @@
 
 - type: Tag
   id: UnathiEmotes
-
+# Floof - M3739 - Begin Floof species tags
 - type: Tag
   id: MothEmotes
 
@@ -1402,6 +1402,10 @@
 
 - type: Tag
   id: DionaEmotes
+  
+- type: Tag
+  id: ChitinidEmotes
+# Floof - M3739 - End Floof species tags
 # EE Emote Fix End
 
 # Floof tags


### PR DESCRIPTION
<!--
This is a semi-strict format, you can add/remove sections as needed but the order/format should be kept the same
Remove these comments before submitting
-->

# Description

<!--
Explain this PR in as much detail as applicable

Some example prompts to consider:
How might this affect the game? The codebase?
What might be some alternatives to this?
How/Who does this benefit/hurt [the game/codebase]?
-->

This PR is a revision of the Chitinids, a pass through of their YAML, markings, and emotes.

They now have access to their Hiss emote, which was mysteriously absent from the chitinid port. The YAML has also been prepped to host any wing markings for future development.

---

# TODO

<!--
A list of everything you have to do before this PR is "complete"
You probably won't have to complete everything before merging but it's good to leave future references
-->

**Emote Wheel**
- [x] Correct emotes
- [x] Add missing hiss emote
- [x] Comment #631 and our changes proper

**Fluent**
- [X] ~~Fix missing injection ftl~~ (I tried)
- [x] Thanks EE.

**Markings**
- [X] ~~Insectoid Wings~~  (no, it looks horrible in my opinion)
- [x] Prep chitinids for future wings

---

<!--
This is default collapsed, readers click to expand it and see all your media
The PR media section can get very large at times, so this is a good way to keep it clean
The title is written using HTML tags
The title must be within the <summary> tags or you won't see it
-->

<details><summary><h1>Media</h1></summary>
<p>

![image](https://github.com/user-attachments/assets/e63336fb-0b0e-4d81-92bb-3e3de9786bc4)

</p>
</details>

---

# Changelog

<!--
You can add an author after the `:cl:` to change the name that appears in the changelog (ex: `:cl: Death`)
Leaving it blank will default to your GitHub display name
This includes all available types for the changelog
-->

:cl: M3739
- fix: The Chitinid's emote wheel has been revised and corrected.
