### PR TITLE
Fix Elite Hardsuit Uplink Prices

### DIFF
--- a/Resources/Prototypes/Catalog/uplink_catalog.yml
+++ b/Resources/Prototypes/Catalog/uplink_catalog.yml
@@ -1500,9 +1500,9 @@
   productEntity: ClothingBackpackDuffelSyndicateEliteHardsuitBundle
   discountCategory: rareDiscounts
   discountDownTo:
-    Telecrystal: 7
+    Telecrystal: 5 # Floof - M3739 - FinancialCrisis - Was originally 7.
   cost:
-    Telecrystal: 1
+    Telecrystal: 11 # Floof - M3739 - FinancialCrisis - Was originally 1. Even Cybersun Industries suffers from "minor inconveniences."
   categories:
   - UplinkWearables
 


### PR DESCRIPTION

![77dmd4](https://github.com/user-attachments/assets/f9b432fd-c4d4-4e9a-8d58-10b784348042)

<!--
This is a semi-strict format, you can add/remove sections as needed but the order/format should be kept the same
Remove these comments before submitting
-->

# Description

<!--
Explain this PR in as much detail as applicable

Some example prompts to consider:
How might this affect the game? The codebase?
What might be some alternatives to this?
How/Who does this benefit/hurt [the game/codebase]?
-->

This PR fixes a '_minor inconvenience'_ with the price of the elite syndicate hardsuit.

It's base price is now 11 TC, with discount to 5 TC. John Syndicate can rest now and his economy can heal.

---

<!--
This is default collapsed, readers click to expand it and see all your media
The PR media section can get very large at times, so this is a good way to keep it clean
The title is written using HTML tags
The title must be within the <summary> tags or you won't see it
-->

<details><summary><h1>Media</h1></summary>
<p>

![image](https://github.com/user-attachments/assets/1d38dc8b-0ce6-49a4-b505-848c774c4fac)

</p>
</details>

---

# Changelog

<!--
You can add an author after the `:cl:` to change the name that appears in the changelog (ex: `:cl: Death`)
Leaving it blank will default to your GitHub display name
This includes all available types for the changelog
-->

:cl: M3739
- fix: The Syndicate has avoided declaring Chapter 11. The Elite Syndicate hardsuit's base price is now 11 telecrystals instead of 1.
