### PR TITLE
Allows Arachne  to Take the Natural Arachnid Trait 

### DIFF
--- a/Resources/Prototypes/Floof/Traits/languages.yml
+++ b/Resources/Prototypes/Floof/Traits/languages.yml
@@ -127,7 +127,7 @@
     - !type:CharacterSpeciesRequirement
       inverted: true
       species:
-        - Arachne
+        # Arachne they cant speak Arachnic
         - Arachnid
   functions:
     - !type:TraitAddComponent


### PR DESCRIPTION

# Description
Arachnes doesn't know Arachnid language. They aren't spider people, they are half and half 
# Changelog

:cl:
- fix: Arachnes can take Arachnid language trait now 