### PR TITLE
Fix Space Villain Arcade Machine

### DIFF
--- a/Content.Client/Arcade/UI/SpaceVillainArcadeBoundUserInterface.cs
+++ b/Content.Client/Arcade/UI/SpaceVillainArcadeBoundUserInterface.cs
@@ -25,6 +25,7 @@ public sealed class SpaceVillainArcadeBoundUserInterface : BoundUserInterface
         base.Open();
 
         _menu = this.CreateWindow<SpaceVillainArcadeMenu>();
+        _menu.OnPlayerAction += SendAction; // Floofstation
     }
 
     protected override void ReceiveMessage(BoundUserInterfaceMessage message)


### PR DESCRIPTION
<!--
This is a semi-strict format, you can add/remove sections as needed but the order/format should be kept the same
Remove these comments before submitting
-->

# Description

<!--
Explain this PR in as much detail as applicable

Some example prompts to consider:
How might this affect the game? The codebase?
What might be some alternatives to this?
How/Who does this benefit/hurt [the game/codebase]?
-->

Makes the arcade machine actually do things when you hit buttons.

---

# TODO

<!--
A list of everything you have to do before this PR is "complete"
You probably won't have to complete everything before merging but it's good to leave future references
-->

- [x] Follow Floof's fix for block arcade machine

---

<!--
This is default collapsed, readers click to expand it and see all your media
The PR media section can get very large at times, so this is a good way to keep it clean
The title is written using HTML tags
The title must be within the <summary> tags or you won't see it
-->

<details><summary><h1>Media</h1></summary>
<p>

![image](https://github.com/user-attachments/assets/38961f84-1f67-4ecf-9729-2fec060eb156)

</p>
</details>

---

# Changelog

<!--
You can add an author after the `:cl:` to change the name that appears in the changelog (ex: `:cl: Death`)
Leaving it blank will default to your GitHub display name
This includes all available types for the changelog
-->

:cl:
- fix: The Space Villain arcade machines have had the gum removed from their buttons.
