### PR TITLE
Antag Modifications

### DIFF
--- a/Resources/Prototypes/DeltaV/Objectives/traitor.yml
+++ b/Resources/Prototypes/DeltaV/Objectives/traitor.yml
@@ -62,5 +62,5 @@
     unique: false
   - type: TargetObjective
     title: objective-condition-teach-person-title
-  - type: PickRandomPerson
+  - type: PickRandomHead
   - type: TeachLessonCondition

--- a/Resources/Prototypes/GameRules/events.yml
+++ b/Resources/Prototypes/GameRules/events.yml
@@ -89,7 +89,7 @@
   categories: [ HideSpawnMenu ]
   components:
   - type: StationEvent
-    weight: 6.5
+    weight: 5 # Floof - changed from 6.5
     duration: 1
     earliestStart: 120 # Floof
     reoccurrenceDelay: 60
@@ -116,7 +116,7 @@
   categories: [ HideSpawnMenu ]
   components:
   - type: StationEvent
-    weight: 7.5
+    weight: 6 # Floof - Changed from 7.5
     duration: 1
     earliestStart: 45
     minimumPlayers: 20
@@ -197,8 +197,8 @@
       prob: 0.02
     - id: MobMouse2
       prob: 0.02
-    - id: MobMouseCancer
-      prob: 0.001
+#    - id: MobMouseCancer # Floof - Removed Cancer mouse spawns
+#      prob: 0.001
     specialEntries:
     - id: SpawnPointGhostRatKing
       prob: 0.001
@@ -388,9 +388,9 @@
   categories: [ HideSpawnMenu ]
   components:
   - type: StationEvent
-    earliestStart: 35
-    weight: 5.5
-    minimumPlayers: 20
+    earliestStart: 60 # Floof - Changed from 35
+    weight: 3 # Floof - Changed from 5.5
+    minimumPlayers: 30 # Floof - changed from 20
     duration: 1
   - type: LoadMapRule
     preloadedGrid: ShuttleStriker

--- a/Resources/Prototypes/GameRules/roundstart.yml
+++ b/Resources/Prototypes/GameRules/roundstart.yml
@@ -147,7 +147,7 @@
   - type: AntagSelection
     definitions:
     - prefRoles: [ Traitor ]
-      max: 2 # Floof - Balance around Security Pop
+      max: 1 # Floof - Balance around Security Pop
       playerRatio: 10
       lateJoinAdditional: true
       mindComponents:

--- a/Resources/Prototypes/Objectives/objectiveGroups.yml
+++ b/Resources/Prototypes/Objectives/objectiveGroups.yml
@@ -39,7 +39,7 @@
   id: TraitorObjectiveGroupState
   weights:
     EscapeShuttleObjective: 1
-    DieObjective: 0.05
+    # DieObjective: 0.05 # Floof - No DAGD
     HijackShuttleObjective: 0.02
 
 - type: weightedRandom


### PR DESCRIPTION
# Description

This PR aims to solve a few issues with antags. Mainly making it so that only Heads can be picked as Lesson targets and lowering the weights of major antags.

---

# Changelog

:cl:
- tweak: Only Heads can be chosen for the "Teach a Lesson" objective.
- tweak: Reduced weights for Dragon, LoneOp, and Revenant.
- tweak: Increased earliest start requirement for LoneOp.
- tweak: Increased minimum player requirement for LoneOp.
- tweak: Reduced number of traitors in a round.
- remove: Cancer mouse no longer spawns from "Mouse Migration" event
- remove: Removed "Die a Glorious Death" objective.
