### PR TITLE
Space Animal Lungs Fix

### DIFF
--- a/Content.Server/Body/Systems/RespiratorSystem.cs
+++ b/Content.Server/Body/Systems/RespiratorSystem.cs
@@ -75,7 +75,7 @@ public sealed class RespiratorSystem : EntitySystem
 
             respirator.NextUpdate += respirator.UpdateInterval;
 
-            if (_mobState.IsDead(uid))
+            if (_mobState.IsDead(uid) || HasComp<BreathingImmunityComponent>(uid)) // Shitmed: BreathingImmunity
                 continue;
 
             if (HasComp<RespiratorImmuneComponent>(uid))

--- a/Content.Server/Body/Systems/RespiratorSystem.cs
+++ b/Content.Server/Body/Systems/RespiratorSystem.cs
@@ -9,6 +9,7 @@ using Content.Server.Popups;
 using Content.Shared.Alert;
 using Content.Shared.Atmos;
 using Content.Shared.Body.Components;
+using Content.Shared._Shitmed.Body.Components; // Shitmed Change
 using Content.Shared._Shitmed.Body.Organ;
 using Content.Shared.Body.Prototypes;
 using Content.Shared.Chemistry.Components;

--- a/Resources/Prototypes/_Shitmed/Body/Organs/cybernetic.yml
+++ b/Resources/Prototypes/_Shitmed/Body/Organs/cybernetic.yml
@@ -7,8 +7,6 @@
   - type: Sprite
     sprite: Mobs/Species/IPC/organs.rsi
     state: "eyes"
-  - type: Perishable # Floof
-    rotAfter: 7200 # 2 hours, should be plenty enough time
 
 - type: entity
   parent: BaseCyberneticEyes


### PR DESCRIPTION
# Description

#733 Space Animal Lung Fix / Identical to https://github.com/Simple-Station/Einstein-Engines/pull/2111

Also, Cybernetic Eyes no longer rot at all, why would they? They're made of metal.

# Changelog

:cl:
- tweak: Cybernetic Eyes and it's Variants should no longer rot
- fix: Space Animal Lungs should actually work now
