### PR TITLE
Fix Rodentia and Chitinid Hunger

### DIFF
--- a/Resources/Prototypes/DeltaV/Entities/Mobs/Species/chitinid.yml
+++ b/Resources/Prototypes/DeltaV/Entities/Mobs/Species/chitinid.yml
@@ -11,7 +11,7 @@
     - HeadTop
 
   - type: Hunger
-    baseDecayRate: 0.0467 #needs to eat more to survive
+    baseDecayRate: 0.0221666666 # Floofstation, changed from 0.0467 so it's actually 33% faster. Original number came from DeltaV, which has a much higher base hunger rate. Original comment: needs to eat more to survive
   - type: Thirst
 
   - type: UnpoweredFlashlight

--- a/Resources/Prototypes/DeltaV/Entities/Mobs/Species/rodentia.yml
+++ b/Resources/Prototypes/DeltaV/Entities/Mobs/Species/rodentia.yml
@@ -9,7 +9,7 @@
     species: Rodentia
   - type: Thirst
   - type: Hunger
-    baseDecayRate: 0.0467 # 33% faster than usual
+    baseDecayRate: 0.0221666666 # Floofstation, changed from 0.0467 so it's actually 33% faster. Original number came from DeltaV, which has a much higher base hunger rate
   - type: Carriable # Carrying system from nyanotrasen.
   - type: Icon
     sprite: DeltaV/Mobs/Species/Rodentia/parts.rsi


### PR DESCRIPTION
<!--
This is a semi-strict format, you can add/remove sections as needed but the order/format should be kept the same
Remove these comments before submitting
-->

# Description

<!--
Explain this PR in as much detail as applicable

Some example prompts to consider:
How might this affect the game? The codebase?
What might be some alternatives to this?
How/Who does this benefit/hurt [the game/codebase]?
-->

It turns out rodentia (and the more recent chitinid) have had something like 180% increased hunger decay rates, instead of the intended 33% increase. This is due to the hard-coded numbers and DeltaV (the originating fork) having a much higher base hunger decay rate.

---

# TODO

<!--
A list of everything you have to do before this PR is "complete"
You probably won't have to complete everything before merging but it's good to leave future references
-->

- [x] Tweak rodentia and chitinid hunger decay

---

<!--
This is default collapsed, readers click to expand it and see all your media
The PR media section can get very large at times, so this is a good way to keep it clean
The title is written using HTML tags
The title must be within the <summary> tags or you won't see it
-->

<details><summary><h1>Media</h1></summary>
<p>

Ehh

</p>
</details>

---

# Changelog

<!--
You can add an author after the `:cl:` to change the name that appears in the changelog (ex: `:cl: Death`)
Leaving it blank will default to your GitHub display name
This includes all available types for the changelog
-->

:cl:
- fix: Rodentia and Chitinid now get hungry at the intended rate.
