### PR TITLE
Mail and Paramedic Door Fixes

### DIFF
--- a/Resources/Prototypes/DeltaV/Entities/Structures/Doors/Windoors/windoor.yml
+++ b/Resources/Prototypes/DeltaV/Entities/Structures/Doors/Windoors/windoor.yml
@@ -3,24 +3,27 @@
   id: WindoorMailLocked
   suffix: Mail, Locked
   components:
-  - type: AccessReader
-    access: [["Mail"]]
+  - type: ContainerFill # Floofstation - hopefully this fix makes it upstream eventually
+    containers:
+      board: [ DoorElectronicsMail ]
 
 - type: entity
   parent: WindoorSecure
   id: WindoorSecureMailLocked
   suffix: Mail, Locked
   components:
-  - type: AccessReader
-    access: [["Mail"]]
+  - type: ContainerFill # Floofstation - hopefully this fix makes it upstream eventually
+    containers:
+      board: [ DoorElectronicsMail ]
 
 - type: entity
   parent: WindoorSecure
   id: WindoorSecureParamedicLocked
   suffix: Paramedic, Locked
   components:
-  - type: AccessReader
-    access: [["Paramedic"]]
+  - type: ContainerFill # Floofstation - hopefully this fix makes it upstream eventually
+    containers:
+      board: [ DoorElectronicsParamedic ]
 
 - type: entity
   parent: WindoorSecure

--- a/Resources/Prototypes/Entities/Objects/Devices/Electronics/door_access.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/Electronics/door_access.yml
@@ -260,6 +260,14 @@
   components:
   - type: AccessReader
     access: [["Medical"]]
+    
+- type: entity # Floofstation - this should be an upstream fix so I'm not putting this in Floof namespace, but EE scares me.
+  parent: DoorElectronics
+  id: DoorElectronicsParamedic
+  suffix: Paramedic, Locked
+  components:
+  - type: AccessReader
+    access: [["Paramedic"]]
 
 # Syndicate
 - type: entity

--- a/Resources/Prototypes/Entities/Objects/Tools/access_configurator.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/access_configurator.yml
@@ -43,6 +43,7 @@
       - Kitchen
       - Lawyer
       - Library #Delta V: Add Library Access
+      - Mail # Floofstation - hopefully this makes it upstream eventually
       - Maintenance
       - Medical
       - Mime #Delta V: Add Mime Access
@@ -124,6 +125,7 @@
     - Kitchen
     - Lawyer
     - Library #Delta V: Add Library Access
+    - Mail # Floofstation - hopefully this makes it upstream eventually
     - Maintenance
     - Medical
     - Mime #Delta V: Add Mime Access

--- a/Resources/Prototypes/Entities/Structures/Doors/Airlocks/access.yml
+++ b/Resources/Prototypes/Entities/Structures/Doors/Airlocks/access.yml
@@ -222,8 +222,9 @@
   id: AirlockParamedicLocked
   suffix: Paramedic, Locked
   components:
-  - type: AccessReader
-    access: [["Paramedic"]]
+  - type: ContainerFill # Floofstation - hopefully this fix makes it upstream eventually
+    containers:
+      board: [ DoorElectronicsParamedic ]
 
 - type: entity
   parent: AirlockVirology
@@ -615,8 +616,9 @@
   id: AirlockParamedicGlassLocked
   suffix: Paramedic, Locked
   components:
-  - type: AccessReader
-    access: [["Paramedic"]]
+  - type: ContainerFill # Floofstation - hopefully this fix makes it upstream eventually
+    containers:
+      board: [ DoorElectronicsParamedic ]
 
 - type: entity
   parent: AirlockVirologyGlass


### PR DESCRIPTION
<!--
This is a semi-strict format, you can add/remove sections as needed but the order/format should be kept the same
Remove these comments before submitting
-->

# Description

<!--
Explain this PR in as much detail as applicable

Some example prompts to consider:
How might this affect the game? The codebase?
What might be some alternatives to this?
How/Who does this benefit/hurt [the game/codebase]?
-->

Adds paramedic door electronics, fixes access for paramedic doors and windoors, fixes mail windoors, and adds mail access to the access configurators.

---

# TODO

<!--
A list of everything you have to do before this PR is "complete"
You probably won't have to complete everything before merging but it's good to leave future references
-->

- [x] Fix mail windoors
- [x] Realize paramedic doors are all broken and fix that
- [x] Get upset mail isn't in the access configurator and fix that too

---

<!--
This is default collapsed, readers click to expand it and see all your media
The PR media section can get very large at times, so this is a good way to keep it clean
The title is written using HTML tags
The title must be within the <summary> tags or you won't see it
-->

<details><summary><h1>Media</h1></summary>
<p>


</p>
</details>

---

# Changelog

<!--
You can add an author after the `:cl:` to change the name that appears in the changelog (ex: `:cl: Death`)
Leaving it blank will default to your GitHub display name
This includes all available types for the changelog
-->

:cl:
- fix: Paramedic and courier doors and windoors should now have the proper access instead of AA
