### PR TITLE
Make Painbrushes Non-Edible

### DIFF
--- a/Resources/Prototypes/_Floof/Entities/Objects/Fun/toys.yml
+++ b/Resources/Prototypes/_Floof/Entities/Objects/Fun/toys.yml
@@ -428,6 +428,8 @@
     color: white
     selectableColor: true
     capacity: 500
+  - type: Food
+    utensilRequired: true # I ate my fucking paintbrush
   - type: SolutionContainerManager
     solutions:
       food:


### PR DESCRIPTION
# Description
I ate my fucking paintbrush.

# Changelog
:cl:
- fix: You can no longer eat paintbrushes. At least not without using a utensil.