### PR TITLE
Leash Fixes Part 812471

### DIFF
--- a/Content.Shared/_Floof/Leash/Components/LeashAnchorComponent.cs
+++ b/Content.Shared/_Floof/Leash/Components/LeashAnchorComponent.cs
@@ -13,4 +13,18 @@ public sealed partial class LeashAnchorComponent : Component
     /// </summary>
     [DataField]
     public Vector2 Offset = Vector2.Zero;
+
+    [DataField]
+    public AnchorKind Kind = AnchorKind.Any;
+
+    [Flags]
+    public enum AnchorKind : int
+    {
+        /// <summary>The entity is a clothing that, when equipped, can have a leash attached to.</summary>
+        Clothing,
+        /// <summary>The entity can have a leash attached to normally.</summary>
+        Intrinsic,
+
+        Any = Clothing | Intrinsic
+    }
 }

--- a/Content.Shared/_Floof/Leash/LeashSystem.cs
+++ b/Content.Shared/_Floof/Leash/LeashSystem.cs
@@ -80,7 +80,7 @@ public sealed class LeashSystem : EntitySystem
 
             // Server - ensure the holder of the leash is always correct
             // I do not know why, perhaps because RobustToolbox tooling is shitty,
-            // but the leash is inside a container that is inside another container (e.g. person inside a locker),
+            // but if the leash is inside a container that is inside another container (e.g. person inside a locker),
             // and then the middle container leaves the outer (person leaves the locker),
             // RobustToolbox won't update the joint between the leashed person and the leash (which should be relayed to the outer container - locker).
             // This means the person will stay attached to the outer container (locker).

--- a/Content.Shared/_Floof/Leash/LeashSystem.cs
+++ b/Content.Shared/_Floof/Leash/LeashSystem.cs
@@ -77,6 +77,22 @@ public sealed class LeashSystem : EntitySystem
             var sourceXForm = Transform(leashEnt);
             foreach (var data in leash.Leashed.ToList())
                 UpdateLeash(data, sourceXForm, leash, leashEnt);
+
+            // Server - ensure the holder of the leash is always correct
+            // I do not know why, perhaps because RobustToolbox tooling is shitty,
+            // but the leash is inside a container that is inside another container (e.g. person inside a locker),
+            // and then the middle container leaves the outer (person leaves the locker),
+            // RobustToolbox won't update the joint between the leashed person and the leash (which should be relayed to the outer container - locker).
+            // This means the person will stay attached to the outer container (locker).
+            // To fix this, we do this expensive (but mandatory) computation and recreate the joint when this occurs.
+            // Luckily for us, this only happens with the leash, not with the leashed person, thanks to the way we handle anchors.
+            if (_net.IsServer
+                && TryComp<JointComponent>(leashEnt, out var leashJointComp)
+                && _container.TryGetOuterContainer(leashEnt, sourceXForm, out var jointRelayTarget)
+                && leashJointComp.Relay != null
+                && leashJointComp.Relay != jointRelayTarget.Owner
+            )
+                _joints.RefreshRelay(leashEnt);
         }
 
         leashQuery.Dispose();
@@ -113,8 +129,9 @@ public sealed class LeashSystem : EntitySystem
 
         // Server: update leash lengths if necessary/possible
         // The length can be increased freely, but can only be decreased if the pulled entity is close enough
-        if (joint is not null && (leash.Length >= joint.MaxLength || leash.Length >= joint.Length))
-            joint.MaxLength = leash.Length;
+        if (joint is not null && joint.MaxLength > leash.Length && joint.Length < joint.MaxLength)
+            joint.MaxLength = Math.Max(joint.Length, leash.Length);
+
     }
 
     #endregion
@@ -356,7 +373,6 @@ public sealed class LeashSystem : EntitySystem
             ? MathF.Max(dist, leash.Comp.Length)
             : leash.Comp.Length;
 
-        joint.CollideConnected = false;
         joint.MinLength = 0f;
         joint.MaxLength = length;
         joint.Stiffness = 1f;
@@ -440,9 +456,16 @@ public sealed class LeashSystem : EntitySystem
     /// <param name="anchor">The anchor entity, usually either target's clothing or the target itself.</param>
     /// <param name="leash">The leash entity.</param>
     /// <param name="leashTarget">The entity to which the leash is actually connected. Can be EntityUid.Invalid, then it will be deduced.</param>
-    public void DoLeash(Entity<LeashAnchorComponent> anchor, Entity<LeashComponent> leash, EntityUid leashTarget)
+    /// <param name="force">Whether to force the leash to be created even if the target is too far away.</param>
+    public void DoLeash(Entity<LeashAnchorComponent> anchor, Entity<LeashComponent> leash, EntityUid leashTarget, bool force = false)
     {
         if (_net.IsClient || leashTarget is { Valid: false } && !TryGetLeashTarget(anchor!, out leashTarget))
+            return;
+
+        // Do not allow to create the joint if the target is too far away - this is mostly to prevent re-creating leashes after teleportation
+        if (!force &&
+            Transform(anchor).Coordinates.TryDistance(EntityManager, Transform(leash).Coordinates, out var dst) &&
+            dst > leash.Comp.MaxDistance)
             return;
 
         var leashedComp = EnsureComp<LeashedComponent>(leashTarget);

--- a/Content.Shared/_Floof/Leash/LeashSystem.cs
+++ b/Content.Shared/_Floof/Leash/LeashSystem.cs
@@ -144,6 +144,7 @@ public sealed class LeashSystem : EntitySystem
         if (TryGetLeashTarget(args.Equipment, out var leashTarget)
             && TryComp<LeashedComponent>(leashTarget, out var leashed)
             && leashed.Puller is not null
+            && leashed.Anchor == args.Equipment
            )
             args.Cancel();
     }

--- a/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
@@ -256,6 +256,7 @@
   - type: RandomBark
     barkType: chicken
   - type: LeashAnchor # Floofstation
+    kind: Intrinsic
 
 - type: entity
   parent: MobChicken
@@ -587,6 +588,7 @@
     sprite: Mobs/Effects/onfire.rsi
     normalState: Mouse_burning
   - type: LeashAnchor # Floofstation - moffroach my beloved
+    kind: Intrinsic
   - type: SurgeryTarget
   - type: UserInterface
     interfaces:
@@ -689,6 +691,7 @@
     barkType: chicken # Duh
     barkMultiplier: 0.7
   - type: LeashAnchor # Floofstation
+    kind: Intrinsic
   - type: SurgeryTarget
   - type: UserInterface
     interfaces:
@@ -876,6 +879,7 @@
     barkType: cow
     barkMultiplier: 3
   - type: LeashAnchor # Floofstation
+    kind: Intrinsic
 
 
 - type: entity
@@ -1047,6 +1051,7 @@
     rootTask:
       task: RuminantHostileCompound
   - type: LeashAnchor # Floofstation
+    kind: Intrinsic
   - type: SurgeryTarget
   - type: UserInterface
     interfaces:
@@ -1101,6 +1106,7 @@
     factions:
     - Passive
   - type: LeashAnchor # Floofstation
+    kind: Intrinsic
 
 - type: entity
   name: kangaroo
@@ -1195,6 +1201,7 @@
     rootTask:
       task: SimpleHostileCompound
   - type: LeashAnchor # Floofstation
+    kind: Intrinsic
 
 - type: entity
   name: boxing kangaroo
@@ -1348,6 +1355,7 @@
     - VimPilot
     - DoorBumpOpener
   - type: LeashAnchor # Floofstation
+    kind: Intrinsic
 
 - type: entity
   name: monkey
@@ -1955,6 +1963,7 @@
     tags:
     - VimPilot
   - type: LeashAnchor # Floofstation
+    kind: Intrinsic
 
 
 - type: entity
@@ -2005,6 +2014,7 @@
   - type: Bloodstream
     bloodMaxVolume: 50
   - type: LeashAnchor # Floofstation
+    kind: Intrinsic
 
 - type: entity
   name: frog
@@ -2601,6 +2611,7 @@
     understands:
     - Hissing
   - type: LeashAnchor # Floofstation
+    kind: Intrinsic
   - type: RandomBark
     barkType: possum
 
@@ -2686,6 +2697,7 @@
     understands:
     - Hissing
   - type: LeashAnchor # Floofstation
+    kind: Intrinsic
   - type: RandomBark
     barkType: raccoon
 
@@ -2777,6 +2789,7 @@
     understands:
     - Fox
   - type: LeashAnchor # Floofstation
+    kind: Intrinsic
   - type: RandomBark
     barkType: fox
     barkMultiplier: 0.5 # Talkative <3
@@ -2851,6 +2864,7 @@
   - type: RandomBark
     barkType: dog
   - type: LeashAnchor # Floofstation
+    kind: Intrinsic
 
 - type: entity
   name: corrupted corgi
@@ -3019,6 +3033,7 @@
   - type: RandomBark
     barkType: cat
   - type: LeashAnchor # Floofstation
+    kind: Intrinsic
 
 - type: entity
   name: calico cat
@@ -3329,6 +3344,7 @@
     understands:
     - Hissing
   - type: LeashAnchor # Floofstation
+    kind: Intrinsic
 
 - type: entity
   name: hamster
@@ -3482,6 +3498,7 @@
     sprite: Mobs/Effects/onfire.rsi
     normalState: Mouse_burning
   - type: LeashAnchor # Floofstation
+    kind: Intrinsic
 
 - type: entity
   parent: MobHamster

--- a/Resources/Prototypes/_Floof/Entities/Clothing/Neck/collars.yml
+++ b/Resources/Prototypes/_Floof/Entities/Clothing/Neck/collars.yml
@@ -6,6 +6,7 @@
   - type: Clothing
   - type: LeashAnchor
     offset: 0, 0.22
+    kind: Clothing
 
 - type: entity
   parent: ClothingNeckCollarBase

--- a/Resources/Prototypes/_Floof/Entities/Clothing/Uncategorized/harness.yml
+++ b/Resources/Prototypes/_Floof/Entities/Clothing/Uncategorized/harness.yml
@@ -21,6 +21,7 @@
     equippedState: equipped
     clothingVisuals: {} # I am 90% sure this is a redundancy coming from ClothingBeltBase, so we're removing it here
   - type: LeashAnchor
+    kind: Clothing
   - type: ClothingLimit
     limitGroups:
     - harness


### PR DESCRIPTION
# Description
Smth smth this is shitcode

- Adds BreakOnMove = true back to the DoAfterArgs of leash do-afters. It was nuked during one of the upstream merges because the old BreakOnUserMove and BreakOnTargetMove were merged into one.
- Separates leash anchors into two distinct types: clothing and intrinsic. This means that mothroaches and mice can now be properly leashed, and can no longer be used as leash anchors when equipped in the head slot as clothing.
- Adds a check to DoLeash that prevents the creation of a leash if the entities are too far apart - this is mostly to prevent leashes from being re-created after teleportation and possible other glitches, which almost always result in... bad outcomes.
- Makes the system refresh the joint relay on the leash whenever it detect that its outer container has changed. This fixes the bugs where placing a leash entity inside a storage and then picking that storage up would result in the leash being non-functional, and where entering a container (e.g. a locker) while holding a leash would result in the leashed person getting stuck to the locker inside of you (until the leash is reparented or smth)
- Fixes the bug that caused leash joints to always be created with minimum MaxLength instead of preserving the length inferred during their creation and shrinking once the distance between the leash and the target becomes close enough.

# Changelog
:cl:
- fix: Fixed a few major bugs with leashes. Again.