### PR TITLE
Senior Physicians Get Paramedic and External Access

### DIFF
--- a/Resources/Prototypes/Roles/Jobs/Medical/senior_physician.yml
+++ b/Resources/Prototypes/Roles/Jobs/Medical/senior_physician.yml
@@ -15,6 +15,10 @@
   - Medical
   - Maintenance
   - Chemistry
+# Floof section - Senior physicians get paramedic and external access  
+  - Paramedic
+  - External
+# Floof section end
   special:
   - !type:AddComponentSpecial
     components:


### PR DESCRIPTION
# Description

Since medical doctors get paramedic access on skeleton crews, senior physicians should get at least that. It was decided to grant them both paramedic and external access at a base level, and no access to the psychologist.

---

:cl:
- add: Senior physicians have paramedic access.
