### PR TITLE
Fix Heavy Attack Never Doing Full Damage

### DIFF
--- a/Content.Shared/Weapons/Melee/SharedMeleeWeaponSystem.cs
+++ b/Content.Shared/Weapons/Melee/SharedMeleeWeaponSystem.cs
@@ -581,7 +581,7 @@ public abstract class SharedMeleeWeaponSystem : EntitySystem
                 return false;
             }
 
-            _stamina.TakeStaminaDamage(user, component.HeavyStaminaCost, stamina, visual: false);
+            //_stamina.TakeStaminaDamage(user, component.HeavyStaminaCost, stamina, visual: false); // Floofstation - moved to end
         }
 
         var userPos = TransformSystem.GetWorldPosition(userXform);
@@ -730,6 +730,9 @@ public abstract class SharedMeleeWeaponSystem : EntitySystem
         {
             DoDamageEffect(targets, user, Transform(targets[0]));
         }
+        
+        if (stamina != null) // Floofstation - moved stamina damage to the end. Previously stamina damage was applying before damage calculations, meaning heavy attacks never did full damage (due to stamina contests)
+            _stamina.TakeStaminaDamage(user, component.HeavyStaminaCost, stamina, visual: false);     
 
         return true;
     }


### PR DESCRIPTION

<!--
This is a semi-strict format, you can add/remove sections as needed but the order/format should be kept the same
Remove these comments before submitting
-->

# Description

<!--
Explain this PR in as much detail as applicable

Some example prompts to consider:
How might this affect the game? The codebase?
What might be some alternatives to this?
How/Who does this benefit/hurt [the game/codebase]?
-->

For heavy attacks, stamina damage was applying to the weapon user before damage calculations - with stamina contests, this means power attacks never did full damage. This is an upstream... bug? design decision? This changes that. 

---

# TODO

<!--
A list of everything you have to do before this PR is "complete"
You probably won't have to complete everything before merging but it's good to leave future references
-->

- [x] Move TakeStaminaDamage to the end of DoHeavyAttack

---

<!--
This is default collapsed, readers click to expand it and see all your media
The PR media section can get very large at times, so this is a good way to keep it clean
The title is written using HTML tags
The title must be within the <summary> tags or you won't see it
-->

<details><summary><h1>Media</h1></summary>
<p>



</p>
</details>

---

# Changelog

<!--
You can add an author after the `:cl:` to change the name that appears in the changelog (ex: `:cl: Death`)
Leaving it blank will default to your GitHub display name
This includes all available types for the changelog
-->

:cl:
- fix: Fixed heavy attack damage at full or mostly-full stamina
