### PR TITLE
Allow Senior Roles to Be Selected in ID Computers and Agent IDs

### DIFF
--- a/Resources/Prototypes/StatusIcon/job.yml
+++ b/Resources/Prototypes/StatusIcon/job.yml
@@ -403,7 +403,7 @@
   icon:
     sprite: /Textures/Interface/Misc/job_icons.rsi
     state: SeniorPhysician
-  allowSelection: false
+#  allowSelection: false # Floof - Allow senior role in ID computer and agent ID.
 
 - type: jobIcon
   parent: JobIcon
@@ -411,7 +411,7 @@
   icon:
     sprite: /Textures/Interface/Misc/job_icons.rsi
     state: SeniorOfficer
-  allowSelection: false
+#  allowSelection: false # Floof - Allow senior role in ID computer and agent ID.
 
 - type: jobIcon
   parent: JobIcon
@@ -419,7 +419,7 @@
   icon:
     sprite: /Textures/Interface/Misc/job_icons.rsi
     state: SeniorEngineer
-  allowSelection: false
+#  allowSelection: false # Floof - Allow senior role in ID computer and agent ID.
 
 - type: jobIcon
   parent: JobIcon
@@ -427,7 +427,7 @@
   icon:
     sprite: /Textures/Interface/Misc/job_icons.rsi
     state: SeniorResearcher
-  allowSelection: false
+#  allowSelection: false # Floof - Allow senior role in ID computer and agent ID.
 
 - type: jobIcon
   parent: JobIcon


### PR DESCRIPTION
# Description

Senior job icons can be selected in ID computers and agent IDs. While there is some rationale in not allowing hiring into senior roles, those roles being immune to copying with agent IDs might be undesirable.

---

<details><summary><h1>Media</h1></summary>
<p>

![idCardComputer](https://github.com/user-attachments/assets/740f4785-692d-4e96-a6c9-f7fb6e936949)
![jobIconVisible](https://github.com/user-attachments/assets/63b3706d-1ff1-4768-b389-0096672a0d34)
![agentIdCard](https://github.com/user-attachments/assets/127bf4db-39b2-489c-af2e-3cbdac814fa5)

</p>
</details>

---

# Changelog

:cl:
- add: Senior roles can be selected with ID computers and agent IDs.
