### PR TITLE
Makes the PDA Beep when Messaged, Even if Its Open

### DIFF
--- a/Content.Server/DeltaV/CartridgeLoader/Cartridges/NanoChatCartridgeSystem.cs
+++ b/Content.Server/DeltaV/CartridgeLoader/Cartridges/NanoChatCartridgeSystem.cs
@@ -477,11 +477,12 @@ public sealed class NanoChatCartridgeSystem : EntitySystem
 
         if (recipient.Comp.NotificationsMuted ||
             recipient.Comp.PdaUid is not {} pdaUid ||
-            !TryComp<CartridgeLoaderComponent>(pdaUid, out var loader) ||
-            // Don't notify if the recipient has the NanoChat program open with this chat selected.
+            !TryComp<CartridgeLoaderComponent>(pdaUid, out var loader) /* || // FLOOF CHANGE - just make it always beep
+            Don't notify if the recipient has the NanoChat program open with this chat selected.
             (hasSelectedCurrentChat &&
                 _ui.IsUiOpen(pdaUid, PdaUiKey.Key) &&
-                HasComp<NanoChatCartridgeComponent>(loader.ActiveProgram)))
+                HasComp<NanoChatCartridgeComponent>(loader.ActiveProgram)) */
+            )
             return;
 
         var title = "";


### PR DESCRIPTION
# Description

So, if you have the PDA open, with a conversation selected, and youve been chatting for a while, it doesnt always scroll to the bottom, which tends to make it hard to know if you got a message. That, and even when it does, it can easily get overlooked if you're doing anything other than reading the PDA.

This just makes the PDA always beep when you get a message, regardless if you have the selected thread opened. You can still mute it, dont worry!

---

# Changelog

:cl:
- tweak: The PDA always beeps when you get a message, even if the conversation is already open. Dont worry, you can still mute it!