### PR TITLE
Typewriter SMG to Uplink

### DIFF
--- a/Resources/Locale/en-US/_Floof/store/uplink-catalog.ftl
+++ b/Resources/Locale/en-US/_Floof/store/uplink-catalog.ftl
@@ -8,3 +8,6 @@ uplink-Cryptobiolininjector-desc = Made by SESWC. This item is prefilled with 20
 
 uplink-EnergySabre-name = Energy Sabre MK. 9
 uplink-EnergySabre-desc = Crafted by Fae, the CyberSun Weapons Designer, a brilliant display of plasma weaponry crafted into a beautiful sabre.
+
+uplink-typewriter-bundle-name = Typewriter Bundle
+uplink-typewriter-bundle-desc = An inconspicuous briefcase that contains a Typewriter SMG, three magazines and an outfit fit for any aspiring mafiosos.

--- a/Resources/Locale/en-US/store/uplink-catalog.ftl
+++ b/Resources/Locale/en-US/store/uplink-catalog.ftl
@@ -225,9 +225,6 @@ uplink-ammo-bundle-desc = Reloading! Contains 4 magazines for the C-20r, 4 drums
 uplink-sniper-bundle-name = Sniper Bundle
 uplink-sniper-bundle-desc = An inconspicuous briefcase that contains a Hristov, 10 spare bullets and a convenient disguise.
 
-uplink-typewriter-bundle-name = Typewriter Bundle
-uplink-typewriter-bundle-desc = An inconspicuous briefcase that contains a Typewriter SMG and three magazines for any aspiring mafiosos.
-
 uplink-c20r-bundle-name = C-20r Bundle
 uplink-c20r-bundle-desc = Old faithful: The classic C-20r Submachine Gun, bundled with three magazines.
 

--- a/Resources/Locale/en-US/store/uplink-catalog.ftl
+++ b/Resources/Locale/en-US/store/uplink-catalog.ftl
@@ -225,6 +225,9 @@ uplink-ammo-bundle-desc = Reloading! Contains 4 magazines for the C-20r, 4 drums
 uplink-sniper-bundle-name = Sniper Bundle
 uplink-sniper-bundle-desc = An inconspicuous briefcase that contains a Hristov, 10 spare bullets and a convenient disguise.
 
+uplink-typewriter-bundle-name = Typewriter Bundle
+uplink-typewriter-bundle-desc = An inconspicuous briefcase that contains a Typewriter SMG and three magazines for any aspiring mafiosos.
+
 uplink-c20r-bundle-name = C-20r Bundle
 uplink-c20r-bundle-desc = Old faithful: The classic C-20r Submachine Gun, bundled with three magazines.
 

--- a/Resources/Prototypes/Catalog/Fills/Items/briefcases.yml
+++ b/Resources/Prototypes/Catalog/Fills/Items/briefcases.yml
@@ -45,7 +45,11 @@
       - id: MagazinePistolSubMachineGun
       - id: MagazinePistolSubMachineGun
       - id: MagazinePistolSubMachineGun
-
+      - id: CigarGoldCase
+      - id: ClothingUniformJumpsuitDetectiveGrey
+      - id: ClothingHeadHatFedoraChoc
+      - id: FlippoEngravedLighter
+      
 - type: entity
   id: BriefcaseSyndieLobbyingBundleFilled
   parent: BriefcaseSyndie

--- a/Resources/Prototypes/Catalog/Fills/Items/briefcases.yml
+++ b/Resources/Prototypes/Catalog/Fills/Items/briefcases.yml
@@ -29,6 +29,23 @@
       - id: BarberScissors
 
 - type: entity
+  id: BriefcaseSyndieTypewriterBundleFilled
+  parent: BriefcaseSyndie
+  suffix: Syndicate, Typewriter Bundle
+  components:
+  - type: Item
+    size: Ginormous
+  - type: Storage
+    maxItemSize: Huge
+    grid:
+    - 0,0,6,3
+  - type: StorageFill
+    contents:
+      - id: WeaponSubMachineGunTypewriter
+      - id: MagazinePistolSubMachineGun
+      - id: MagazinePistolSubMachineGun
+
+- type: entity
   id: BriefcaseSyndieLobbyingBundleFilled
   parent: BriefcaseSyndie
   suffix: Syndicate, Spesos

--- a/Resources/Prototypes/Catalog/Fills/Items/briefcases.yml
+++ b/Resources/Prototypes/Catalog/Fills/Items/briefcases.yml
@@ -27,28 +27,6 @@
       - id: ClothingHandsGlovesLatex
       - id: ClothingUniformJumpsuitLawyerBlack
       - id: BarberScissors
-
-- type: entity
-  id: BriefcaseSyndieTypewriterBundleFilled
-  parent: BriefcaseSyndie
-  suffix: Syndicate, Typewriter Bundle
-  components:
-  - type: Item
-    size: Ginormous
-  - type: Storage
-    maxItemSize: Huge
-    grid:
-    - 0,0,6,3
-  - type: StorageFill
-    contents:
-      - id: WeaponSubMachineGunTypewriter
-      - id: MagazinePistolSubMachineGun
-      - id: MagazinePistolSubMachineGun
-      - id: MagazinePistolSubMachineGun
-      - id: CigarGoldCase
-      - id: ClothingUniformJumpsuitDetectiveGrey
-      - id: ClothingHeadHatFedoraChoc
-      - id: FlippoEngravedLighter
       
 - type: entity
   id: BriefcaseSyndieLobbyingBundleFilled

--- a/Resources/Prototypes/Catalog/Fills/Items/briefcases.yml
+++ b/Resources/Prototypes/Catalog/Fills/Items/briefcases.yml
@@ -44,6 +44,7 @@
       - id: WeaponSubMachineGunTypewriter
       - id: MagazinePistolSubMachineGun
       - id: MagazinePistolSubMachineGun
+      - id: MagazinePistolSubMachineGun
 
 - type: entity
   id: BriefcaseSyndieLobbyingBundleFilled

--- a/Resources/Prototypes/Catalog/uplink_catalog.yml
+++ b/Resources/Prototypes/Catalog/uplink_catalog.yml
@@ -158,21 +158,7 @@
     Telecrystal: 12
   categories:
   - UplinkWeaponry
-
-- type: listing
-  id: UplinkTypewriterBundle
-  name: uplink-typewriter-bundle-name
-  description: uplink-typewriter-bundle-desc
-  icon: { sprite: /Textures/DeltaV/Objects/Weapons/Guns/SMGs/typewriter.rsi, state: base }
-  productEntity: BriefcaseSyndieTypewriterBundleFilled
-  discountCategory: usualDiscounts
-  discountDownTo:
-    Telecrystal: 4
-  cost:
-    Telecrystal: 8
-  categories:
-  - UplinkWeaponry
-
+  
 - type: listing
   id: UplinkC20RBundle
   name: uplink-c20r-bundle-name

--- a/Resources/Prototypes/Catalog/uplink_catalog.yml
+++ b/Resources/Prototypes/Catalog/uplink_catalog.yml
@@ -159,7 +159,7 @@
   categories:
   - UplinkWeaponry
 
-  - type: listing
+- type: listing
   id: UplinkTypewriterBundle
   name: uplink-typewriter-bundle-name
   description: uplink-typewriter-bundle-desc

--- a/Resources/Prototypes/Catalog/uplink_catalog.yml
+++ b/Resources/Prototypes/Catalog/uplink_catalog.yml
@@ -163,7 +163,7 @@
   id: UplinkTypewriterBundle
   name: uplink-typewriter-bundle-name
   description: uplink-typewriter-bundle-desc
-  icon: { sprite: /Textures/Objects/Weapons/Guns/SMGs/typewriter.rsi, state: base }
+  icon: { sprite: /Textures/DeltaV/Objects/Weapons/Guns/SMGs/typewriter.rsi, state: base }
   productEntity: BriefcaseSyndieTypewriterBundleFilled
   discountCategory: usualDiscounts
   discountDownTo:

--- a/Resources/Prototypes/Catalog/uplink_catalog.yml
+++ b/Resources/Prototypes/Catalog/uplink_catalog.yml
@@ -159,6 +159,20 @@
   categories:
   - UplinkWeaponry
 
+  - type: listing
+  id: UplinkTypewriterBundle
+  name: uplink-typewriter-bundle-name
+  description: uplink-typewriter-bundle-desc
+  icon: { sprite: /Textures/Objects/Weapons/Guns/SMGs/typewriter.rsi, state: base }
+  productEntity: BriefcaseSyndieTypewriterBundleFilled
+  discountCategory: usualDiscounts
+  discountDownTo:
+    Telecrystal: 4
+  cost:
+    Telecrystal: 8
+  categories:
+  - UplinkWeaponry
+
 - type: listing
   id: UplinkC20RBundle
   name: uplink-c20r-bundle-name

--- a/Resources/Prototypes/_Floof/Catalog/Fills/Items/briefcases.yml
+++ b/Resources/Prototypes/_Floof/Catalog/Fills/Items/briefcases.yml
@@ -1,0 +1,21 @@
+- type: entity
+  id: BriefcaseSyndieTypewriterBundleFilled
+  parent: BriefcaseSyndie
+  suffix: Syndicate, Typewriter Bundle
+  components:
+  - type: Item
+    size: Ginormous
+  - type: Storage
+    maxItemSize: Huge
+    grid:
+    - 0,0,6,3
+  - type: StorageFill
+    contents:
+      - id: WeaponSubMachineGunTypewriter
+      - id: MagazinePistolSubMachineGun
+      - id: MagazinePistolSubMachineGun
+      - id: MagazinePistolSubMachineGun
+      - id: CigarGoldCase
+      - id: ClothingUniformJumpsuitDetectiveGrey
+      - id: ClothingHeadHatFedoraChoc
+      - id: FlippoEngravedLighter

--- a/Resources/Prototypes/_Floof/Catalog/uplink_catalog.yml
+++ b/Resources/Prototypes/_Floof/Catalog/uplink_catalog.yml
@@ -32,3 +32,17 @@
   #  Telecrystal: 2
   #categories:
   #- UplinkUtility
+
+- type: listing
+  id: UplinkTypewriterBundle
+  name: uplink-typewriter-bundle-name
+  description: uplink-typewriter-bundle-desc
+  icon: { sprite: /Textures/DeltaV/Objects/Weapons/Guns/SMGs/typewriter.rsi, state: base }
+  productEntity: BriefcaseSyndieTypewriterBundleFilled
+  discountCategory: usualDiscounts
+  discountDownTo:
+    Telecrystal: 4
+  cost:
+    Telecrystal: 8
+  categories:
+  - UplinkWeaponry


### PR DESCRIPTION
# Description

Adds the Typewriter SMG Bundle to Syndicate Uplink.
Comes in a briefcase (sorry all outta violin cases) with 3 spare magazines.

For my friend, Chokovit.

# Changelog

- add: Added the Typewriter SMG to the traitor Uplink.