### PR TITLE
Fix Certain Species Fixtures

### DIFF
--- a/Resources/Prototypes/DeltaV/Entities/Mobs/Species/rodentia.yml
+++ b/Resources/Prototypes/DeltaV/Entities/Mobs/Species/rodentia.yml
@@ -25,7 +25,7 @@
       fix1:
         shape:
           !type:PhysShapeCircle
-          radius: 0.28
+          radius: 0.35 # Floofstation - changed from 0.28. Default shape scaling is both not needed and causes issues due to EE's heightAdjust system. 0.35 is standard, DeltaV used 0.28 to shrink their size to 80%
         density: 140
         restitution: 0.0
         mask:
@@ -33,7 +33,7 @@
         layer:
         - MobLayer
   - type: Sprite
-    scale: 0.8, 0.8
+    # scale: 0.8, 0.8 Floofstation - while this doesn't technically cause any issues, this creates potential instability if changes to the heightAdjust system are made. As someone who made changes to the heightAdjust system, this can be very confusing.
     layers:
       - map: [ "enum.HumanoidVisualLayers.TailBehind" ]
       - map: [ "enum.HumanoidVisualLayers.Chest" ]

--- a/Resources/Prototypes/DeltaV/Species/rodentia.yml
+++ b/Resources/Prototypes/DeltaV/Species/rodentia.yml
@@ -13,10 +13,10 @@
   lastNames: names_rodentia_last
   naming: LastFirst
   minHeight: 0.65
-  defaultHeight: 0.8
+  #defaultHeight: 0.8 Floofstation - disabled due to upstream bug, this is broken for any value other than 1.
   maxHeight: 1.1
   minWidth: 0.6
-  defaultWidth: 0.8
+  #defaultWidth: 0.8 Floofstation - disabled due to upstream bug, this is broken for any value other than 1.
   maxWidth: 1.15
   customName: true
 

--- a/Resources/Prototypes/Entities/Mobs/Species/harpy.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/harpy.yml
@@ -69,7 +69,7 @@
       fix1:
         shape:
           !type:PhysShapeCircle
-          radius: 0.32
+          radius: 0.35 # Floofstation - changed from 0.32. Default shape scaling is both not needed and causes issues due to EE's heightAdjust system. 0.35 is standard, originator used 0.32 to shrink their size to 90%
         density: 90
         restitution: 0.0
         mask:
@@ -149,7 +149,7 @@
     speciesId: harpy
     templateId: digitigrade
   - type: Sprite
-    scale: 0.9, 0.9
+    #scale: 0.9, 0.9 Floofstation - while this doesn't technically cause any issues, this creates potential instability if changes to the heightAdjust system are made. As someone who made changes to the heightAdjust system, this can be very confusing.
     layers:
       - map: [ "enum.HumanoidVisualLayers.TailBehind" ]
       - map: [ "enum.HumanoidVisualLayers.Chest" ]

--- a/Resources/Prototypes/Entities/Mobs/Species/shadowkin.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/shadowkin.yml
@@ -258,7 +258,7 @@
       netsync: false
       noRot: true
       drawdepth: Mobs
-      scale: 0.85, 0.85 # Small
+      #scale: 0.85, 0.85 # Small | Floofstation - while this doesn't technically cause any issues, this creates potential instability if changes to the heightAdjust system are made. As someone who made changes to the heightAdjust system, this can be very confusing.
       layers:
         - map: [ "enum.HumanoidVisualLayers.TailBehind" ]
         - map: ["enum.HumanoidVisualLayers.Chest"]

--- a/Resources/Prototypes/Nyanotrasen/Entities/Mobs/Species/felinid.yml
+++ b/Resources/Prototypes/Nyanotrasen/Entities/Mobs/Species/felinid.yml
@@ -6,7 +6,7 @@
   abstract: true
   components:
   - type: Sprite
-    scale: 0.8, 0.8
+    #scale: 0.8, 0.8 Floofstation - while this doesn't technically cause any issues, this creates potential instability if changes to the heightAdjust system are made. As someone who made changes to the heightAdjust system, this can be very confusing.
   - type: HumanoidAppearance
     species: Felinid
   - type: Fixtures
@@ -14,7 +14,7 @@
       fix1:
         shape:
           !type:PhysShapeCircle
-          radius: 0.28
+          radius: 0.35 # Floofstation - changed from 0.28. Default shape scaling is both not needed and causes issues due to EE's heightAdjust system. 0.35 is standard, DeltaV used 0.28 to shrink their size to 80%
         density: 140
         restitution: 0.0
         mask:

--- a/Resources/Prototypes/Nyanotrasen/Species/Oni.yml
+++ b/Resources/Prototypes/Nyanotrasen/Species/Oni.yml
@@ -13,10 +13,10 @@
   lastNames: names_oni_location
   naming: LastNoFirst
   minHeight: 0.9
-  defaultHeight: 1.2
+  #defaultHeight: 1.2 Floofstation - disabled due to upstream bug, this is broken for any value other than 1.
   maxHeight: 1.3
   minWidth: 0.85
-  defaultWidth: 1.2
+  #defaultWidth: 1.2 Floofstation - disabled due to upstream bug, this is broken for any value other than 1.
   maxWidth: 1.35
   customName: true
 

--- a/Resources/Prototypes/Nyanotrasen/Species/felinid.yml
+++ b/Resources/Prototypes/Nyanotrasen/Species/felinid.yml
@@ -9,10 +9,10 @@
   dollPrototype: MobFelinidDummy
   skinColoration: Hues #FloofStation copied from DeltaV
   minHeight: 0.65
-  defaultHeight: 0.8
+  #defaultHeight: 0.8 Floofstation - disabled due to upstream bug, this is broken for any value other than 1.
   maxHeight: 1.1
   minWidth: 0.6
-  defaultWidth: 0.8
+  #defaultWidth: 0.8 Floofstation - disabled due to upstream bug, this is broken for any value other than 1.
   maxWidth: 1.15
   customName: true
 

--- a/Resources/Prototypes/Species/harpy.yml
+++ b/Resources/Prototypes/Species/harpy.yml
@@ -9,10 +9,10 @@
   dollPrototype: MobHarpyDummy
   skinColoration: HumanToned
   minHeight: 0.6
-  defaultHeight: 0.8
+  #defaultHeight: 0.8 Floofstation - disabled due to upstream bug, this is broken for any value other than 1.
   maxHeight: 1.1
   minWidth: 0.55
-  defaultWidth: 0.8
+  #defaultWidth: 0.8 Floofstation - disabled due to upstream bug, this is broken for any value other than 1.
   maxWidth: 1.15
   customName: true
 

--- a/Resources/Prototypes/Species/reptilian.yml
+++ b/Resources/Prototypes/Species/reptilian.yml
@@ -12,10 +12,10 @@
   femaleFirstNames: names_reptilian_female
   naming: FirstDashFirst
   minHeight: 0.7
-  defaultHeight: 0.95
+  #defaultHeight: 0.95 Floofstation - disabled due to upstream bug, this is broken for any value other than 1.
   maxHeight: 1.25
   minWidth: 0.65
-  defaultWidth: 0.95
+  #defaultWidth: 0.95 Floofstation - disabled due to upstream bug, this is broken for any value other than 1.
   maxWidth: 1.3
   customName: true
 

--- a/Resources/Prototypes/Species/shadowkin.yml
+++ b/Resources/Prototypes/Species/shadowkin.yml
@@ -20,10 +20,10 @@
     - Female
     - Unsexed
   minHeight: 0.65
-  defaultHeight: 0.85
+  #defaultHeight: 0.85 Floofstation - disabled due to upstream bug, this is broken for any value other than 1.
   maxHeight: 1.15
   minWidth: 0.6
-  defaultWidth: 0.85
+  #defaultWidth: 0.85 Floofstation - disabled due to upstream bug, this is broken for any value other than 1.
   maxWidth: 1.2
 
 - type: speciesBaseSprites

--- a/Resources/Prototypes/_Floof/Species/resomi.yml
+++ b/Resources/Prototypes/_Floof/Species/resomi.yml
@@ -12,10 +12,10 @@
   femaleFirstNames: names_resomi_female
   naming: First
   minHeight: 0.65
-  defaultHeight: 0.8
+  #defaultHeight: 0.8 Floofstation - disabled due to upstream bug, this is broken for any value other than 1.
   maxHeight: 1.1
   minWidth: 0.6
-  defaultWidth: 0.8
+  #defaultWidth: 0.8 Floofstation - disabled due to upstream bug, this is broken for any value other than 1.
   maxWidth: 1.15
   customName: true
   sexes:


### PR DESCRIPTION
<!--
This is a semi-strict format, you can add/remove sections as needed but the order/format should be kept the same
Remove these comments before submitting
-->

# Description

<!--
Explain this PR in as much detail as applicable

Some example prompts to consider:
How might this affect the game? The codebase?
What might be some alternatives to this?
How/Who does this benefit/hurt [the game/codebase]?
-->

So, it turns out there's two separate long-standing bugs with certain species fixture scaling. This appears to be contributing to certain issues, including: incorrect weights, incorrect fixture hitbox, and... I dunno, probably other stuff.

The two issues are 1) originating fork species scaling left in place despite EE's heightAdjustSystem and 2) defaultHeight/defaultWidth being applied as scaling to all characters on top of character creation scaling. Because of how EE's heightAdjustSystem works, the height/width scaling is masked/dropped but the cumulative fixture adjustments stay. This is also the source of one of the bugs caused by my original Tiny trait rework - I unintentionally exposed these repeated fixture adjustments as visual scaling adjustments as well.

So far I have been unable to determine why defaultWidth and defaultHeight are being applied in this way, despite them only being used in two places in the code. The issue almost certainly lies in the SharedHumanoidAppearanceSystem LoadProfile. The same issue also causes the affected species to have a different weight when they are spawned in verses what is displayed in the character creator.

My search found that one or both of these bugs applies to, at minimum, the following races: dwarf (ignored because disabled), rodentia, harpy, shadowkin, felinid, oni, harpy, unathi (reptilian), and resomi. I have provided mitigations to both issues in the form of yaml changes.

I'll give an example of rodentia, since they are what led to me discovering this:

The rodentia yaml contains DeltaV's original scaling that was never removed/changed, the systems just overwrite the sprite scaling. That makes the fixtures scaled down to 0.8 (0.28) despite the code assuming they are at 1.0 (0.35). Then we get to "defaultHeight" and "defaultWidth". It seems that these are taken into account, fixtures adjusted AGAIN down to 0.8 (which is what those are set to for rodentia) before this too is forgotten and assumed to be at 1.0 (0.35). If you then make a rodentia actually be it's default size (0.8, 0.8) via the character creator, this fixture adjustment is made a THIRD time. Your fixtures are then, instead of 0.8 of standard, actually 0.8x0.8x0.8 of standard. 

As a secondary example, Skittish Flora (my primary character) is a 117cm (3'10) rodentia. She weighs 8.9kg (~19lb?). This is absurd (though I love it). With these fixes, she instead weighs 21.6kg (~46lb). This is much more reasonable. These fixes make me a tiny bit sad, but make my logical brain happy. I was baffled by how light some of the characters could get.

---

# TODO

<!--
A list of everything you have to do before this PR is "complete"
You probably won't have to complete everything before merging but it's good to leave future references
-->

- [x] Finally look into why rodentia and felinid appear to be SO MUCH LIGHTER than they should be. 
- [x] Mitigate both bugs via yaml changes
- [ ] (optional) Fix bug two (2) properly instead of masking it via yaml changes
- [ ] (optional) Consider if these fixes are enough to make lightweight eligible for some of these races

---

<!--
This is default collapsed, readers click to expand it and see all your media
The PR media section can get very large at times, so this is a good way to keep it clean
The title is written using HTML tags
The title must be within the <summary> tags or you won't see it
-->

<details><summary><h1>Media</h1></summary>
<p>

</p>
</details>

---

# Changelog

<!--
You can add an author after the `:cl:` to change the name that appears in the changelog (ex: `:cl: Death`)
Leaving it blank will default to your GitHub display name
This includes all available types for the changelog
-->

:cl:
- fix: Mitigated two underlying issues that caused many races to have incorrect mass, unintended hitbox sizes, etc. This impacts rodentia, harpy, shadowkin, felinid, oni, harpy, unathi (reptilian), and resomi.
