### PR TITLE
Give Unathi Hair Back

### DIFF
--- a/Resources/Prototypes/Species/reptilian.yml
+++ b/Resources/Prototypes/Species/reptilian.yml
@@ -26,8 +26,8 @@
     TailOversuit: MobHumanoidAnyMarking
     Head: MobReptilianHead
     Face: MobHumanoidAnyMarking
-    Hair: MobHumanoidAnyMarking
-    FacialHair: MobHumanoidAnyMarking
+    Hair: MobHumanoidAnyMarking # Floofstation
+    FacialHair: MobHumanoidAnyMarking # Floofstation
     Snout: MobHumanoidAnyMarking
     Chest: MobReptilianTorso
     Underwear: MobHumanoidAnyMarking # Floof, add underwear
@@ -48,7 +48,7 @@
 
 - type: markingPoints
   id: MobReptilianMarkingLimits
-  onlyWhitelisted: true
+  onlyWhitelisted: false # Floofstation, changed from true. Not sure I like that change, makes the whitelisting kinda wacky if there's a race that just ignores it. This was just to allow them to take hair and facial hair.
   points:
     Underwear:
       points: 2 # FLOOF CHANGE
@@ -57,10 +57,10 @@
       points: 2 # Floof, add underwear # FLOOF CHANGE
       required: false
     Hair:
-      points: 0
+      points: 1 # Floofstation, changed from 0
       required: false
     FacialHair:
-      points: 0
+      points: 1 # Floofstation, changed from 0
       required: false
     Tail:
       points: 1


### PR DESCRIPTION
<!--
This is a semi-strict format, you can add/remove sections as needed but the order/format should be kept the same
Remove these comments before submitting
-->

# Description

<!--
Explain this PR in as much detail as applicable

Some example prompts to consider:
How might this affect the game? The codebase?
What might be some alternatives to this?
How/Who does this benefit/hurt [the game/codebase]?
-->

Reapply the changes in https://github.com/Fansana/floofstation1/pull/770, which were partially overwritten by https://github.com/Fansana/floofstation1/pull/806. Also added comments that probably should have been there before.

---

# TODO

<!--
A list of everything you have to do before this PR is "complete"
You probably won't have to complete everything before merging but it's good to leave future references
-->

- [x] Fix Unathi hair availability

---

<!--
This is default collapsed, readers click to expand it and see all your media
The PR media section can get very large at times, so this is a good way to keep it clean
The title is written using HTML tags
The title must be within the <summary> tags or you won't see it
-->

<details><summary><h1>Media</h1></summary>
<p>

![image](https://github.com/user-attachments/assets/bd64014c-9776-4ec4-a267-181a677b2b79)

</p>
</details>

---

# Changelog

<!--
You can add an author after the `:cl:` to change the name that appears in the changelog (ex: `:cl: Death`)
Leaving it blank will default to your GitHub display name
This includes all available types for the changelog
-->

:cl:
- fix: Unathi can have hair once again.
