### PR TITLE
Upstream Merge #1989 | Power Cell Draw Fix

### DIFF
--- a/Content.Server/PowerCell/PowerCellSystem.Draw.cs
+++ b/Content.Server/PowerCell/PowerCellSystem.Draw.cs
@@ -30,7 +30,8 @@ public sealed partial class PowerCellSystem
             if (!TryGetBatteryFromSlot(uid, out var batteryEnt, out var battery, slot))
                 continue;
 
-            if (_battery.TryUseCharge(batteryEnt.Value, comp.DrawRate, battery))
+            // TCJ: "Multiplying by frameTime to make this tick-invariant. Otherwise it'll draw 30x to 60x faster than you expect."
+            if (_battery.TryUseCharge(batteryEnt.Value, comp.DrawRate * frameTime, battery))
                 continue;
 
             Toggle.TryDeactivate((uid, toggle));


### PR DESCRIPTION
# Description

https://github.com/Simple-Station/Einstein-Engines/pull/1989

Power cell draw wasn't tick invariant, so batteries on this codebase were being drained anywhere from 30 to 60x faster than people expect, depending on server performance.

# Changelog

- fix: Batteries no longer drain power 30 to 60 times faster than physics states. This is particularly a large buff to IPCs and MODSuits, who both no longer have to deal with batteries lasting an absurdly short amount of time.)