### PR TITLE
Fix Untargetted Damage Dealing Extreme Damage to Limbs

### DIFF
--- a/Content.Shared/_Shitmed/Body/Systems/SharedBodySystem.Targeting.cs
+++ b/Content.Shared/_Shitmed/Body/Systems/SharedBodySystem.Targeting.cs
@@ -153,7 +153,7 @@ public partial class SharedBodySystem
             if (targetPart == null)
                 return;
 
-            if (!TryChangePartDamage(ent, args.Damage, args.IgnoreResistances, args.CanSever, args.CanEvade, args.PartMultiplier, targetPart.Value, out var evaded)
+            if (!TryChangePartDamage(ent, damage, args.IgnoreResistances, args.CanSever, args.CanEvade, args.PartMultiplier, targetPart.Value, out var evaded)
                 && args.CanEvade && evaded)
             {
                 if (_net.IsServer)

--- a/Content.Shared/_Shitmed/Body/Systems/SharedBodySystem.Targeting.cs
+++ b/Content.Shared/_Shitmed/Body/Systems/SharedBodySystem.Targeting.cs
@@ -154,7 +154,7 @@ public partial class SharedBodySystem
                 return;
 
             // Floofstation - changed to use the local damage instead of the original args.Damage
-            if (!TryChangePartDamage(ent, damage, args.IgnoreResistances, args.CanSever, args.CanEvade, args.PartMultiplier, targetPart.Value, out var evaded)
+            if (!TryChangePartDamage(ent, damage!, args.IgnoreResistances, args.CanSever, args.CanEvade, args.PartMultiplier, targetPart.Value, out var evaded)
                 && args.CanEvade && evaded)
             {
                 if (_net.IsServer)

--- a/Content.Shared/_Shitmed/Body/Systems/SharedBodySystem.Targeting.cs
+++ b/Content.Shared/_Shitmed/Body/Systems/SharedBodySystem.Targeting.cs
@@ -153,6 +153,7 @@ public partial class SharedBodySystem
             if (targetPart == null)
                 return;
 
+            // Floofstation - changed to use the local damage instead of the original args.Damage
             if (!TryChangePartDamage(ent, damage, args.IgnoreResistances, args.CanSever, args.CanEvade, args.PartMultiplier, targetPart.Value, out var evaded)
                 && args.CanEvade && evaded)
             {


### PR DESCRIPTION
# Description
The system used to ignore the local variable `damage` that was divided by 10 and pass the raw, full damage to all limbs.

## This will need testing as the change was done in webedit, do not merge until tested

# Changelog
:cl:
- fix: Damage that targets all limbs (spacing, heat, immovable rods) should now deal 10 times less damage to each limb, as intended.