### PR TITLE
Make the LawDrobe Require Prosecutor Access

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Machines/vending_machines.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/vending_machines.yml
@@ -1728,7 +1728,7 @@
     - state: panel
       map: ["enum.WiresVisualLayers.MaintenancePanel"]
   - type: AccessReader
-    access: [["Lawyer"]]
+    access: [["Justice"]]
 
 - type: entity
   parent: VendingMachine


### PR DESCRIPTION
# Description
Title. I don't want to figure out which way it is to make it justice OR lawyer, so I just replaced the lawyer access requirement with a justice one.

# Changelog
:cl:
- fix: LawDrobe now requires justice access, allowing both attorneys and prosecutors to use it.