### PR TITLE
China Lake Bundle Grenade Change

### DIFF
--- a/Resources/Prototypes/Catalog/Fills/Backpacks/duffelbag.yml
+++ b/Resources/Prototypes/Catalog/Fills/Backpacks/duffelbag.yml
@@ -111,9 +111,9 @@
     contents:
       - id: WeaponLauncherChinaLake
       - id: GrenadeBlast
-        amount: 4
-      - id: GrenadeFrag
-        amount: 4
+        amount: 8 # Floof - Only blast to reduce overall damage.
+      # - id: GrenadeFrag
+      #   amount: 4
 
 - type: entity
   parent: ClothingBackpackDuffelSyndicateBundle


### PR DESCRIPTION
# Description

This PR is for modifying the China Lake bundle as it was added back in by upstream.

This time instead of removing it at first, I think it's a good idea to try and see how having 8 blast (instead of 4 blast and 4 frags) works out.

Blast has less intensity than frag (frags are supposed to spawn shrapnel but that is yet to be implemented) and an increased slope.

---

# Changelog

:cl:
- tweak: Removed Frag grenades from China Lake and replaced them with Blast grenades.
