### PR TITLE
AutoDoc Now Has `AntiRottingContainer`

### DIFF
--- a/Resources/Prototypes/_Shitmed/Entities/Structures/Machines/autodoc.yml
+++ b/Resources/Prototypes/_Shitmed/Entities/Structures/Machines/autodoc.yml
@@ -82,6 +82,7 @@
     speedModifier: 0.5 # on par with a surgeon using normal tools
   - type: GuideHelp
     guides: [ Autodoc ]
+  - type: AntiRottingContainer
 
 - type: entity
   parent: Autodoc


### PR DESCRIPTION
Avoids having organs spoil inside the AutoDoc.

# Changelog
:cl: Carlen White
- tweak: AutoDoc's storage is now refrigerated, preventing organs rotting
