### PR TITLE
Fix Wizards Grimoire

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Magic/books.yml
+++ b/Resources/Prototypes/Entities/Objects/Magic/books.yml
@@ -31,7 +31,7 @@
   id: WizardsGrimoire
   name: wizards grimoire
   suffix: Wizard
-  parent: BaseItem
+  parent: [ BaseItem, StorePresetSpellbook ] # Floofstation - added StorePresetSpellbook to fix buying spells
   components:
     - type: Sprite
       sprite: Objects/Misc/books.rsi


### PR DESCRIPTION
<!--
This is a semi-strict format, you can add/remove sections as needed but the order/format should be kept the same
Remove these comments before submitting
-->

# Description

<!--
Explain this PR in as much detail as applicable

Some example prompts to consider:
How might this affect the game? The codebase?
What might be some alternatives to this?
How/Who does this benefit/hurt [the game/codebase]?
-->

The Wizard's Grimoire was made non-functional during the recent upstream merge. As far as I can tell, it is still non-functional upstream. An admin has requested this be fixed, so this fixes it. 

The store preset was removed, likely due to changes to how it works, without the new(?) way of applying the presets getting put into place.

---

# TODO

<!--
A list of everything you have to do before this PR is "complete"
You probably won't have to complete everything before merging but it's good to leave future references
-->

- [x] Reapply the store preset to the wizard's grimoire

---

<!--
This is default collapsed, readers click to expand it and see all your media
The PR media section can get very large at times, so this is a good way to keep it clean
The title is written using HTML tags
The title must be within the <summary> tags or you won't see it
-->

<details><summary><h1>Media</h1></summary>
<p>

![image](https://github.com/user-attachments/assets/a3f53398-470b-4260-be23-0fdb018df558)

</p>
</details>

---

# Changelog

<!--
You can add an author after the `:cl:` to change the name that appears in the changelog (ex: `:cl: Death`)
Leaving it blank will default to your GitHub display name
This includes all available types for the changelog
-->

no CL - item intended for admin use
