### PR TITLE
Add Missing Janitor Loadouts

### DIFF
--- a/Resources/Prototypes/CharacterItemGroups/Jobs/Service/janitor.yml
+++ b/Resources/Prototypes/CharacterItemGroups/Jobs/Service/janitor.yml
@@ -13,22 +13,46 @@
 #  id: LoadoutJanitorEars
 #  maxItems: 1
 #  items:
-#
-#- type: characterItemGroup
-#  id: LoadoutJanitorEquipment
-#  maxItems: 1
-#  items:
-#
+
+- type: characterItemGroup
+  id: LoadoutJanitorEquipment
+  maxItems: 4 # Floof - Add janitor loadouts
+  items:
+# Floof section - Add janitor loadouts
+    - type: loadout
+      id: LoadoutJanitorEquipmentMopItem
+    - type: loadout
+      id: LoadoutJanitorEquipmentBoxMousetrap
+    - type: loadout
+      id: LoadoutJanitorEquipmentWetFloorSign
+    - type: loadout
+      id: LoadoutJanitorEquipmentTrashBag
+    - type: loadout
+      id: LoadoutJanitorEquipmentLightReplacer
+    - type: loadout
+      id: LoadoutJanitorEquipmentBoxLightMixed
+    - type: loadout
+      id: LoadoutJanitorEquipmentHoloprojector
+    - type: loadout
+      id: LoadoutJanitorEquipmentPlunger
+# Floof section end
+
 #- type: characterItemGroup
 #  id: LoadoutJanitorEyes
 #  maxItems: 1
 #  items:
-#
-#- type: characterItemGroup
-#  id: LoadoutJanitorGloves
-#  maxItems: 1
-#  items:
-#
+
+- type: characterItemGroup
+  id: LoadoutJanitorGloves
+  maxItems: 1
+  items:
+# Floof section - Add janitor loadouts
+    - type: loadout
+      id: LoadoutClothingHandsJanitorWarmers
+    - type: loadout
+      id: LoadoutJanitorGloves
+# Floof section end
+
 #- type: characterItemGroup
 #  id: LoadoutJanitorHead
 #  maxItems: 1
@@ -53,12 +77,20 @@
 #  id: LoadoutJanitorOuter
 #  maxItems: 1
 #  items:
-#
-#- type: characterItemGroup
-#  id: LoadoutJanitorShoes
-#  maxItems: 1
-#  items:
-#
+
+- type: characterItemGroup
+  id: LoadoutJanitorShoes
+  maxItems: 1
+  items:
+# Floof section - Add janitor loadouts
+    - type: loadout
+      id: LoadoutClothingUnderSocksJanitor
+    - type: loadout
+      id: LoadoutJanitorShoesGaloshes
+    - type: loadout
+      id: LoadoutJanitorShoesWinter
+# Floof section end
+
 - type: characterItemGroup
   id: LoadoutJanitorUniforms
   maxItems: 1
@@ -69,3 +101,15 @@
       id: LoadoutServiceJumpsuitJanitorIdris
     - type: loadout
       id: LoadoutServiceJumpsuitJanitorOrion
+# Floof section - Add janitor loadouts
+    - type: loadout
+      id: LoadoutServiceJumpsuitJanitor
+    - type: loadout
+      id: LoadoutServiceJumpsuitJanitorSkirt
+    - type: loadout
+      id: LoadoutServiceJumpsuitJanitorJanimaidSkirt
+    - type: loadout
+      id: LoadoutServiceJumpsuitJanitorJanimaidMini
+    - type: loadout
+      id: LoadoutServiceJumpsuitJanitorClassicalMaidDress
+# Floof section end

--- a/Resources/Prototypes/Floof/Loadouts/Jobs/Service/janitor.yml
+++ b/Resources/Prototypes/Floof/Loadouts/Jobs/Service/janitor.yml
@@ -1,55 +1,348 @@
+# Janitor
+# Backpacks
+
+# Belt
+- type: loadout
+  id: LoadoutJanitorBelt
+  category: JobsServiceJanitor
+  cost: 0
+  exclusive: true
+  items:
+    - ClothingBeltJanitorFilled
+  requirements:
+    - !type:CharacterJobRequirement
+      jobs:
+        - Janitor
+
+# Ears
+
+# Equipment
+- type: loadout
+  id: LoadoutJanitorEquipmentMopItem
+  category: JobsServiceJanitor
+  cost: 0
+  exclusive: true
+  items:
+    - MopItem
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: LoadoutJanitorEquipment
+    - !type:CharacterJobRequirement
+      jobs:
+        - Janitor
+
+- type: loadout
+  id: LoadoutJanitorEquipmentBoxMousetrap
+  category: JobsServiceJanitor
+  cost: 0
+  exclusive: true
+  items:
+    - BoxMousetrap
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: LoadoutJanitorEquipment
+    - !type:CharacterJobRequirement
+      jobs:
+        - Janitor
+
+- type: loadout
+  id: LoadoutJanitorEquipmentWetFloorSign
+  category: JobsServiceJanitor
+  cost: 0
+  exclusive: true
+  items:
+    - WetFloorSign
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: LoadoutJanitorEquipment
+    - !type:CharacterJobRequirement
+      jobs:
+        - Janitor
+
+- type: loadout
+  id: LoadoutJanitorEquipmentTrashBag
+  category: JobsServiceJanitor
+  cost: 0
+  exclusive: true
+  items:
+    - TrashBag
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: LoadoutJanitorEquipment
+    - !type:CharacterJobRequirement
+      jobs:
+        - Janitor
+
+- type: loadout
+  id: LoadoutJanitorEquipmentLightReplacer
+  category: JobsServiceJanitor
+  cost: 0
+  exclusive: true
+  items:
+    - LightReplacer
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: LoadoutJanitorEquipment
+    - !type:CharacterJobRequirement
+      jobs:
+        - Janitor
+
+- type: loadout
+  id: LoadoutJanitorEquipmentBoxLightMixed
+  category: JobsServiceJanitor
+  cost: 0
+  exclusive: true
+  items:
+    - BoxLightMixed
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: LoadoutJanitorEquipment
+    - !type:CharacterJobRequirement
+      jobs:
+        - Janitor
+
+- type: loadout
+  id: LoadoutJanitorEquipmentHoloprojector
+  category: JobsServiceJanitor
+  cost: 1
+  exclusive: true
+  items:
+    - Holoprojector
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: LoadoutJanitorEquipment
+    - !type:CharacterJobRequirement
+      jobs:
+        - Janitor
+
+- type: loadout
+  id: LoadoutJanitorEquipmentPlunger
+  category: JobsServiceJanitor
+  cost: 0
+  exclusive: true
+  items:
+    - Plunger
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: LoadoutJanitorEquipment
+    - !type:CharacterJobRequirement
+      jobs:
+        - Janitor
+
+# Eyes
+
+# Gloves
 - type: loadout
   id: LoadoutClothingHandsJanitorWarmers
   category: JobsServiceJanitor
   cost: 0
   exclusive: true
   items:
-  - ClothingHandsJanitorWarmers
+    - ClothingHandsJanitorWarmers
   requirements:
-  - !type:CharacterJobRequirement
-    jobs:
-    - Janitor
+    - !type:CharacterItemGroupRequirement
+      group: LoadoutJanitorGloves
+    - !type:CharacterJobRequirement
+      jobs:
+        - Janitor
 
+- type: loadout
+  id: LoadoutJanitorGloves
+  category: JobsServiceJanitor
+  cost: 0
+  exclusive: true
+  items:
+    - ClothingHandsGlovesJanitor
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: LoadoutJanitorGloves
+    - !type:CharacterJobRequirement
+      jobs:
+        - Janitor
+
+# Head
+- type: loadout
+  id: LoadoutJanitorHeadHatPurplesoft
+  category: JobsServiceJanitor
+  cost: 0
+  exclusive: true
+  items:
+    - ClothingHeadHatPurplesoft
+  requirements:
+    - !type:CharacterJobRequirement
+      jobs:
+        - Janitor
+
+# Id
+
+# Neck
+- type: loadout
+  id: LoadoutClothingNeckCloakJanitor
+  category: JobsServiceJanitor
+  cost: 2
+  exclusive: true
+  items:
+    - ClothingNeckCloakJanitor
+  requirements:
+    - !type:CharacterJobRequirement
+      jobs:
+        - Janitor
+    - !type:CharacterPlaytimeRequirement
+      tracker: JobJanitor
+      min: 36000 # 10 hours
+
+# Mask
+
+# Outer
+- type: loadout
+  id: LoadoutJanitorOuterWinter
+  category: JobsServiceJanitor
+  cost: 0
+  exclusive: true
+  items:
+    - ClothingOuterWinterJani
+  requirements:
+    - !type:CharacterJobRequirement
+      jobs:
+        - Janitor
+
+# Shoes
 - type: loadout
   id: LoadoutClothingUnderSocksJanitor
   category: JobsServiceJanitor
   cost: 0
   exclusive: true
   items:
-  - ClothingUnderSocksJanitor
+    - ClothingUnderSocksJanitor
   requirements:
-  - !type:CharacterSpeciesRequirement
-    inverted: true
-    species:
-    - Diona
-    - Harpy
-  - !type:CharacterJobRequirement
-    jobs:
-    - Janitor
+    - !type:CharacterItemGroupRequirement
+      group: LoadoutJanitorShoes
+    - !type:CharacterSpeciesRequirement
+      inverted: true
+      species:
+        - Diona
+        - Harpy
+    - !type:CharacterJobRequirement
+      jobs:
+        - Janitor
 
+- type: loadout
+  id: LoadoutJanitorShoesGaloshes
+  category: JobsServiceJanitor
+  cost: 0
+  exclusive: true
+  items:
+    - ClothingShoesGaloshes
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: LoadoutJanitorShoes
+    - !type:CharacterSpeciesRequirement
+      inverted: true
+      species:
+        - Diona
+        - Harpy
+    - !type:CharacterJobRequirement
+      jobs:
+        - Janitor
+
+- type: loadout
+  id: LoadoutJanitorShoesWinter
+  category: JobsServiceJanitor
+  cost: 0
+  exclusive: true
+  items:
+    - ClothingShoesBootsWinterJani
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: LoadoutJanitorShoes
+    - !type:CharacterSpeciesRequirement
+      inverted: true
+      species:
+        - Diona
+        - Harpy
+    - !type:CharacterJobRequirement
+      jobs:
+        - Janitor
+
+# Uniforms
 - type: loadout
   id: LoadoutClothingUniformJanitorThong
   category: JobsServiceJanitor
   cost: 0
   exclusive: true
   items:
-  - ClothingUniformJanitorThong
+    - ClothingUniformJanitorThong
   requirements:
-  - !type:CharacterJobRequirement
-    jobs:
-    - Janitor
+    - !type:CharacterJobRequirement
+      jobs:
+        - Janitor
 
 - type: loadout
-  id: LoadoutClothingNeckCloakJanitor
+  id: LoadoutServiceJumpsuitJanitor
   category: JobsServiceJanitor
-  cost: 2
+  cost: 0
   exclusive: true
-  requirements:
-  - !type:CharacterJobRequirement
-    jobs:
-    - Janitor
-  - !type:CharacterPlaytimeRequirement
-    tracker: JobJanitor
-    min: 36000 # 10 hours
   items:
-  - ClothingNeckCloakJanitor
+    - ClothingUniformJumpsuitJanitor
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: LoadoutJanitorUniforms
+    - !type:CharacterJobRequirement
+      jobs:
+        - Janitor
+
+- type: loadout
+  id: LoadoutServiceJumpsuitJanitorSkirt
+  category: JobsServiceJanitor
+  cost: 0
+  exclusive: true
+  items:
+    - ClothingUniformJumpskirtJanitor
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: LoadoutJanitorUniforms
+    - !type:CharacterJobRequirement
+      jobs:
+        - Janitor
+
+- type: loadout
+  id: LoadoutServiceJumpsuitJanitorJanimaidSkirt
+  category: JobsServiceJanitor
+  cost: 0
+  exclusive: true
+  items:
+    - ClothingUniformJumpskirtJanimaid
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: LoadoutJanitorUniforms
+    - !type:CharacterJobRequirement
+      jobs:
+        - Janitor
+
+- type: loadout
+  id: LoadoutServiceJumpsuitJanitorJanimaidMini
+  category: JobsServiceJanitor
+  cost: 0
+  exclusive: true
+  items:
+    - ClothingUniformJumpskirtJanimaidmini
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: LoadoutJanitorUniforms
+    - !type:CharacterJobRequirement
+      jobs:
+        - Janitor
+
+- type: loadout
+  id: LoadoutServiceJumpsuitJanitorClassicalMaidDress
+  category: JobsServiceJanitor
+  cost: 0
+  exclusive: true
+  items:
+    - ClothingUniformClassicalMaidDress
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: LoadoutJanitorUniforms
+    - !type:CharacterJobRequirement
+      jobs:
+        - Janitor


### PR DESCRIPTION
# Description

Adds the following items to the janitor loadout, collected from the janitor's default equipment, locker, and janidrobe:
- Belt
- Equipment, maximum of four:
  - Mop
  - mousetrap box
  - wet floor sign
  - trash bag
  - light replacer
  - lights box
  - holoprojector
  - plunger
- Gloves
- Purple hat
- Winter coat and boots
- Galoshes
- Regular jumpsuit, plus janimaid, janimaid miniskirt, and classical maid dress

---

<details><summary><h1>Media</h1></summary>
<p>

![janitorloadouts](https://github.com/user-attachments/assets/2a99200b-783c-450a-ade4-c2e300c7d305)

</p>
</details>

---

# Changelog

:cl:
- add: Added 18 janitor loadout items. Millions must swag.
