### PR TITLE
Add Pickaxes to Salvage Lockers and Missing Salvage Loadouts

### DIFF
--- a/Resources/Locale/en-US/Floof/loadouts/jobs/cargo.ftl
+++ b/Resources/Locale/en-US/Floof/loadouts/jobs/cargo.ftl
@@ -1,0 +1,1 @@
+loadout-name-LoadoutSalvageBeltUtilityFilled = utility belt (filled)

--- a/Resources/Prototypes/Catalog/Fills/Lockers/cargo.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/cargo.yml
@@ -12,6 +12,7 @@
       - id: SurvivalKnife
       - id: HandheldGPSBasic
       - id: RadioHandheld
+      - id: Pickaxe # Floof - Add pickaxe to salvage lockers
       - id: SeismicCharge
         amount: 2
       - id: ClothingShoesBootsWinterMiner #Delta V: Add departmental winter boots

--- a/Resources/Prototypes/CharacterItemGroups/Jobs/Logistics/salvageSpecialist.yml
+++ b/Resources/Prototypes/CharacterItemGroups/Jobs/Logistics/salvageSpecialist.yml
@@ -20,16 +20,34 @@
       id: LoadoutSalvageBeltSalvageWebbing
     - type: loadout
       id: LoadoutSalvageBeltMilitaryWebbing
+# Floof section - Add missing salvage loadouts
+    - type: loadout
+      id: LoadoutSalvageBeltUtility
+    - type: loadout
+      id: LoadoutSalvageBeltUtilityFilled
+# Floof section end
 
 #- type: characterItemGroup
 #  id: LoadoutSalvageSpecialistEars
 #  maxItems: 1
 #  items:
-#
-#- type: characterItemGroup
-#  id: LoadoutSalvageSpecialistEquipment
-#  maxItems: 1
-#  items:
+
+- type: characterItemGroup
+  id: LoadoutSalvageSpecialistEquipment
+  maxItems: 3 # Floof - Add missing salvage loadouts - increased from 1
+  items:
+# Floof section - Add missing salvage loadouts
+    - type: loadout
+      id: LoadoutSalvageEquipmentHandheldGPSBasic
+    - type: loadout
+      id: LoadoutSalvageEquipmentRadioHandheld
+    - type: loadout
+      id: LoadoutSalvageEquipmentPickaxe
+    - type: loadout
+      id: LoadoutSalvageEquipmentOreBag
+    - type: loadout
+      id: LoadoutSalvageEquipmentFlare
+# Floof section end
 
 - type: characterItemGroup
   id: LoadoutSalvageSpecialistWeapons
@@ -86,12 +104,16 @@
       id: LoadoutCargoNeckGoliathCloak
     - type: loadout
       id: LoadoutSalvageNeckCloakMiner
+    - type: loadout # Floof - Add missing salvage loadouts
+      id: LoadoutSalvageNeckSalvager
 
-#- type: characterItemGroup
-#  id: LoadoutSalvageSpecialistMask
-#  maxItems: 1
-#  items:
-#
+- type: characterItemGroup
+  id: LoadoutSalvageSpecialistMask
+  maxItems: 1
+  items:
+    - type: loadout # Floof - Add missing salvage loadouts
+      id: LoadoutSalvageMaskGas
+
 - type: characterItemGroup
   id: LoadoutSalvageSpecialistOuter
   maxItems: 1
@@ -99,11 +121,13 @@
     - type: loadout
       id: LoadoutCargoOuterWinterMiner
 
-#- type: characterItemGroup
-#  id: LoadoutSalvageSpecialistShoes
-#  maxItems: 1
-#  items:
-#
+- type: characterItemGroup
+  id: LoadoutSalvageSpecialistShoes
+  maxItems: 1
+  items:
+    - type: loadout # Floof - Add missing salvage loadouts
+      id: LoadoutSalvageShoesBoots
+
 - type: characterItemGroup
   id: LoadoutSalvageSpecialistUniforms
   maxItems: 1

--- a/Resources/Prototypes/Floof/Loadouts/Jobs/Logistics/salvageSpecialist.yml
+++ b/Resources/Prototypes/Floof/Loadouts/Jobs/Logistics/salvageSpecialist.yml
@@ -1,0 +1,166 @@
+# Salvage Specialist
+# Backpacks
+
+# Belt
+- type: loadout
+  id: LoadoutSalvageBeltUtility
+  category: JobsLogisticsSalvageSpecialist
+  cost: 0
+  exclusive: true
+  items:
+    - ClothingBeltUtility
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: LoadoutSalvageSpecialistBelt
+    - !type:CharacterJobRequirement
+      jobs:
+        - SalvageSpecialist
+
+- type: loadout
+  id: LoadoutSalvageBeltUtilityFilled
+  category: JobsLogisticsSalvageSpecialist
+  cost: 0
+  exclusive: true
+  items:
+    - ClothingBeltUtilityFilled
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: LoadoutSalvageSpecialistBelt
+    - !type:CharacterJobRequirement
+      jobs:
+        - SalvageSpecialist
+
+# Ears
+
+# Equipment
+- type: loadout
+  id: LoadoutSalvageEquipmentHandheldGPSBasic
+  category: JobsLogisticsSalvageSpecialist
+  cost: 0
+  exclusive: false
+  items:
+    - HandheldGPSBasic
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: LoadoutSalvageSpecialistEquipment
+    - !type:CharacterJobRequirement
+      jobs:
+        - SalvageSpecialist
+
+- type: loadout
+  id: LoadoutSalvageEquipmentRadioHandheld
+  category: JobsLogisticsSalvageSpecialist
+  cost: 0
+  exclusive: false
+  items:
+    - RadioHandheld
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: LoadoutSalvageSpecialistEquipment
+    - !type:CharacterJobRequirement
+      jobs:
+        - SalvageSpecialist
+
+- type: loadout
+  id: LoadoutSalvageEquipmentPickaxe
+  category: JobsLogisticsSalvageSpecialist
+  cost: 0
+  exclusive: false
+  items:
+    - Pickaxe
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: LoadoutSalvageSpecialistEquipment
+    - !type:CharacterJobRequirement
+      jobs:
+        - SalvageSpecialist
+
+- type: loadout
+  id: LoadoutSalvageEquipmentOreBag
+  category: JobsLogisticsSalvageSpecialist
+  cost: 0
+  exclusive: false
+  items:
+    - OreBag
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: LoadoutSalvageSpecialistEquipment
+    - !type:CharacterJobRequirement
+      jobs:
+        - SalvageSpecialist
+
+- type: loadout
+  id: LoadoutSalvageEquipmentFlare
+  category: JobsLogisticsSalvageSpecialist
+  cost: 0
+  exclusive: false
+  items:
+    - Flare
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: LoadoutSalvageSpecialistEquipment
+    - !type:CharacterJobRequirement
+      jobs:
+        - SalvageSpecialist
+
+# Eyes
+
+# Gloves
+
+# Head
+
+# Id
+
+# Neck
+- type: loadout
+  id: LoadoutSalvageNeckSalvager
+  category: JobsLogisticsSalvageSpecialist
+  cost: 0
+  exclusive: true
+  items:
+    - ClothingNeckSalvager
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: LoadoutSalvageSpecialistNeck
+    - !type:CharacterJobRequirement
+      jobs:
+        - SalvageSpecialist
+
+# Mask
+- type: loadout
+  id: LoadoutSalvageMaskGas
+  category: JobsLogisticsSalvageSpecialist
+  cost: 0
+  exclusive: true
+  items:
+    - ClothingMaskGasExplorer
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: LoadoutSalvageSpecialistMask
+    - !type:CharacterJobRequirement
+      jobs:
+        - SalvageSpecialist
+
+# Outer
+
+# Shoes
+- type: loadout
+  id: LoadoutSalvageShoesBoots
+  category: JobsLogisticsSalvageSpecialist
+  cost: 0
+  exclusive: true
+  items:
+    - ClothingShoesBootsSalvage
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: LoadoutSalvageSpecialistShoes
+    - !type:CharacterJobRequirement
+      jobs:
+        - SalvageSpecialist
+    - !type:CharacterSpeciesRequirement
+      inverted: true
+      species:
+        - Diona
+        - Harpy
+
+# Uniforms


### PR DESCRIPTION
# Description

Adds pickaxes to the salvage lockers, to ensure salvage specialists have access to pickaxes every round. Without this, they are unable to mine until epistemics researches drills.

Adds the following loadout options to salvage specialists:
- Utility belt (filled and unfilled)
- Equipment, any three of: GPS, radio, pickaxe, ore bag, and flare
- Explorer's gas mas, salvager's cloak, and winter boots

---

<details><summary><h1>Media</h1></summary>
<p>

![pickaxe-in-locker](https://github.com/user-attachments/assets/a069cebd-87fb-453d-ae04-6521c2ed89d5)
![salvage-loadouts](https://github.com/user-attachments/assets/cfc55c51-e5da-4296-82c0-d4b0b00c3cd4)

</p>
</details>

---

# Changelog

:cl:
- add: Salvage lockers now have pickaxes.
- add: Salvage specialists have 10 new loadout options.
