### PR TITLE
More Admin Assistant Accesses

### DIFF
--- a/Resources/Prototypes/DeltaV/Roles/Jobs/Command/administrative_assistant.yml
+++ b/Resources/Prototypes/DeltaV/Roles/Jobs/Command/administrative_assistant.yml
@@ -32,10 +32,10 @@
   access:
     - Command
     - Maintenance
-    - Janitor
+    - Janitor # Floof section - expanded access list
     - Service
     - Bar
-    - Kitchen
+    - Kitchen # Floof section end
   special:
     - !type:AddImplantSpecial
       implants: [MindShieldImplant]

--- a/Resources/Prototypes/DeltaV/Roles/Jobs/Command/administrative_assistant.yml
+++ b/Resources/Prototypes/DeltaV/Roles/Jobs/Command/administrative_assistant.yml
@@ -32,6 +32,10 @@
   access:
     - Command
     - Maintenance
+    - Janitor
+    - Service
+    - Bar
+    - Kitchen
   special:
     - !type:AddImplantSpecial
       implants: [MindShieldImplant]


### PR DESCRIPTION
# Description

Added Janitor, Service, Bar and Kitchen access to Admin Assistant. Mostly QoL so they can clean the bridge, use the bridge boozevend and fetch service items without requesting the access.

# Changelog

:cl:
- add: Added several QoL accesses for the Admin Assistant.

