### PR TITLE
Remove Duplicate CJ Job From the Command Department

### DIFF
--- a/Resources/Prototypes/Roles/Jobs/departments.yml
+++ b/Resources/Prototypes/Roles/Jobs/departments.yml
@@ -46,7 +46,6 @@
   - ChiefMedicalOfficer
   - HeadOfPersonnel
   - HeadOfSecurity
-  - ChiefJustice # Floof - M3739 - This should make it clear now.
   - ResearchDirector
   - Quartermaster
   - ChiefJustice # DeltaV - chief justice is in command staff


### PR DESCRIPTION
# Description
Title

# Changelog
:cl:
- fix: Removed the duplicate CJ job from the command department.