### PR TITLE
ERP Seeking Toggle

### DIFF
--- a/Content.Server/FloofStation/HornyComponent.cs
+++ b/Content.Server/FloofStation/HornyComponent.cs
@@ -1,0 +1,4 @@
+namespace Content.Server.FloofStation.Horny;
+
+[RegisterComponent]
+public sealed partial class HornyComponent : Component;

--- a/Content.Server/FloofStation/HornySystem.cs
+++ b/Content.Server/FloofStation/HornySystem.cs
@@ -1,0 +1,40 @@
+using Content.Shared.Examine;
+using Content.Shared.IdentityManagement;
+using Content.Server.Consent;
+
+namespace Content.Server.FloofStation.Horny;
+
+public sealed class MindbrokenSystem : EntitySystem
+{
+    [Dependency] private readonly ConsentSystem _consent = default!;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+        SubscribeLocalEvent<HornyComponent, ExaminedEvent>(OnExamined);
+    }
+
+    private void OnExamined(EntityUid uid, HornyComponent component, ExaminedEvent args)
+    {
+        if (!args.IsInDetailsRange)
+            return;
+        if (!_consent.HasConsent(args.Examined, "Horny"))
+            return;
+
+        var identity = Identity.Entity(args.Examined, EntityManager);
+        args.PushMarkup($"[color=pink]{Loc.GetString("consent-Horny-examine", ("user", identity))}[/color]");
+    }
+}
+
+
+
+
+
+
+
+
+
+
+
+
+

--- a/Content.Shared/Humanoid/SharedHumanoidAppearanceSystem.cs
+++ b/Content.Shared/Humanoid/SharedHumanoidAppearanceSystem.cs
@@ -362,7 +362,7 @@ public abstract class SharedHumanoidAppearanceSystem : EntitySystem
         }
 
         if (sync)
-            Dirty(uid, humanoid);    
+            Dirty(uid, humanoid);
     }
 
     /// <summary>

--- a/Resources/Locale/en-US/Blep/consent.ftl
+++ b/Resources/Locale/en-US/Blep/consent.ftl
@@ -30,5 +30,9 @@ consent-Digestion-desc = Allow yourself to be digested. WARNING: BEING DIGESTED 
 consent-Hypno-name = Hypnosis
 consent-Hypno-desc = Allow yourself to be hypnotized.
 
+consent-Horny-name = Seeking ERP
+consent-Horny-desc = Display a message when examined that you're actively looking for ERP (or some kind of scene).
+consent-Horny-examine = {$user} seems like they're looking for a good time! Go talk to them!
+
 consent-NoClone-name = Disallow Paradox Anomaly
 consent-NoClone-desc = Disallow yourself to be the target of a paradox anomaly clone.

--- a/Resources/Prototypes/Entities/Mobs/Species/base.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/base.yml
@@ -241,6 +241,7 @@
   - type: SurgeryTarget
   - type: FootPrints
   - type: Wagging
+  - type: Horny
 
 - type: entity
   save: false

--- a/Resources/Prototypes/consent.yml
+++ b/Resources/Prototypes/consent.yml
@@ -17,3 +17,6 @@
 
 - type: consentToggle
   id: NoClone
+
+- type: consentToggle
+  id: Horny


### PR DESCRIPTION
A relatively simple toggle to show that a player is specifically seeking out an ERP partner.

Dan Code in a Fen VSC.

![image](https://github.com/user-attachments/assets/6f6ed3e5-66ac-495e-81c6-c793b2be4145)


---

# Changelog

<!--
You can add an author after the `:cl:` to change the name that appears in the changelog (ex: `:cl: Death`)
Leaving it blank will default to your GitHub display name
This includes all available types for the changelog
-->

:cl: FennyAndDan
- add: ERP Seeking Consent Menu Toggle to Alert others that you are IN DA MOOD.