### PR TITLE
Remove Errant `DoafterEvent.cs` in Favour of `DoAfterEvent.cs`

### DIFF
--- a/Content.Shared/Execution/DoafterEvent.cs
+++ b/Content.Shared/Execution/DoafterEvent.cs
@@ -1,9 +1,0 @@
-using Content.Shared.DoAfter;
-using Robust.Shared.Serialization;
-
-namespace Content.Shared.Execution;
-
-[Serializable, NetSerializable]
-public sealed partial class ExecutionDoAfterEvent : SimpleDoAfterEvent
-{
-}


### PR DESCRIPTION
Quick-dirty PR due to a mistake that fouled up builds that me and @Lokilotus discovered