### PR TITLE
Heterochromia Fix

### DIFF
--- a/Resources/Prototypes/DeltaV/Species/chitinid.yml
+++ b/Resources/Prototypes/DeltaV/Species/chitinid.yml
@@ -62,7 +62,7 @@
       points: 1
       required: false
     Head:
-      points: 1
+      points: 2
       required: false
     Chest:
       points: 1

--- a/Resources/Prototypes/DeltaV/Species/rodentia.yml
+++ b/Resources/Prototypes/DeltaV/Species/rodentia.yml
@@ -67,7 +67,7 @@
       points: 1
       required: false
     Head:
-      points: 1
+      points: 2
       required: false
     RightLeg:
       points: 2

--- a/Resources/Prototypes/DeltaV/Species/vulpkanin.yml
+++ b/Resources/Prototypes/DeltaV/Species/vulpkanin.yml
@@ -60,7 +60,7 @@
       points: 1
       required: false
     Head:
-      points: 1
+      points: 2
       required: false
     RightLeg:
       points: 2

--- a/Resources/Prototypes/Entities/Mobs/Customization/Markings/tattoos.yml
+++ b/Resources/Prototypes/Entities/Mobs/Customization/Markings/tattoos.yml
@@ -114,7 +114,6 @@
   id: TattooEyeRight
   bodyPart: Eyes
   markingCategory: Head
-  speciesRestriction: [Human, SlimePerson, Reptilian, Dwarf, Felinid, Oni, Harpy, Rodentia, Feroxi] # Delta V - Felinid, Vulpkanin, Oni, Harpy, Rodentia
   coloring:
     default:
       type:
@@ -128,7 +127,6 @@
   id: TattooEyeLeft
   bodyPart: Eyes
   markingCategory: Head
-  speciesRestriction: [Human, SlimePerson, Reptilian, Dwarf, Felinid, Oni, Harpy, Rodentia, Feroxi] # Delta V - Felinid, Vulpkanin, Oni, Harpy, Rodentia
   coloring:
     default:
       type:

--- a/Resources/Prototypes/Entities/Mobs/Customization/Markings/tattoos.yml
+++ b/Resources/Prototypes/Entities/Mobs/Customization/Markings/tattoos.yml
@@ -114,6 +114,7 @@
   id: TattooEyeRight
   bodyPart: Eyes
   markingCategory: Head
+  speciesRestriction: [Vulpkanin, Dwarf, Human, SlimePerson, Oni, Harpy, Rodentia, Reptilian, Feroxi, Felinid]
   coloring:
     default:
       type:
@@ -127,6 +128,7 @@
   id: TattooEyeLeft
   bodyPart: Eyes
   markingCategory: Head
+  speciesRestriction: [Vulpkanin, Dwarf, Human, SlimePerson, Oni, Harpy, Rodentia, Reptilian, Feroxi, Felinid]
   coloring:
     default:
       type:

--- a/Resources/Prototypes/Species/slime.yml
+++ b/Resources/Prototypes/Species/slime.yml
@@ -62,7 +62,7 @@
       points: 1
       required: false
     Head:
-      points: 1
+      points: 2
       required: false
     HeadTop:
       points: 1


### PR DESCRIPTION
# Description

Adjusted the Left and Right eye tattoo markings(Heterochromia markings) to be usable on every species with the standard eye sprite and adjusted the head marking slots of every affected species to accommodate for the change. This change was based on player request that I agree with as even Vulpkanin's were previously unable to have it which is interesting for the canine species not to be able to have heterochromia.

---

<details><summary><h1>Media</h1></summary>
<p>

![Screenshot 2025-04-08 015854](https://github.com/user-attachments/assets/7b3fa140-2753-44d5-82f4-05fa4faa9d11)

</p>
</details>

---

# Changelog

<!--
You can add an author after the `:cl:` to change the name that appears in the changelog (ex: `:cl: Death`)
Leaving it blank will default to your GitHub display name
This includes all available types for the changelog
-->

:cl: faefyr
- tweak: Adjusted head markings to include left and right eye for heterochromia, this is done on species with standard eye sprites, this change comes with an addition head marking slot to accommodate for the change so it can be added on top of existing markings.