### PR TITLE
Add `RawMaterial` Tag to Diamond

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Materials/materials.yml
+++ b/Resources/Prototypes/Entities/Objects/Materials/materials.yml
@@ -381,6 +381,7 @@
   - type: Tag  #Floof
     tags:
     - Diamond
+    - RawMaterial
 
 - type: entity
   parent: MaterialDiamond


### PR DESCRIPTION
Should fix being unable to load Diamond into the Lathes (and preventing making Diamond Tipped Drills)

![image](https://github.com/user-attachments/assets/cd9f34c6-0ee1-4515-a802-0610bd613a29)

# Changelog

:cl: Carlen White
- fix: Refined Diamond can now be loaded into lathes, allowing you to finally make diamond tipped drills