### PR TITLE
Fix Melee Weapons Attack Rates

### DIFF
--- a/Resources/Prototypes/Floof/Entities/Objects/Weapons/Melee.yml
+++ b/Resources/Prototypes/Floof/Entities/Objects/Weapons/Melee.yml
@@ -11,7 +11,7 @@
     sprite: Floof/Objects/Weapons/Melee/brassknuckles.rsi
   - type: MeleeWeapon
     autoAttack: true
-    attackRate: 2 # ~12 dps
+    attackRate: 0.5 # ~12 dps
     damage:
       types:
        Blunt: 6
@@ -44,7 +44,7 @@
   description: Ever wanted to punch just a little harder?
   components:
   - type: MeleeWeapon
-    attackRate: 1.6 # ~9.6 dps
+    attackRate: 0.625 # ~9.6 dps
   - type: Construction
     graph: GraphWeaponBrassKnucklesImprovised
     node: WeaponBrassKnucklesImprovised

--- a/Resources/Prototypes/Floof/Entities/Objects/Weapons/borgmodules.yml
+++ b/Resources/Prototypes/Floof/Entities/Objects/Weapons/borgmodules.yml
@@ -5,7 +5,7 @@
   categories: [ HideSpawnMenu ]
   components:
   - type: Gun
-    fireRate: 0.5
+    fireRate: 2 # once in two seconds, NOT attacks per minute!
     selectedMode: SemiAuto
     minAngle: 1
     maxAngle: 3

--- a/Resources/Prototypes/Floof/Entities/Objects/Weapons/borgmodules.yml
+++ b/Resources/Prototypes/Floof/Entities/Objects/Weapons/borgmodules.yml
@@ -5,7 +5,7 @@
   categories: [ HideSpawnMenu ]
   components:
   - type: Gun
-    fireRate: 2 # once in two seconds, NOT attacks per minute!
+    fireRate: 0.5
     selectedMode: SemiAuto
     minAngle: 1
     maxAngle: 3


### PR DESCRIPTION
# Description
Upstream fucked 'em up by inverting the attackRate field (rates are canonically expressed in <unit>/second, but they decided to change it to just seconds) of melee weapons, and melee weapons only it seems (guns are not affected afaik). Seems like some weapons weren't updated.

# TODO
- [X] Brass knuckles
- [ ] Knife (unknown which, waiting on the bug reporter)
- [ ] ???

# Changelog
:cl:
- fix: Fixed the attack rates of some melee weapons
