### PR TITLE
Nonclothing Loadouts Are Nonexclusive

### DIFF
--- a/Resources/Prototypes/Floof/Loadouts/Jobs/Security/uncategorized.yml
+++ b/Resources/Prototypes/Floof/Loadouts/Jobs/Security/uncategorized.yml
@@ -4,7 +4,6 @@
   id: LoadoutMagazineSpecialRubber
   category: JobsSecurityAUncategorized
   cost: 2
-  exclusive: true
   requirements:
     - !type:CharacterDepartmentTimeRequirement
       department: Security
@@ -21,7 +20,6 @@
   id: LoadoutSpeedLoaderSpecialRubberSpare
   category: JobsSecurityAUncategorized
   cost: 4
-  exclusive: true
   requirements:
     - !type:CharacterItemGroupRequirement
       group: LoadoutSecurityEquipment
@@ -35,7 +33,6 @@
   id: LoadoutSpeedLoaderSpecial
   category: JobsSecurityAUncategorized
   cost: 2
-  exclusive: true
   requirements:
     - !type:CharacterDepartmentTimeRequirement
       department: Security
@@ -52,7 +49,6 @@
   id: LoadoutSpeedLoaderSpecialSpare
   category: JobsSecurityAUncategorized
   cost: 4
-  exclusive: true
   requirements:
     - !type:CharacterDepartmentTimeRequirement
       department: Security

--- a/Resources/Prototypes/Floof/Loadouts/Jobs/Service/bartender.yml
+++ b/Resources/Prototypes/Floof/Loadouts/Jobs/Service/bartender.yml
@@ -111,7 +111,6 @@
   id: LoadoutServiceBartenderArgentiNonlethal
   category: JobsServiceBartender
   cost: 0
-  exclusive: true
   requirements:
   - !type:CharacterItemGroupRequirement
     group: LoadoutBartenderWeapon
@@ -125,7 +124,6 @@
   id: LoadoutServiceBartenderRepeaterNonlethal
   category: JobsServiceBartender
   cost: 0
-  exclusive: true
   requirements:
   - !type:CharacterItemGroupRequirement
     group: LoadoutBartenderWeapon
@@ -141,7 +139,6 @@
   id: LoadoutServiceBartenderBrassKnuckles
   category: JobsServiceBartender
   cost: 0
-  exclusive: true
   requirements:
   - !type:CharacterItemGroupRequirement
     group: LoadoutBartenderWeapon

--- a/Resources/Prototypes/Floof/Loadouts/Jobs/Service/janitor.yml
+++ b/Resources/Prototypes/Floof/Loadouts/Jobs/Service/janitor.yml
@@ -21,7 +21,6 @@
   id: LoadoutJanitorEquipmentMopItem
   category: JobsServiceJanitor
   cost: 0
-  exclusive: true
   items:
     - MopItem
   requirements:
@@ -35,7 +34,6 @@
   id: LoadoutJanitorEquipmentBoxMousetrap
   category: JobsServiceJanitor
   cost: 0
-  exclusive: true
   items:
     - BoxMousetrap
   requirements:
@@ -49,7 +47,6 @@
   id: LoadoutJanitorEquipmentWetFloorSign
   category: JobsServiceJanitor
   cost: 0
-  exclusive: true
   items:
     - WetFloorSign
   requirements:
@@ -63,7 +60,6 @@
   id: LoadoutJanitorEquipmentTrashBag
   category: JobsServiceJanitor
   cost: 0
-  exclusive: true
   items:
     - TrashBag
   requirements:
@@ -77,7 +73,6 @@
   id: LoadoutJanitorEquipmentLightReplacer
   category: JobsServiceJanitor
   cost: 0
-  exclusive: true
   items:
     - LightReplacer
   requirements:
@@ -91,7 +86,6 @@
   id: LoadoutJanitorEquipmentBoxLightMixed
   category: JobsServiceJanitor
   cost: 0
-  exclusive: true
   items:
     - BoxLightMixed
   requirements:
@@ -105,7 +99,6 @@
   id: LoadoutJanitorEquipmentHoloprojector
   category: JobsServiceJanitor
   cost: 1
-  exclusive: true
   items:
     - Holoprojector
   requirements:
@@ -119,7 +112,6 @@
   id: LoadoutJanitorEquipmentPlunger
   category: JobsServiceJanitor
   cost: 0
-  exclusive: true
   items:
     - Plunger
   requirements:

--- a/Resources/Prototypes/Loadouts/Jobs/Command/uncategorized.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Command/uncategorized.yml
@@ -10,7 +10,7 @@
   id: LoadoutCommandTelescopicBaton
   category: JobsCommandAUncategorized
   cost: 3
-  exclusive: true
+#  exclusive: true # Floof - Nonclothing loadouts are nonexclusive
   canBeHeirloom: true
   requirements:
     - !type:CharacterItemGroupRequirement
@@ -25,7 +25,7 @@
   id: LoadoutCommandDisabler
   category: JobsCommandAUncategorized
   cost: 2
-  exclusive: true
+#  exclusive: true # Floof - Nonclothing loadouts are nonexclusive
   requirements:
     - !type:CharacterItemGroupRequirement
       group: LoadoutCommandSelfDefense
@@ -39,7 +39,7 @@
   id: LoadoutCommandStunBaton
   category: JobsCommandAUncategorized
   cost: 1
-  exclusive: true
+#  exclusive: true # Floof - Nonclothing loadouts are nonexclusive
   requirements:
     - !type:CharacterItemGroupRequirement
       group: LoadoutCommandSelfDefense
@@ -53,7 +53,7 @@
   id: LoadoutCommandFlash
   category: JobsCommandAUncategorized
   cost: 0
-  exclusive: true
+#  exclusive: true # Floof - Nonclothing loadouts are nonexclusive
   requirements:
     - !type:CharacterItemGroupRequirement
       group: LoadoutCommandSelfDefense

--- a/Resources/Prototypes/Loadouts/Jobs/Epistemics/chaplain.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Epistemics/chaplain.yml
@@ -10,7 +10,7 @@
   id: LoadoutChaplainBible
   category: JobsEpistemicsChaplain
   cost: 0
-  exclusive: true
+#  exclusive: true # Floof - Nonclothing loadouts are nonexclusive
   requirements:
     - !type:CharacterItemGroupRequirement
       group: LoadoutChaplainEquipment
@@ -24,7 +24,7 @@
   id: LoadoutChaplainStamp
   category: JobsEpistemicsChaplain
   cost: 0
-  exclusive: true
+#  exclusive: true # Floof - Nonclothing loadouts are nonexclusive
   requirements:
     - !type:CharacterItemGroupRequirement
       group: LoadoutChaplainEquipment

--- a/Resources/Prototypes/Loadouts/Jobs/Security/detective.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Security/detective.yml
@@ -53,7 +53,7 @@
   id: LoadoutDetectiveEquipmentScanner # Floof - M3739 - #690 - Spare equipment in case the station's equipment is missing.
   category: JobsSecurityDetective
   cost: 0
-  exclusive: true
+#  exclusive: true # Floof - Nonclothing loadouts are nonexclusive
   requirements:
     - !type:CharacterItemGroupRequirement
       group: LoadoutDetectiveEquipment

--- a/Resources/Prototypes/Loadouts/Jobs/Security/uncategorized.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Security/uncategorized.yml
@@ -179,7 +179,7 @@
   id: LoadoutSpeedLoaderMagnum
   category: JobsSecurityAUncategorized
   cost: 2
-  exclusive: true
+#  exclusive: true # Floof - Nonclothing loadouts are nonexclusive
   requirements:
     - !type:CharacterDepartmentTimeRequirement
       department: Security
@@ -196,7 +196,7 @@
   id: LoadoutSpeedLoaderMagnumSpare
   category: JobsSecurityAUncategorized
   cost: 4
-  exclusive: true
+#  exclusive: true # Floof - Nonclothing loadouts are nonexclusive
   requirements:
     - !type:CharacterDepartmentTimeRequirement
       department: Security
@@ -213,7 +213,7 @@
   id: LoadoutSpeedLoaderMagnumRubber
   category: JobsSecurityAUncategorized
   cost: 2
-  exclusive: true
+#  exclusive: true # Floof - Nonclothing loadouts are nonexclusive
   requirements:
     - !type:CharacterItemGroupRequirement
       group: LoadoutSecurityEquipment
@@ -227,7 +227,7 @@
   id: LoadoutSpeedLoaderMagnumRubberSpare
   category: JobsSecurityAUncategorized
   cost: 4
-  exclusive: true
+#  exclusive: true # Floof - Nonclothing loadouts are nonexclusive
   requirements:
     - !type:CharacterItemGroupRequirement
       group: LoadoutSecurityEquipment
@@ -241,7 +241,7 @@
   id: LoadoutMagazineMagnum
   category: JobsSecurityAUncategorized
   cost: 4
-  exclusive: true
+#  exclusive: true # Floof - Nonclothing loadouts are nonexclusive
   requirements:
     - !type:CharacterDepartmentTimeRequirement
       department: Security
@@ -258,7 +258,7 @@
   id: LoadoutMagazineMagnumRubber
   category: JobsSecurityAUncategorized
   cost: 4
-  exclusive: true
+#  exclusive: true # Floof - Nonclothing loadouts are nonexclusive
   requirements:
     - !type:CharacterDepartmentTimeRequirement
       department: Security
@@ -275,7 +275,7 @@
   id: LoadoutMagazineMagnumSpare
   category: JobsSecurityAUncategorized
   cost: 4
-  exclusive: true
+#  exclusive: true # Floof - Nonclothing loadouts are nonexclusive
   requirements:
     - !type:CharacterDepartmentTimeRequirement
       department: Security
@@ -292,7 +292,7 @@
   id: LoadoutMagazineMagnumRubberSpare
   category: JobsSecurityAUncategorized
   cost: 4
-  exclusive: true
+#  exclusive: true # Floof - Nonclothing loadouts are nonexclusive
   requirements:
     - !type:CharacterDepartmentTimeRequirement
       department: Security


### PR DESCRIPTION
# Description

This prevents things like your trash bag or disabler replacing your belt.

---

# Changelog

:cl:
- fix: Loadout equipment, such as trash bags and weapons, will no longer replace items in slots they can fit in.
