### PR TITLE
FIX SHITMED

### DIFF
--- a/Content.Shared/_Shitmed/Body/Systems/SharedBodySystem.PartAppearance.cs
+++ b/Content.Shared/_Shitmed/Body/Systems/SharedBodySystem.PartAppearance.cs
@@ -99,6 +99,10 @@ public partial class SharedBodySystem
         string markingId,
         bool remove = false)
     {
+        // Floofstation - DO NOT TOUCH MARKINGS CLIENT-SIDE, YOU ARE DUPLICATING THEM!!!
+        if (_net.IsClient && !IsClientSide(uid))
+            return;
+
 
         if (!Resolve(partAppearance, ref partAppearance.Comp))
             return;
@@ -163,6 +167,10 @@ public partial class SharedBodySystem
     protected void UpdateAppearance(EntityUid target,
         BodyPartAppearanceComponent component)
     {
+        // Floofstation - DO NOT TOUCH MARKINGS CLIENT-SIDE, YOU ARE DUPLICATING THEM!!!
+        if (_net.IsClient && !IsClientSide(target))
+            return;
+
         if (!TryComp(target, out HumanoidAppearanceComponent? bodyAppearance))
             return;
 


### PR DESCRIPTION
# Description
Fixes every marking on every humanoid entity duplicating every time it re-enters your PVS (leading to things like double tails and degrading client performance over time) due to the poor implementation of shared humanoid appearence system code (works fine server-side, but leads to marking duplication client-side)

Tested, made sure markings are preserved in all of the following scenarios:
- [X] Re-entering PVS multiple times
- [X] Removing and re-attaching a limb via surgery
- [X] Reconnecting

# Changelog
:cl:
- fix: Humanoid markings (including tails) should no longer duplicate every time they re-enter your field of view.