### PR TITLE
Return Sec Watch to Security PDA

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Devices/pda.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/pda.yml
@@ -1004,6 +1004,7 @@
       - NotekeeperCartridge
       - NewsReaderCartridge
       - CrimeAssistCartridge
+      - SecWatchCartridge
       - NanoChatCartridge
 
 - type: entity


### PR DESCRIPTION
PR #718 removed it for some reason

# Changelog


:cl:
- fix: Security PDA has SecWatch back
