### PR TITLE
Added Oni Snout/Tail Customizations

### DIFF
--- a/Resources/Prototypes/DeltaV/Entities/Mobs/Customization/Markings/felinid.yml
+++ b/Resources/Prototypes/DeltaV/Entities/Mobs/Customization/Markings/felinid.yml
@@ -2,7 +2,7 @@
   id: FelinidFluffyTailRings
   bodyPart: Tail
   markingCategory: Tail
-  speciesRestriction: [Felinid, SlimePerson, Human, Rodentia, Vulpkanin]
+  speciesRestriction: [Felinid, SlimePerson, Human, Rodentia, Vulpkanin, Oni]
   sprites:
   - sprite: DeltaV/Mobs/Customization/Felinid/felinid_tails.rsi
     state: Felinid_fluffy_tail_full
@@ -13,7 +13,7 @@
   id: FelinidFluffyTail
   bodyPart: Tail
   markingCategory: Tail
-  speciesRestriction: [Felinid, SlimePerson, Human, Rodentia, Vulpkanin]
+  speciesRestriction: [Felinid, SlimePerson, Human, Rodentia, Vulpkanin, Oni]
   sprites:
   - sprite: DeltaV/Mobs/Customization/Felinid/felinid_tails.rsi
     state: Felinid_fluffy_tail_full
@@ -22,7 +22,7 @@
   id: FelinidAlternativeTail
   bodyPart: Tail
   markingCategory: Tail
-  speciesRestriction: [Felinid, SlimePerson, Human, Rodentia, Vulpkanin]
+  speciesRestriction: [Felinid, SlimePerson, Human, Rodentia, Vulpkanin, Oni]
   sprites:
     - sprite: DeltaV/Mobs/Customization/Felinid/alternative_tail.rsi
       state: m_waggingtail_cat_FRONT

--- a/Resources/Prototypes/DeltaV/Entities/Mobs/Customization/Markings/rodentia.yml
+++ b/Resources/Prototypes/DeltaV/Entities/Mobs/Customization/Markings/rodentia.yml
@@ -283,7 +283,7 @@
   id: RodentiaTailBeaver
   markingCategory: Tail
   bodyPart: Tail
-  speciesRestriction: [Rodentia, SlimePerson, Human, Harpy, IPC, Felinid, Vulpkanin]
+  speciesRestriction: [Rodentia, SlimePerson, Human, Harpy, IPC, Felinid, Vulpkanin, Oni]
   sprites:
     - sprite: DeltaV/Mobs/Customization/Rodentia/tail_markings.rsi
       state: beaver
@@ -292,7 +292,7 @@
   id: RodentiaTailHamster
   markingCategory: Tail
   bodyPart: Tail
-  speciesRestriction: [Rodentia, SlimePerson, Human, Harpy, IPC, Felinid, Vulpkanin]
+  speciesRestriction: [Rodentia, SlimePerson, Human, Harpy, IPC, Felinid, Vulpkanin, Oni]
   sprites:
     - sprite: DeltaV/Mobs/Customization/Rodentia/tail_markings.rsi
       state: hamster
@@ -301,7 +301,7 @@
   id: RodentiaTailLong
   markingCategory: Tail
   bodyPart: Tail
-  speciesRestriction: [Rodentia, SlimePerson, Human, Harpy, IPC, Felinid, Vulpkanin]
+  speciesRestriction: [Rodentia, SlimePerson, Human, Harpy, IPC, Felinid, Vulpkanin, Oni]
   sprites:
     - sprite: DeltaV/Mobs/Customization/Rodentia/tail_markings.rsi
       state: long
@@ -310,7 +310,7 @@
   id: RodentiaTailLongCounter
   markingCategory: Tail
   bodyPart: Tail
-  speciesRestriction: [Rodentia, SlimePerson, Human, Harpy, IPC, Felinid, Vulpkanin]
+  speciesRestriction: [Rodentia, SlimePerson, Human, Harpy, IPC, Felinid, Vulpkanin, Oni]
   sprites:
     - sprite: DeltaV/Mobs/Customization/Rodentia/tail_markings.rsi
       state: long
@@ -321,7 +321,7 @@
   id: RodentiaTailLongCounterTip
   markingCategory: Tail
   bodyPart: Tail
-  speciesRestriction: [Rodentia, SlimePerson, Human, Harpy, IPC, Felinid, Vulpkanin]
+  speciesRestriction: [Rodentia, SlimePerson, Human, Harpy, IPC, Felinid, Vulpkanin, Oni]
   sprites:
     - sprite: DeltaV/Mobs/Customization/Rodentia/tail_markings.rsi
       state: long
@@ -334,7 +334,7 @@
   id: RodentiaTailMouse
   markingCategory: Tail
   bodyPart: Tail
-  speciesRestriction: [Rodentia, SlimePerson, Human, Harpy, IPC, Felinid, Vulpkanin]
+  speciesRestriction: [Rodentia, SlimePerson, Human, Harpy, IPC, Felinid, Vulpkanin, Oni]
   sprites:
     - sprite: DeltaV/Mobs/Customization/Rodentia/tail_markings.rsi
       state: mouse
@@ -343,7 +343,7 @@
   id: RodentiaTailRabbit
   markingCategory: Tail
   bodyPart: Tail
-  speciesRestriction: [Rodentia, SlimePerson, Human, Harpy, IPC, Felinid, Vulpkanin]
+  speciesRestriction: [Rodentia, SlimePerson, Human, Harpy, IPC, Felinid, Vulpkanin, Oni]
   sprites:
     - sprite: DeltaV/Mobs/Customization/Rodentia/tail_markings.rsi
       state: rabbit
@@ -352,7 +352,7 @@
   id: RodentiaTailRabbitCounter
   markingCategory: Tail
   bodyPart: Tail
-  speciesRestriction: [Rodentia, SlimePerson, Human, Harpy, IPC, Felinid, Vulpkanin]
+  speciesRestriction: [Rodentia, SlimePerson, Human, Harpy, IPC, Felinid, Vulpkanin, Oni]
   sprites:
     - sprite: DeltaV/Mobs/Customization/Rodentia/tail_markings.rsi
       state: rabbit
@@ -363,7 +363,7 @@
   id: RodentiaTailShort
   markingCategory: Tail
   bodyPart: Tail
-  speciesRestriction: [Rodentia, SlimePerson, Human, Harpy, IPC, Felinid, Vulpkanin]
+  speciesRestriction: [Rodentia, SlimePerson, Human, Harpy, IPC, Felinid, Vulpkanin, Oni]
   sprites:
     - sprite: DeltaV/Mobs/Customization/Rodentia/tail_markings.rsi
       state: short
@@ -372,7 +372,7 @@
   id: RodentiaTailSquirrel
   markingCategory: Tail
   bodyPart: Tail
-  speciesRestriction: [Rodentia, SlimePerson, Human, Harpy, IPC, Felinid, Vulpkanin]
+  speciesRestriction: [Rodentia, SlimePerson, Human, Harpy, IPC, Felinid, Vulpkanin, Oni]
   sprites:
     - sprite: DeltaV/Mobs/Customization/Rodentia/tail_markings.rsi
       state: squirrel
@@ -381,7 +381,7 @@
   id: RodentiaTailSquirrelBicolor
   markingCategory: Tail
   bodyPart: Tail
-  speciesRestriction: [Rodentia, SlimePerson, Human, Harpy, IPC, Felinid, Vulpkanin]
+  speciesRestriction: [Rodentia, SlimePerson, Human, Harpy, IPC, Felinid, Vulpkanin, Oni]
   sprites:
     - sprite: DeltaV/Mobs/Customization/Rodentia/tail_markings.rsi
       state: squirrel

--- a/Resources/Prototypes/Entities/Mobs/Customization/Markings/cat_parts.yml
+++ b/Resources/Prototypes/Entities/Mobs/Customization/Markings/cat_parts.yml
@@ -25,7 +25,7 @@
   id: CatTail
   bodyPart: Tail
   markingCategory: Tail
-  speciesRestriction: [Human, SlimePerson]
+  speciesRestriction: [Human, SlimePerson, Oni]
   coloring:
     default:
       type:

--- a/Resources/Prototypes/Entities/Mobs/Customization/Markings/kemonomimi_tails.yml
+++ b/Resources/Prototypes/Entities/Mobs/Customization/Markings/kemonomimi_tails.yml
@@ -2,7 +2,7 @@
   id: BunnyTail
   bodyPart: Tail
   markingCategory: Tail
-  speciesRestriction: [Human, SlimePerson, Vulpkanin]
+  speciesRestriction: [Human, SlimePerson, Vulpkanin, Oni]
   coloring:
     default:
       type:
@@ -20,7 +20,7 @@
   id: DobleFur
   bodyPart: Tail
   markingCategory: Tail
-  speciesRestriction: [Human, SlimePerson, Vulpkanin]
+  speciesRestriction: [Human, SlimePerson, Vulpkanin, Oni]
   coloring:
     default:
       type:
@@ -40,7 +40,7 @@
   id: FluffyTail
   bodyPart: Tail
   markingCategory: Tail
-  speciesRestriction: [Human, SlimePerson, Vulpkanin]
+  speciesRestriction: [Human, SlimePerson, Vulpkanin, Oni]
   coloring:
     default:
       type:
@@ -58,7 +58,7 @@
   id: FoxNineTails
   bodyPart: Tail
   markingCategory: Tail
-  speciesRestriction: [Human, SlimePerson, Vulpkanin]
+  speciesRestriction: [Human, SlimePerson, Vulpkanin, Oni]
   coloring:
     default:
       type:
@@ -78,7 +78,7 @@
   id: FoxThreeTails
   bodyPart: Tail
   markingCategory: Tail
-  speciesRestriction: [Human, SlimePerson, Vulpkanin]
+  speciesRestriction: [Human, SlimePerson, Vulpkanin, Oni]
   coloring:
     default:
       type:
@@ -98,7 +98,7 @@
   id: HorseTailCulty
   bodyPart: Tail
   markingCategory: Tail
-  speciesRestriction: [Human, SlimePerson, Vulpkanin]
+  speciesRestriction: [Human, SlimePerson, Vulpkanin, Oni]
   coloring:
     default:
       type:
@@ -116,7 +116,7 @@
   id: HorseTailLong
   bodyPart: Tail
   markingCategory: Tail
-  speciesRestriction: [Human, SlimePerson, Vulpkanin]
+  speciesRestriction: [Human, SlimePerson, Vulpkanin, Oni]
   coloring:
     default:
       type:
@@ -134,7 +134,7 @@
   id: SharkTail
   bodyPart: Tail
   markingCategory: Tail
-  speciesRestriction: [Human, SlimePerson, Vulpkanin, Reptilian]
+  speciesRestriction: [Human, SlimePerson, Vulpkanin, Reptilian, Oni]
   coloring:
     default:
       type:
@@ -152,7 +152,7 @@
   id: TasselTail
   bodyPart: Tail
   markingCategory: Tail
-  speciesRestriction: [Human, SlimePerson, Vulpkanin]
+  speciesRestriction: [Human, SlimePerson, Vulpkanin, Oni]
   coloring:
     default:
       type:

--- a/Resources/Prototypes/_Floof/Entities/Mobs/Customization/Markings/anthro.yml
+++ b/Resources/Prototypes/_Floof/Entities/Mobs/Customization/Markings/anthro.yml
@@ -5,7 +5,7 @@
   id: SnoutCanidAlt2
   bodyPart: Snout
   markingCategory: Snout
-  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid]
+  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni]
   sprites:
   - sprite: _Floof/Mobs/Customization/skyratsnouts.rsi
     state: snout_canid_alt2
@@ -14,7 +14,7 @@
 #  id: SnoutCanidAlt
 #  bodyPart: Snout
 #  markingCategory: Snout
-#  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid]
+#  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni]
 #  sprites:
 #  - sprite: _Floof/Mobs/Customization/skyratsnouts.rsi
 #    state: snout_canid_alt
@@ -25,7 +25,7 @@
   id: SnoutFLCanid
   bodyPart: Snout
   markingCategory: Snout
-  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid]
+  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni]
   sprites:
   - sprite: _Floof/Mobs/Customization/skyratsnouts.rsi
     state: snout_flcanid_primary
@@ -36,7 +36,7 @@
   id: SnoutLCanid
   bodyPart: Snout
   markingCategory: Snout
-  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid]
+  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni]
   sprites:
   - sprite: _Floof/Mobs/Customization/skyratsnouts.rsi
     state: snout_lcanid_primary
@@ -47,7 +47,7 @@
   id: SnoutFLCanidAlt
   bodyPart: Snout
   markingCategory: Snout
-  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid]
+  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni]
   sprites:
   - sprite: _Floof/Mobs/Customization/skyratsnouts.rsi
     state: snout_flcanidalt_primary
@@ -56,7 +56,7 @@
   id: SnoutFLCanidStripe
   bodyPart: Snout
   markingCategory: Snout
-  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid]
+  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni]
   sprites:
   - sprite: _Floof/Mobs/Customization/skyratsnouts.rsi
     state: snout_flcanidstripe_primary
@@ -67,7 +67,7 @@
   id: SnoutLCanidStripe
   bodyPart: Snout
   markingCategory: Snout
-  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid]
+  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni]
   sprites:
   - sprite: _Floof/Mobs/Customization/skyratsnouts.rsi
     state: snout_lcanidstripe_primary
@@ -78,7 +78,7 @@
   id: SnoutFLCanidStripeAlt
   bodyPart: Snout
   markingCategory: Snout
-  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid]
+  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni]
   sprites:
   - sprite: _Floof/Mobs/Customization/skyratsnouts.rsi
     state: snout_flcanidstripealt_primary
@@ -89,7 +89,7 @@
   id: SnoutLCanidStripeAlt
   bodyPart: Snout
   markingCategory: Snout
-  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid]
+  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni]
   sprites:
   - sprite: _Floof/Mobs/Customization/skyratsnouts.rsi
     state: snout_lcanidstripealt_primary
@@ -100,7 +100,7 @@
 #  id: SnoutFHusky
 #  bodyPart: Snout
 #  markingCategory: Snout
-#  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid]
+#  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni]
 #  sprites:
 #  - sprite: _Floof/Mobs/Customization/skyratsnouts.rsi
 #    state: snout_fhusky_primary
@@ -111,7 +111,7 @@
   id: SnoutHusky
   bodyPart: Snout
   markingCategory: Snout
-  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid]
+  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni]
   sprites:
   - sprite: _Floof/Mobs/Customization/skyratsnouts.rsi
     state: snout_husky_primary
@@ -122,7 +122,7 @@
 #  id: SnoutFWolf
 #  bodyPart: Snout
 #  markingCategory: Snout
-#  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid]
+#  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni]
 #  sprites:
 #  - sprite: _Floof/Mobs/Customization/skyratsnouts.rsi
 #    state: snout_fwolf_primary
@@ -133,7 +133,7 @@
   id: SnoutWolf
   bodyPart: Snout
   markingCategory: Snout
-  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid]
+  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni]
   sprites:
   - sprite: _Floof/Mobs/Customization/skyratsnouts.rsi
     state: snout_wolf_primary
@@ -144,7 +144,7 @@
 #  id: SnoutFWolfAlt
 #  bodyPart: Snout
 #  markingCategory: Snout
-#  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid]
+#  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni]
 #  sprites:
 #  - sprite: _Floof/Mobs/Customization/skyratsnouts.rsi
 #    state: snout_fwolfalt_primary
@@ -153,7 +153,7 @@
   id: SnoutWolfAlt
   bodyPart: Snout
   markingCategory: Snout
-  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid]
+  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni]
   sprites:
   - sprite: _Floof/Mobs/Customization/skyratsnouts.rsi
     state: snout_wolfalt_primary
@@ -162,7 +162,7 @@
   id: SnoutFSCanid
   bodyPart: Snout
   markingCategory: Snout
-  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid]
+  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni]
   sprites:
   - sprite: _Floof/Mobs/Customization/skyratsnouts.rsi
     state: snout_fscanid_primary
@@ -173,7 +173,7 @@
   id: SnoutSCanid
   bodyPart: Snout
   markingCategory: Snout
-  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid]
+  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni]
   sprites:
   - sprite: _Floof/Mobs/Customization/skyratsnouts.rsi
     state: snout_scanid_primary
@@ -184,7 +184,7 @@
 #  id: SnoutFSCanidAlt
 #  bodyPart: Snout
 #  markingCategory: Snout
-#  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid]
+#  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni]
 #  sprites:
 #  - sprite: _Floof/Mobs/Customization/skyratsnouts.rsi
 #    state: snout_fscanidalt_primary
@@ -195,7 +195,7 @@
 #  id: SnoutFSCanidAlt2
 #  bodyPart: Snout
 #  markingCategory: Snout
-#  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid]
+#  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni]
 #  sprites:
 #  - sprite: _Floof/Mobs/Customization/skyratsnouts.rsi
 #    state: snout_fscanidalt2_primary
@@ -204,7 +204,7 @@
 #  id: SnoutFSCanidAlt3
 #  bodyPart: Snout
 #  markingCategory: Snout
-#  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid]
+#  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni]
 #  sprites:
 #  - sprite: _Floof/Mobs/Customization/skyratsnouts.rsi
 #    state: snout_fscanidalt3_primary
@@ -215,7 +215,7 @@
   id: SnoutSCanidAlt3
   bodyPart: Snout
   markingCategory: Snout
-  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid]
+  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni]
   sprites:
   - sprite: _Floof/Mobs/Customization/skyratsnouts.rsi
     state: snout_scanidalt3_primary
@@ -228,7 +228,7 @@
   id: SnoutRound
   bodyPart: Snout
   markingCategory: Snout
-  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid]
+  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni]
   sprites:
   - sprite: _Floof/Mobs/Customization/skyratsnouts.rsi
     state: snout_round
@@ -237,7 +237,7 @@
   id: SnoutSharp
   bodyPart: Snout
   markingCategory: Snout
-  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid]
+  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni]
   sprites:
   - sprite: _Floof/Mobs/Customization/skyratsnouts.rsi
     state: snout_sharp
@@ -246,7 +246,7 @@
   id: SnoutRoundLight
   bodyPart: Snout
   markingCategory: Snout
-  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid]
+  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni]
   sprites:
   - sprite: _Floof/Mobs/Customization/skyratsnouts.rsi
     state: snout_roundlight
@@ -255,7 +255,7 @@
   id: SnoutSharpLight
   bodyPart: Snout
   markingCategory: Snout
-  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid]
+  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni]
   sprites:
   - sprite: _Floof/Mobs/Customization/skyratsnouts.rsi
     state: snout_sharplight
@@ -266,7 +266,7 @@
 #  id: SnoutFBird
 #  bodyPart: Snout
 #  markingCategory: Snout
-#  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid]
+#  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni]
 #  sprites:
 #  - sprite: _Floof/Mobs/Customization/skyratsnouts.rsi
 #    state: snout_fbird_primary
@@ -279,7 +279,7 @@
   id: SnoutBird
   bodyPart: Snout
   markingCategory: Snout
-  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid]
+  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni]
   sprites:
   - sprite: _Floof/Mobs/Customization/skyratsnouts.rsi
     state: snout_bird_primary
@@ -292,7 +292,7 @@
 #  id: SnoutFBigBeak
 #  bodyPart: Snout
 #  markingCategory: Snout
-#  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid]
+#  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni]
 #  sprites:
 #  - sprite: _Floof/Mobs/Customization/skyratsnouts.rsi
 #    state: snout_fbigbeak_primary
@@ -301,7 +301,7 @@
   id: SnoutBigBeak
   bodyPart: Snout
   markingCategory: Snout
-  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid]
+  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni]
   sprites:
   - sprite: _Floof/Mobs/Customization/skyratsnouts.rsi
     state: snout_bigbeak_primary
@@ -310,7 +310,7 @@
 #  id: SnoutFCorvidBeak
 #  bodyPart: Snout
 #  markingCategory: Snout
-#  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid]
+#  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni]
 #  sprites:
 #  - sprite: _Floof/Mobs/Customization/skyratsnouts.rsi
 #    state: snout_fcorvidbeak_primary
@@ -319,7 +319,7 @@
 #  id: SnoutFToucan
 #  bodyPart: Snout
 #  markingCategory: Snout
-#  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid]
+#  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni]
 #  sprites:
 #  - sprite: _Floof/Mobs/Customization/skyratsnouts.rsi
 #    state: snout_ftoucan_primary
@@ -330,7 +330,7 @@
   id: SnoutToucan
   bodyPart: Snout
   markingCategory: Snout
-  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid]
+  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni]
   sprites:
   - sprite: _Floof/Mobs/Customization/skyratsnouts.rsi
     state: snout_toucan_primary
@@ -341,7 +341,7 @@
   id: SnoutBirdSmall
   bodyPart: Snout
   markingCategory: Snout
-  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid]
+  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni]
   sprites:
   - sprite: _Floof/Mobs/Customization/skyratsnouts.rsi
     state: snout_birdsmall_primary
@@ -354,7 +354,7 @@
   id: SnoutBigBeakShort
   bodyPart: Snout
   markingCategory: Snout
-  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid]
+  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni]
   sprites:
   - sprite: _Floof/Mobs/Customization/skyratsnouts.rsi
     state: snout_bigbeakshort_primary
@@ -363,7 +363,7 @@
   id: SnoutSlimBeak
   bodyPart: Snout
   markingCategory: Snout
-  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid]
+  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni]
   sprites:
   - sprite: _Floof/Mobs/Customization/skyratsnouts.rsi
     state: snout_slimbeak_primary
@@ -372,7 +372,7 @@
   id: SnoutSlimBeakAlt
   bodyPart: Snout
   markingCategory: Snout
-  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid]
+  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni]
   sprites:
   - sprite: _Floof/Mobs/Customization/skyratsnouts.rsi
     state: snout_slimbeakalt_primary
@@ -381,7 +381,7 @@
   id: SnoutSlimBeakShort
   bodyPart: Snout
   markingCategory: Snout
-  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid]
+  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni]
   sprites:
   - sprite: _Floof/Mobs/Customization/skyratsnouts.rsi
     state: snout_slimbeakshort_primary
@@ -390,7 +390,7 @@
   id: SnoutHookBeak
   bodyPart: Snout
   markingCategory: Snout
-  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid]
+  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni]
   sprites:
   - sprite: _Floof/Mobs/Customization/skyratsnouts.rsi
     state: snout_hookbeak_primary
@@ -399,7 +399,7 @@
   id: SnoutHookBeakBig
   bodyPart: Snout
   markingCategory: Snout
-  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid]
+  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni]
   sprites:
   - sprite: _Floof/Mobs/Customization/skyratsnouts.rsi
     state: snout_hookbeakbig_primary
@@ -410,7 +410,7 @@
 #  id: SnoutFWah
 #  bodyPart: Snout
 #  markingCategory: Snout
-#  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid]
+#  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni]
 #  sprites:
 #  - sprite: _Floof/Mobs/Customization/skyratsnouts.rsi
 #    state:  snout_fwah_primary
@@ -423,7 +423,7 @@
   id: SnoutWah
   bodyPart: Snout
   markingCategory: Snout
-  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid]
+  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni]
   sprites:
   - sprite: _Floof/Mobs/Customization/skyratsnouts.rsi
     state:  snout_wah_primary
@@ -436,7 +436,7 @@
 #  id: SnoutFWahAlt
 #  bodyPart: Snout
 #  markingCategory: Snout
-#  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid]
+#  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni]
 #  sprites:
 #  - sprite: _Floof/Mobs/Customization/skyratsnouts.rsi
 #    state:  snout_fwahalt_primary
@@ -447,7 +447,7 @@
   id: SnoutWahAlt
   bodyPart: Snout
   markingCategory: Snout
-  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid]
+  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni]
   sprites:
   - sprite: _Floof/Mobs/Customization/skyratsnouts.rsi
     state:  snout_wahalt_primary
@@ -458,7 +458,7 @@
 #  id: SnoutFOtie
 #  bodyPart: Snout
 #  markingCategory: Snout
-#  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid]
+#  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni]
 #  sprites:
 #  - sprite: _Floof/Mobs/Customization/skyratsnouts.rsi
 #    state:  snout_fotie_primary
@@ -469,7 +469,7 @@
   id: SnoutOtie
   bodyPart: Snout
   markingCategory: Snout
-  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid]
+  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni]
   sprites:
   - sprite: _Floof/Mobs/Customization/skyratsnouts.rsi
     state:  snout_otie_primary
@@ -480,7 +480,7 @@
 #  id: SnoutFOtieSmile
 #  bodyPart: Snout
 #  markingCategory: Snout
-#  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid]
+#  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni]
 #  sprites:
 #  - sprite: _Floof/Mobs/Customization/skyratsnouts.rsi
 #    state:  snout_fotiesmile_primary
@@ -491,7 +491,7 @@
   id: SnoutOtieSmile
   bodyPart: Snout
   markingCategory: Snout
-  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid]
+  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni]
   sprites:
   - sprite: _Floof/Mobs/Customization/skyratsnouts.rsi
     state:  snout_otiesmile_primary
@@ -502,7 +502,7 @@
 #  id: SnoutFPede
 #  bodyPart: Snout
 #  markingCategory: Snout
-#  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid]
+#  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni]
 #  sprites:
 #  - sprite: _Floof/Mobs/Customization/skyratsnouts.rsi
 #    state:  snout_fpede_primary
@@ -513,7 +513,7 @@
   id: SnoutPede
   bodyPart: Snout
   markingCategory: Snout
-  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid]
+  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni]
   sprites:
   - sprite: _Floof/Mobs/Customization/skyratsnouts.rsi
     state:  snout_pede_primary
@@ -524,7 +524,7 @@
 #  id: SnoutFRodent
 #  bodyPart: Snout
 #  markingCategory: Snout
-#  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid]
+#  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni]
 #  sprites:
 #  - sprite: _Floof/Mobs/Customization/skyratsnouts.rsi
 #    state:  snout_frodent_primary
@@ -533,7 +533,7 @@
   id: SnoutRodent
   bodyPart: Snout
   markingCategory: Snout
-  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid]
+  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni]
   sprites:
   - sprite: _Floof/Mobs/Customization/skyratsnouts.rsi
     state:  snout_rodent_primary
@@ -542,7 +542,7 @@
 #  id: SnoutFSergal
 #  bodyPart: Snout
 #  markingCategory: Snout
-#  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid]
+#  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni]
 #  sprites:
 #  - sprite: _Floof/Mobs/Customization/skyratsnouts.rsi
 #    state:  snout_fsergal_primary
@@ -553,7 +553,7 @@
 #  id: SnoutFRhino
 #  bodyPart: Snout
 #  markingCategory: Snout
-#  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid]
+#  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni]
 #  sprites:
 #  - sprite: _Floof/Mobs/Customization/skyratsnouts.rsi
 #    state:  snout_frhino_primary
@@ -564,7 +564,7 @@
   id: SnoutRhino
   bodyPart: Snout
   markingCategory: Snout
-  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid]
+  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni]
   sprites:
   - sprite: _Floof/Mobs/Customization/skyratsnouts.rsi
     state:  snout_rhino_primary
@@ -577,7 +577,7 @@
 #  id: SnoutFBovine
 #  bodyPart: Snout
 #  markingCategory: Snout
-#  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid]
+#  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni]
 #  sprites:
 #  - sprite: _Floof/Mobs/Customization/skyratsnouts.rsi
 #    state:  snout_fbovine_primary
@@ -590,7 +590,7 @@
   id: SnoutBovine
   bodyPart: Snout
   markingCategory: Snout
-  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid]
+  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni]
   sprites:
   - sprite: _Floof/Mobs/Customization/skyratsnouts.rsi
     state:  snout_bovine_primary
@@ -603,7 +603,7 @@
 #  id: SnoutFElephant
 #  bodyPart: Snout
 #  markingCategory: Snout
-#  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid]
+#  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni]
 #  sprites:
 #  - sprite: _Floof/Mobs/Customization/skyratsnouts.rsi
 #    state:  snout_felephant_primary
@@ -614,7 +614,7 @@
   id: SnoutElephant
   bodyPart: Snout
   markingCategory: Snout
-  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid]
+  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni]
   sprites:
   - sprite: _Floof/Mobs/Customization/skyratsnouts.rsi
     state:  snout_elephant_primary
@@ -625,7 +625,7 @@
 #  id: SnoutFRound
 #  bodyPart: Snout
 #  markingCategory: Snout
-#  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid]
+#  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni]
 #  sprites:
 #  - sprite: _Floof/Mobs/Customization/skyratsnouts.rsi
 #    state:  snout_fround
@@ -634,7 +634,7 @@
 #  id: SnoutFSharpLight
 #  bodyPart: Snout
 #  markingCategory: Snout
-#  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid]
+#  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni]
 #  sprites:
 #  - sprite: _Floof/Mobs/Customization/skyratsnouts.rsi
 #    state:  snout_fsharplight
@@ -643,7 +643,7 @@
 #  id: SnoutFRoundLight
 #  bodyPart: Snout
 #  markingCategory: Snout
-#  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid]
+#  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni]
 #  sprites:
 #  - sprite: _Floof/Mobs/Customization/skyratsnouts.rsi
 #    state:  snout_froundlight
@@ -652,7 +652,7 @@
 #  id: SnoutFShark
 #  bodyPart: Snout
 #  markingCategory: Snout
-#  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid]
+#  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni]
 #  sprites:
 #  - sprite: _Floof/Mobs/Customization/skyratsnouts.rsi
 #    state:  snout_fshark_primary
@@ -661,7 +661,7 @@
   id: SnoutShark
   bodyPart: Snout
   markingCategory: Snout
-  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid]
+  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni]
   sprites:
   - sprite: _Floof/Mobs/Customization/skyratsnouts.rsi
     state:  snout_shark_primary
@@ -670,7 +670,7 @@
   id: SnoutHShark
   bodyPart: Snout
   markingCategory: Snout
-  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid]
+  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni]
   sprites:
   - sprite: _Floof/Mobs/Customization/skyratsnouts.rsi
     state:  snout_hshark_primary
@@ -681,7 +681,7 @@
   id: SnoutHSharkEyes
   bodyPart: Snout
   markingCategory: Snout
-  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid]
+  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni]
   sprites:
   - sprite: _Floof/Mobs/Customization/skyratsnouts.rsi
     state:  snout_hshark_eyes_primary
@@ -692,7 +692,7 @@
 #  id: SnoutFBug
 #  bodyPart: Snout
 #  markingCategory: Snout
-#  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid]
+#  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni]
 #  colorLinks:
 #    snout_fbug_FRONT_primary: snout_fbug_primary
 #  sprites:
@@ -707,7 +707,7 @@
   id: SnoutBug
   bodyPart: Snout
   markingCategory: Snout
-  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid]
+  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni]
   sprites:
   - sprite: _Floof/Mobs/Customization/skyratsnouts.rsi
     state:  snout_bug_primary
@@ -718,7 +718,7 @@
   id: SnoutBugNoEyes
   bodyPart: Snout
   markingCategory: Snout
-  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid]
+  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni]
   sprites:
   - sprite: _Floof/Mobs/Customization/skyratsnouts.rsi
     state:  snout_bug_no_eyes
@@ -727,7 +727,7 @@
   id: SnoutSergal
   bodyPart: Snout
   markingCategory: Snout
-  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid]
+  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni]
   sprites:
   - sprite: _Floof/Mobs/Customization/skyratsnouts.rsi
     state:  snout_sergal_primary
@@ -738,7 +738,7 @@
   id: SnoutHHorse
   bodyPart: Snout
   markingCategory: Snout
-  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid]
+  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni]
   sprites:
   - sprite: _Floof/Mobs/Customization/skyratsnouts.rsi
     state:  snout_hhorse_primary
@@ -749,7 +749,7 @@
   id: SnoutHZebra
   bodyPart: Snout
   markingCategory: Snout
-  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid]
+  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni]
   sprites:
   - sprite: _Floof/Mobs/Customization/skyratsnouts.rsi
     state:  snout_hzebra_primary
@@ -760,7 +760,7 @@
   id: SnoutHAnubus
   bodyPart: Snout
   markingCategory: Snout
-  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid]
+  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni]
   sprites:
   - sprite: _Floof/Mobs/Customization/skyratsnouts.rsi
     state:  snout_hanubus_primary
@@ -771,7 +771,7 @@
   id: SnoutHPanda
   bodyPart: Snout
   markingCategory: Snout
-  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid]
+  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni]
   sprites:
   - sprite: _Floof/Mobs/Customization/skyratsnouts.rsi
     state:  snout_hpanda_primary
@@ -782,7 +782,7 @@
   id: SnoutHJackal
   bodyPart: Snout
   markingCategory: Snout
-  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid]
+  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni]
   sprites:
   - sprite: _Floof/Mobs/Customization/skyratsnouts.rsi
     state:  snout_hjackal_primary
@@ -793,7 +793,7 @@
   id: SnoutHSpots
   bodyPart: Snout
   markingCategory: Snout
-  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid]
+  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni]
   sprites:
   - sprite: _Floof/Mobs/Customization/skyratsnouts.rsi
     state: snout_hspots_primary
@@ -804,7 +804,7 @@
 #  id: SnoutFSkulldog
 #  bodyPart: Snout
 #  markingCategory: Snout
-#  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid]
+#  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni]
 #  sprites:
 #  - sprite: _Floof/Mobs/Customization/skyratsnouts.rsi
 #    state: snout_fskulldog_primary
@@ -817,7 +817,7 @@
   id: SnoutSkulldog
   bodyPart: Snout
   markingCategory: Snout
-  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid]
+  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni]
   sprites:
   - sprite: _Floof/Mobs/Customization/skyratsnouts.rsi
     state: snout_skulldog_primary
@@ -830,7 +830,7 @@
   id: SnoutSharkBlubber
   bodyPart: Snout
   markingCategory: Snout
-  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid]
+  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni]
   sprites:
   - sprite: _Floof/Mobs/Customization/skyratsnouts.rsi
     state: snout_sharkblubber_primary
@@ -841,7 +841,7 @@
   id: SnoutRat
   bodyPart: Snout
   markingCategory: Snout
-  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid]
+  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni]
   sprites:
   - sprite: _Floof/Mobs/Customization/skyratsnouts.rsi
     state: snout_rat_primary
@@ -852,7 +852,7 @@
   id: SnoutNTajaran
   bodyPart: Snout
   markingCategory: Snout
-  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid]
+  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni]
   sprites:
   - sprite: _Floof/Mobs/Customization/skyratsnouts.rsi
     state: snout_ntajaran
@@ -861,7 +861,7 @@
   id: SnoutStubby
   bodyPart: Snout
   markingCategory: Snout
-  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid]
+  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni]
   sprites:
   - sprite: _Floof/Mobs/Customization/skyratsnouts.rsi
     state: snout_stubby_primary
@@ -872,7 +872,7 @@
   id: SnoutLeporid
   bodyPart: Snout
   markingCategory: Snout
-  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid]
+  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni]
   sprites:
   - sprite: _Floof/Mobs/Customization/skyratsnouts.rsi
     state: snout_leporid_primary

--- a/Resources/Prototypes/_Floof/Entities/Mobs/Customization/Markings/anthro_tails.yml
+++ b/Resources/Prototypes/_Floof/Entities/Mobs/Customization/Markings/anthro_tails.yml
@@ -4,7 +4,7 @@
   id: TailFox
   bodyPart: Tail
   markingCategory: Tail
-  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid]
+  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni]
   sprites:
   - sprite: _Floof/Mobs/Customization/skyrattails.rsi
     state: tail_fox_secondary
@@ -15,7 +15,7 @@
   id: Tail9sune
   bodyPart: Tail
   markingCategory: Tail
-  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid]
+  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni]
   layering:
     m_tail_9sune_BEHIND_primary: TailBehind
     m_tail_9sune_BEHIND_secondary: TailBehind
@@ -39,7 +39,7 @@
   id: TailAvian1
   bodyPart: Tail
   markingCategory: Tail
-  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid]
+  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni]
   layering:
     m_tail_avian1_BEHIND_primary: TailBehind
     m_tail_avian1_BEHIND_secondary: TailBehind
@@ -63,7 +63,7 @@
   id: TailAvian2
   bodyPart: Tail
   markingCategory: Tail
-  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid]
+  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni]
   layering:
     m_tail_avian2_BEHIND_primary: TailBehind
     m_tail_avian2_BEHIND_secondary: TailBehind
@@ -86,7 +86,7 @@
   id: TailBatl
   bodyPart: Tail
   markingCategory: Tail
-  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid]
+  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni]
   layering:
     m_tail_batl_BEHIND_primary: TailBehind
     m_tail_batl_BEHIND_secondary: TailBehind
@@ -109,7 +109,7 @@
   id: TailBats
   bodyPart: Tail
   markingCategory: Tail
-  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid]
+  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni]
   layering:
     m_tail_bats_BEHIND_primary: TailBehind
     m_tail_bats_BEHIND_secondary: TailBehind
@@ -140,7 +140,7 @@
   colorLinks:
     m_tail_bee_BEHIND_primary: m_tail_bee_FRONT_primary
     m_tail_bee_BEHIND_secondary: m_tail_bee_FRONT_secondary
-  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid]
+  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni]
   sprites:
   - sprite: _Floof/Mobs/Customization/skyrattails.rsi
     state: m_tail_bee_FRONT_primary
@@ -156,7 +156,7 @@
   id: TailCable
   bodyPart: Tail
   markingCategory: Tail
-  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid]
+  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni]
   layering:
     m_tail_cable_BEHIND_primary: TailBehind
     m_tail_cable_BEHIND_secondary: TailBehind
@@ -175,7 +175,7 @@
   id: TailCat
   bodyPart: Tail
   markingCategory: Tail
-  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid]
+  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni]
   layering:
     m_tail_cat_BEHIND: TailBehind
     m_tail_cat_FRONT: Tail #should go over backpack!
@@ -191,7 +191,7 @@
   id: TailCatBig
   bodyPart: Tail
   markingCategory: Tail
-  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid]
+  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni]
   layering:
     m_tail_catbig_BEHIND: TailBehind
     m_tail_catbig_FRONT: TailOversuit
@@ -207,7 +207,7 @@
   id: TailCow
   bodyPart: Tail
   markingCategory: Tail
-  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid]
+  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni]
   layering:
     m_tail_cow_BEHIND_primary: TailBehind
     m_tail_cow_FRONT_primary: TailOversuit
@@ -223,7 +223,7 @@
   id: TailCrow
   bodyPart: Tail
   markingCategory: Tail
-  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid]
+  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni]
   layering:
     m_tail_crow_BEHIND_primary: TailBehind
     m_tail_crow_FRONT_primary: TailOversuit
@@ -240,7 +240,7 @@
 #  id: TailDatashark
 #  bodyPart: Tail
 #  markingCategory: Tail
-#  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid]
+#  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni]
 #  sprites:
 #  - sprite: _Floof/Mobs/Customization/skyrattails.rsi
 #    state: m_tail_datashark_FRONT_primary
@@ -256,7 +256,7 @@
   id: TailDeer
   bodyPart: Tail
   markingCategory: Tail
-  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid]
+  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni]
   layering:
     m_tail_deer_BEHIND_primary: TailBehind
     m_tail_deer_BEHIND_secondary: TailBehind
@@ -279,7 +279,7 @@
   id: TailDeerTwo
   bodyPart: Tail
   markingCategory: Tail
-  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid]
+  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni]
   layering:
     m_tail_deer_two_BEHIND: TailBehind
     m_tail_deer_two_FRONT: TailOversuit
@@ -296,7 +296,7 @@
   id: TailDoubleKitsune
   bodyPart: Tail
   markingCategory: Tail
-  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid]
+  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni]
   layering:
     m_tail_doublekitsune_BEHIND_primary: TailBehind
     m_tail_doublekitsune_BEHIND_secondary: TailBehind
@@ -319,7 +319,7 @@
   id: TailDTiger
   bodyPart: Tail
   markingCategory: Tail
-  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid]
+  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni]
   layering:
     m_tail_dtiger_BEHIND: TailBehind
     m_tail_dtiger_FRONT: TailOversuit
@@ -335,7 +335,7 @@
   id: TailEevee
   bodyPart: Tail
   markingCategory: Tail
-  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid]
+  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni]
   layering:
     m_tail_eevee_BEHIND_primary: TailBehind
     m_tail_eevee_BEHIND_secondary: TailBehind
@@ -358,7 +358,7 @@
   id: TailFennec
   bodyPart: Tail
   markingCategory: Tail
-  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid]
+  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni]
   layering:
     m_tail_fennec_BEHIND_primary: TailBehind
     m_tail_fennec_BEHIND_secondary: TailBehind
@@ -382,7 +382,7 @@
   id: TailFox2
   bodyPart: Tail
   markingCategory: Tail
-  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid]
+  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni]
   layering:
     m_tail_fox2_BEHIND_primary: TailBehind
     m_tail_fox2_FRONT_primary: TailOversuit
@@ -399,7 +399,7 @@
   id: TailFox3
   bodyPart: Tail
   markingCategory: Tail
-  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid]
+  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni]
   layering:
     m_tail_fox3_BEHIND_primary: TailBehind
     m_tail_fox3_FRONT_primary: TailOversuit
@@ -415,7 +415,7 @@
   id: TailGuilmon
   bodyPart: Tail
   markingCategory: Tail
-  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid]
+  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni]
   layering:
     m_tail_guilmon_BEHIND_primary: TailBehind
     m_tail_guilmon_FRONT_primary: TailOversuit
@@ -431,7 +431,7 @@
   id: TailHawk
   bodyPart: Tail
   markingCategory: Tail
-  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid]
+  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni]
   layering:
     m_tail_hawk_BEHIND_primary: TailBehind
     m_tail_hawk_BEHIND_secondary: TailBehind
@@ -454,7 +454,7 @@
   id: TailHorse
   bodyPart: Tail
   markingCategory: Tail
-  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid]
+  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni]
   layering:
     m_tail_horse_BEHIND: TailBehind
     m_tail_horse_FRONT: TailOversuit
@@ -470,7 +470,7 @@
   id: TailHusk
   bodyPart: Tail
   markingCategory: Tail
-  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid]
+  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni]
   layering:
     m_tail_husk_BEHIND_primary: TailBehind
     m_tail_husk_FRONT_primary: TailOversuit
@@ -486,7 +486,7 @@
   id: TailHusky
   bodyPart: Tail
   markingCategory: Tail
-  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid]
+  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni]
   layering:
     m_tail_husky_BEHIND_primary: TailBehind
     m_tail_husky_BEHIND_secondary: TailBehind
@@ -509,7 +509,7 @@
   id: TailInsect
   bodyPart: Tail
   markingCategory: Tail
-  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid]
+  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni]
   layering:
     m_tail_insect_BEHIND_primary: TailBehind
     m_tail_insect_FRONT_primary: TailOversuit
@@ -525,7 +525,7 @@
   id: TailKangaroo
   bodyPart: Tail
   markingCategory: Tail
-  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid]
+  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni]
   layering:
     m_tail_kangaroo_BEHIND_primary: TailBehind
     m_tail_kangaroo_FRONT_primary: TailOversuit
@@ -541,7 +541,7 @@
   id: TailKitsune
   bodyPart: Tail
   markingCategory: Tail
-  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid]
+  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni]
   layering:
     m_tail_kitsune_BEHIND_primary: TailBehind
     m_tail_kitsune_BEHIND_secondary: TailBehind
@@ -564,7 +564,7 @@
   id: TailLab
   bodyPart: Tail
   markingCategory: Tail
-  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid]
+  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni]
   layering:
     m_tail_lab_BEHIND_primary: TailBehind
     m_tail_lab_FRONT_primary: Tail
@@ -580,7 +580,7 @@
   id: TailLeopard
   bodyPart: Tail
   markingCategory: Tail
-  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid]
+  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni]
   layering:
     m_tail_leopard_BEHIND_primary: TailBehind
     m_tail_leopard_BEHIND_secondary: TailBehind
@@ -603,7 +603,7 @@
   id: TailLTiger
   bodyPart: Tail
   markingCategory: Tail
-  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid]
+  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni]
   layering:
     m_tail_ltiger_BEHIND: TailBehind
     m_tail_ltiger_FRONT: Tail
@@ -619,7 +619,7 @@
   id: TailLunasune
   bodyPart: Tail
   markingCategory: Tail
-  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid]
+  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni]
   layering:
     m_tail_lunasune_BEHIND: TailBehind
     m_tail_lunasune_FRONT: Tail
@@ -636,7 +636,7 @@
 #  id: TailMFox
 #  bodyPart: Tail
 #  markingCategory: Tail
-#  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid]
+#  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni]
 #  sprites:
 #  - sprite: _Floof/Mobs/Customization/skyrattails.rsi
 #    state: m_tail_fox_FRONT_primary
@@ -647,7 +647,7 @@
   id: TailMurid
   bodyPart: Tail
   markingCategory: Tail
-  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid]
+  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni]
   layering:
     m_tail_murid_BEHIND_primary: TailBehind
     m_tail_murid_FRONT_primary: TailOversuit
@@ -663,7 +663,7 @@
   id: TailMuridTwo
   bodyPart: Tail
   markingCategory: Tail
-  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid]
+  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni]
   layering:
     m_tail_murid_two_BEHIND_primary: TailBehind
     m_tail_murid_two_FRONT_primary: TailOversuit
@@ -679,7 +679,7 @@
   id: TailOrca
   bodyPart: Tail
   markingCategory: Tail
-  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid]
+  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni]
   layering:
     m_tail_orca_BEHIND_primary: TailBehind
     m_tail_orca_FRONT_primary: TailOversuit
@@ -695,7 +695,7 @@
   id: TailOtie
   bodyPart: Tail
   markingCategory: Tail
-  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid]
+  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni]
   layering:
     m_tail_otie_BEHIND_primary: TailBehind
     m_tail_otie_FRONT_primary: TailOversuit
@@ -711,7 +711,7 @@
   id: TailPede
   bodyPart: Tail
   markingCategory: Tail
-  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid]
+  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni]
   layering:
     m_tail_leopard_BEHIND_primary: TailBehind
     m_tail_leopard_BEHIND_secondary: TailBehind
@@ -741,7 +741,7 @@
   id: TailPlugTail
   bodyPart: Tail
   markingCategory: Tail
-  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid]
+  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni]
   layering:
     m_tail_plugtail_BEHIND_primary: TailBehind
     m_tail_plugtail_BEHIND_secondary: TailBehind
@@ -771,7 +771,7 @@
   id: TailQueenBee
   bodyPart: Tail
   markingCategory: Tail
-  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid]
+  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni]
   layering:
     m_tail_queenbee_BEHIND_primary: TailBehind
     m_tail_queenbee_BEHIND_secondary: TailBehind
@@ -794,7 +794,7 @@
   id: TailQueenInsect
   bodyPart: Tail
   markingCategory: Tail
-  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid]
+  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni]
   layering:
     m_tail_queeninsect_BEHIND_primary: TailBehind
     m_tail_queeninsect_BEHIND_secondary: TailBehind
@@ -813,7 +813,7 @@
   id: TailRabbit
   bodyPart: Tail
   markingCategory: Tail
-  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid]
+  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni]
   layering:
     m_tail_rabbit_BEHIND_primary: TailBehind
     m_tail_rabbit_FRONT_primary: Tail
@@ -829,7 +829,7 @@
   id: TailRabbitAlt
   bodyPart: Tail
   markingCategory: Tail
-  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid]
+  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni]
   layering:
     m_tail_rabbit_alt_FRONT_primary: Tail
     m_tail_rabbit_alt_FRONT_secondary: Tail
@@ -843,7 +843,7 @@
   id: TailRaccoon
   bodyPart: Tail
   markingCategory: Tail
-  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid]
+  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni]
   layering:
     m_tail_raccoon_BEHIND_primary: TailBehind
     m_tail_raccoon_BEHIND_secondary: TailBehind
@@ -866,7 +866,7 @@
   id: TailRaptor
   bodyPart: Tail
   markingCategory: Tail
-  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid]
+  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni]
   layering:
     m_tail_raptor_BEHIND_primary: TailBehind
     m_tail_raptor_BEHIND_secondary: TailBehind
@@ -896,7 +896,7 @@
   id: TailReptileSlim
   bodyPart: Tail
   markingCategory: Tail
-  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid]
+  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni]
   layering:
     m_tail_reptileslim_BEHIND: TailBehind
     m_tail_reptileslim_FRONT: Tail
@@ -912,7 +912,7 @@
   id: TailSabresune
   bodyPart: Tail
   markingCategory: Tail
-  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid]
+  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni]
   layering:
     m_tail_sabresune_BEHIND_primary: TailBehind
     m_tail_sabresune_BEHIND_secondary: TailBehind
@@ -935,7 +935,7 @@
   id: TailSegmentedTail
   bodyPart: Tail
   markingCategory: Tail
-  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid]
+  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni]
   layering:
     m_tail_segmentedtail_BEHIND_primary: TailBehind
     m_tail_segmentedtail_BEHIND_secondary: TailBehind
@@ -965,7 +965,7 @@
   id: TailSergal
   bodyPart: Tail
   markingCategory: Tail
-  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid]
+  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni]
   layering:
     m_tail_sergal_BEHIND_primary: TailBehind
     m_tail_sergal_BEHIND_secondary: TailBehind
@@ -988,7 +988,7 @@
   id: TailSevenKitsune
   bodyPart: Tail
   markingCategory: Tail
-  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid]
+  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni]
   layering:
     m_tail_sevenkitsune_BEHIND_primary: TailBehind
     m_tail_sevenkitsune_BEHIND_secondary: TailBehind
@@ -1011,7 +1011,7 @@
   id: TailShark
   bodyPart: Tail
   markingCategory: Tail
-  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid]
+  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni]
   layering:
     m_tail_shark_BEHIND_primary: TailBehind
     m_tail_shark_FRONT_primary: TailOversuit
@@ -1027,7 +1027,7 @@
   id: TailSharkNoFin
   bodyPart: Tail
   markingCategory: Tail
-  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid]
+  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni]
   layering:
     m_tail_sharknofin_BEHIND_primary: TailBehind
     m_tail_sharknofin_FRONT_primary: TailOversuit
@@ -1043,7 +1043,7 @@
   id: TailShepherd
   bodyPart: Tail
   markingCategory: Tail
-  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid]
+  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni]
   layering:
     m_tail_shepherd_BEHIND_secondary: TailBehind
     m_tail_shepherd_BEHIND_tertiary: TailBehind
@@ -1066,7 +1066,7 @@
   id: TailSkunk
   bodyPart: Tail
   markingCategory: Tail
-  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid]
+  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni]
   layering:
     m_tail_skunk_BEHIND_primary: TailBehind
     m_tail_skunk_BEHIND_secondary: TailBehind
@@ -1096,7 +1096,7 @@
   id: TailSmooth
   bodyPart: Tail
   markingCategory: Tail
-  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid]
+  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni]
   layering:
     m_tail_smooth_BEHIND: TailBehind
     m_tail_smooth_FRONT: TailOversuit
@@ -1112,7 +1112,7 @@
   id: TailSnakeDual
   bodyPart: Tail
   markingCategory: Tail
-  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid]
+  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni]
   layering:
     m_tail_snakedual_BEHIND_primary: TailBehind
     m_tail_snakedual_BEHIND_secondary: TailBehind
@@ -1135,7 +1135,7 @@
   id: TailSnakeStripe
   bodyPart: Tail
   markingCategory: Tail
-  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid]
+  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni]
   layering:
     m_tail_snakestripe_BEHIND_primary: TailBehind
     m_tail_snakestripe_BEHIND_secondary: TailBehind
@@ -1158,7 +1158,7 @@
   id: TailSnakeStripeAlt
   bodyPart: Tail
   markingCategory: Tail
-  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid]
+  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni]
   layering:
     m_tail_snakestripealt_BEHIND_primary: TailBehind
     m_tail_snakestripealt_BEHIND_secondary: TailBehind
@@ -1181,7 +1181,7 @@
   id: TailSnakeTail
   bodyPart: Tail
   markingCategory: Tail
-  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid]
+  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni]
   layering:
     m_tail_snaketail_BEHIND: TailBehind
     m_tail_snaketail_FRONT: Tail
@@ -1197,7 +1197,7 @@
   id: TailSnakeUnder
   bodyPart: Tail
   markingCategory: Tail
-  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid]
+  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni]
   layering:
     m_tail_snakeunder_BEHIND_primary: TailBehind
     m_tail_snakeunder_BEHIND_secondary: TailBehind
@@ -1220,7 +1220,7 @@
   id: TailSpade
   bodyPart: Tail
   markingCategory: Tail
-  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid]
+  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni]
   layering:
     m_tail_spade_BEHIND_primary: TailBehind
     m_tail_spade_FRONT_primary: TailOversuit
@@ -1236,7 +1236,7 @@
   id: TailSpikes
   bodyPart: Tail
   markingCategory: Tail
-  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid]
+  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni]
   layering:
     m_tail_spikes_BEHIND: TailBehind
     m_tail_spikes_FRONT: TailOversuit
@@ -1252,7 +1252,7 @@
   id: TailSquirrel
   bodyPart: Tail
   markingCategory: Tail
-  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid]
+  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni]
   layering:
     m_tail_squirrel_BEHIND: TailBehind
     m_tail_squirrel_FRONT: Tail
@@ -1268,7 +1268,7 @@
   id: TailStraightTail
   bodyPart: Tail
   markingCategory: Tail
-  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid]
+  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni]
   layering:
     m_tail_straighttail_BEHIND_primary: TailBehind
     m_tail_straighttail_FRONT_primary: Tail
@@ -1284,7 +1284,7 @@
   id: TailStripe
   bodyPart: Tail
   markingCategory: Tail
-  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid]
+  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni]
   layering:
     m_tail_stripe_BEHIND_primary: TailBehind
     m_tail_stripe_BEHIND_secondary: TailBehind
@@ -1308,7 +1308,7 @@
 #  id: TailMawWag
 #  bodyPart: Tail
 #  markingCategory: Tail
-#  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid]
+#  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni]
 #  layering:
 #    m_tail_tailmawwag_BEHIND_primary: TailBehind
 #    m_tail_tailmawwag_FRONT_primary: Tail
@@ -1324,7 +1324,7 @@
   id: TailThreeCat
   bodyPart: Tail
   markingCategory: Tail
-  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid]
+  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni]
   layering:
     m_tail_threecat_BEHIND_primary: TailBehind
     m_tail_threecat_FRONT_primary: Tail
@@ -1340,7 +1340,7 @@
   id: TailTiger
   bodyPart: Tail
   markingCategory: Tail
-  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid]
+  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni]
   layering:
     m_tail_tiger_BEHIND_primary: TailBehind
     m_tail_tiger_BEHIND_secondary: TailBehind
@@ -1370,7 +1370,7 @@
   id: TailTiger2
   bodyPart: Tail
   markingCategory: Tail
-  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid]
+  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni]
   layering:
     m_tail_tiger2_BEHIND_primary: TailBehind
     m_tail_tiger2_BEHIND_secondary: TailBehind
@@ -1400,7 +1400,7 @@
   id: TailTwoCat
   bodyPart: Tail
   markingCategory: Tail
-  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid]
+  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni]
   layering:
     m_tail_twocat_BEHIND_primary: TailBehind
     m_tail_twocat_FRONT_primary: Tail
@@ -1416,7 +1416,7 @@
   id: TailWah
   bodyPart: Tail
   markingCategory: Tail
-  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid]
+  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni]
   layering:
     m_tail_wah_BEHIND_primary: TailBehind
     m_tail_wah_BEHIND_secondary: TailBehind
@@ -1439,7 +1439,7 @@
   id: TailWolf
   bodyPart: Tail
   markingCategory: Tail
-  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid]
+  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni]
   layering:
     m_tail_wolf_BEHIND: TailBehind
     m_tail_wolf_FRONT: Tail
@@ -1455,7 +1455,7 @@
   id: TailZorgoia
   bodyPart: Tail
   markingCategory: Tail
-  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid]
+  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni]
   layering:
     m_tail_zorgoia_BEHIND_primary: TailBehind
     m_tail_zorgoia_BEHIND_secondary: TailBehind

--- a/Resources/Prototypes/_Floof/Entities/Mobs/Customization/Markings/felinid.yml
+++ b/Resources/Prototypes/_Floof/Entities/Mobs/Customization/Markings/felinid.yml
@@ -3,7 +3,7 @@
   id: FelinidTiger
   bodyPart: Tail
   markingCategory: Tail
-  speciesRestriction: [Felinid, Human]
+  speciesRestriction: [Felinid, Human, Oni]
   sprites:
   - sprite: _Floof/Mobs/Customization/Felinid/tiger_tail.rsi
     state: m_tail_tiger_primary


### PR DESCRIPTION
# Description

Allow for more customization/creativity with the Oni race by granting them access to Tail/Snout markings, using Human as a template for availability. 

---

# TODO

- [x] Update applicable .yml files

# Changelog

:cl: teeny
- tweak: Updated Oni to have all anthropomorphic Tail/Snout markings available to humans.
