### PR TITLE
Move Senior Physician Loadouts to the Senior Physician Tab

### DIFF
--- a/Resources/Prototypes/Floof/Loadouts/Jobs/Medical/seniorPhysician.yml
+++ b/Resources/Prototypes/Floof/Loadouts/Jobs/Medical/seniorPhysician.yml
@@ -22,7 +22,7 @@
 # Outer
 - type: loadout
   id: LoadoutSeniorPhysicianOuterLabcoat
-  category: JobsMedicalAUncategorized
+  category: JobsMedicalSeniorPhysician
   cost: 0
   exclusive: true
   items:
@@ -37,7 +37,7 @@
 # Shoes
 - type: loadout
   id: LoadoutSeniorPhysicianShoesBlack
-  category: JobsMedicalAUncategorized
+  category: JobsMedicalSeniorPhysician
   cost: 0
   exclusive: true
   items:


### PR DESCRIPTION
# Description

Oops. Not sure how I missed this one.

---

# Changelog

:cl:
- fix: Senior physician loadouts moved to the senior physician loadout tab.
