### PR TITLE
Colorable Cyberjacket and Loincloth

### DIFF
--- a/Resources/Locale/en-US/Floof/loadouts/uniform.ftl
+++ b/Resources/Locale/en-US/Floof/loadouts/uniform.ftl
@@ -1,0 +1,2 @@
+loadout-name-LoadoutClothingOuterCyberJacketWhite = cyberjacket (colorable)
+loadout-name-LoadoutClothingUniformLoinClothWhite = loin-cloth (colorable)

--- a/Resources/Prototypes/Floof/Entities/Clothing/OuterClothing/MiscOuterwear.yml
+++ b/Resources/Prototypes/Floof/Entities/Clothing/OuterClothing/MiscOuterwear.yml
@@ -102,7 +102,7 @@
 - type: entity
   parent: ClothingOuterWinterCoat
   id: ClothingOuterCyberJacketWhite
-  name: cyberjacket # Floof - M3739 - ChromaClothes
+  name: cyberjacket # Floof - M3739 - #741
   description: a mono coloured jacket, with a short crop.
   components:
   - type: Sprite

--- a/Resources/Prototypes/Floof/Entities/Clothing/OuterClothing/MiscOuterwear.yml
+++ b/Resources/Prototypes/Floof/Entities/Clothing/OuterClothing/MiscOuterwear.yml
@@ -102,7 +102,7 @@
 - type: entity
   parent: ClothingOuterWinterCoat
   id: ClothingOuterCyberJacketWhite
-  name: white cyberjacket
+  name: cyberjacket # Floof - M3739 - ChromaClothes
   description: a mono coloured jacket, with a short crop.
   components:
   - type: Sprite

--- a/Resources/Prototypes/Floof/Entities/Clothing/Uniforms/misc.yml
+++ b/Resources/Prototypes/Floof/Entities/Clothing/Uniforms/misc.yml
@@ -34,7 +34,7 @@
 - type: entity
   parent: ClothingUniformBaseSwitch
   id: ClothingUniformLoinClothWhite
-  name: white loin-cloth
+  name: loin-cloth # Floof - M3739 - ChromaClothes
   description: A piece of cloth wrapped around the waist.
   components:
   - type: Sprite

--- a/Resources/Prototypes/Floof/Entities/Clothing/Uniforms/misc.yml
+++ b/Resources/Prototypes/Floof/Entities/Clothing/Uniforms/misc.yml
@@ -34,7 +34,7 @@
 - type: entity
   parent: ClothingUniformBaseSwitch
   id: ClothingUniformLoinClothWhite
-  name: loin-cloth # Floof - M3739 - ChromaClothes
+  name: loin-cloth # Floof - M3739 - #741
   description: A piece of cloth wrapped around the waist.
   components:
   - type: Sprite

--- a/Resources/Prototypes/Floof/Loadouts/Generic/outerClothing.yml
+++ b/Resources/Prototypes/Floof/Loadouts/Generic/outerClothing.yml
@@ -82,6 +82,7 @@
   id: LoadoutClothingOuterCyberJacketWhite
   category: Outer
   cost: 0
+  customColorTint: true # Floof - M3739 - ChromaClothes
   items:
     - ClothingOuterCyberJacketWhite
   requirements:

--- a/Resources/Prototypes/Floof/Loadouts/Generic/outerClothing.yml
+++ b/Resources/Prototypes/Floof/Loadouts/Generic/outerClothing.yml
@@ -82,7 +82,7 @@
   id: LoadoutClothingOuterCyberJacketWhite
   category: Outer
   cost: 0
-  customColorTint: true # Floof - M3739 - ChromaClothes
+  customColorTint: true # Floof - M3739 - #741
   items:
     - ClothingOuterCyberJacketWhite
   requirements:

--- a/Resources/Prototypes/Floof/Loadouts/Generic/uniform.yml
+++ b/Resources/Prototypes/Floof/Loadouts/Generic/uniform.yml
@@ -133,6 +133,7 @@
   id: LoadoutClothingUniformLoinClothWhite
   category: Uniform
   cost: 0
+  customColorTint: true # Floof - M3739 - ChromaClothes
   exclusive: true
   items:
     - ClothingUniformLoinClothWhite

--- a/Resources/Prototypes/Floof/Loadouts/Generic/uniform.yml
+++ b/Resources/Prototypes/Floof/Loadouts/Generic/uniform.yml
@@ -133,7 +133,7 @@
   id: LoadoutClothingUniformLoinClothWhite
   category: Uniform
   cost: 0
-  customColorTint: true # Floof - M3739 - ChromaClothes
+  customColorTint: true # Floof - M3739 - #741
   exclusive: true
   items:
     - ClothingUniformLoinClothWhite


### PR DESCRIPTION
<!--
This is a semi-strict format, you can add/remove sections as needed but the order/format should be kept the same
Remove these comments before submitting
-->

# Description

<!--
Explain this PR in as much detail as applicable

Some example prompts to consider:
How might this affect the game? The codebase?
What might be some alternatives to this?
How/Who does this benefit/hurt [the game/codebase]?
-->

Title says all. They are already white, so why not make it colorable?

---

# TODO

<!--
A list of everything you have to do before this PR is "complete"
You probably won't have to complete everything before merging but it's good to leave future references
-->

- [x] Seems superfluous.
- [x] What do you want me to say?
- [x] I don't know, bababoey?

---

<!--
This is default collapsed, readers click to expand it and see all your media
The PR media section can get very large at times, so this is a good way to keep it clean
The title is written using HTML tags
The title must be within the <summary> tags or you won't see it
-->

<details><summary><h1>Media</h1></summary>
<p>

![image](https://github.com/user-attachments/assets/6ad9045c-83ed-4941-a32b-e7d4972e4acf)
![image](https://github.com/user-attachments/assets/c8edff50-e4da-495d-8835-d07524d2f3ee)
![image](https://github.com/user-attachments/assets/8753dd4a-eef5-4bb7-8554-25004415fd1d)


</p>
</details>

---

# Changelog

<!--
You can add an author after the `:cl:` to change the name that appears in the changelog (ex: `:cl: Death`)
Leaving it blank will default to your GitHub display name
This includes all available types for the changelog
-->

:cl: M3739
- tweak: The white cyberjacket and loincloth are now colorable.
