### PR TITLE
Add Safety Harness to Lathes

### DIFF
--- a/Content.Shared/Lathe/EmagLatheComponent.cs
+++ b/Content.Shared/Lathe/EmagLatheComponent.cs
@@ -8,16 +8,20 @@ namespace Content.Shared.Lathe
     [RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
     public sealed partial class EmagLatheRecipesComponent : Component
     {
+        // FloofStation Modified
+        // AlwaysPushInheritance done to remain consistent with LatheComponent
         /// <summary>
         /// All of the dynamic recipes that the lathe is capable to get using EMAG
         /// </summary>
-        [DataField, AutoNetworkedField]
+        [DataField, AlwaysPushInheritance, AutoNetworkedField]
         public List<ProtoId<LatheRecipePrototype>> EmagDynamicRecipes = new();
 
+        // FloofStation Modified
+        // Ditto from EmagDynamicRecipes
         /// <summary>
         /// All of the static recipes that the lathe is capable to get using EMAG
         /// </summary>
-        [DataField, AutoNetworkedField]
+        [DataField, AlwaysPushInheritance, AutoNetworkedField]
         public List<ProtoId<LatheRecipePrototype>> EmagStaticRecipes = new();
     }
 }

--- a/Content.Shared/Lathe/LatheComponent.cs
+++ b/Content.Shared/Lathe/LatheComponent.cs
@@ -9,16 +9,21 @@ namespace Content.Shared.Lathe
     [RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
     public sealed partial class LatheComponent : Component
     {
+        // FloofStation Modified
+        // AlwaysPushInheritance added so lathes that use the AutoLathe as their
+        // parent could add on some extra recipes.
         /// <summary>
         /// All of the recipes that the lathe has by default
         /// </summary>
-        [DataField]
+        [DataField, AlwaysPushInheritance]
         public List<ProtoId<LatheRecipePrototype>> StaticRecipes = new();
 
+        // FloofStation Modified
+        // Ditto from StaticRecipes.
         /// <summary>
         /// All of the recipes that the lathe is capable of researching
         /// </summary>
-        [DataField]
+        [DataField, AlwaysPushInheritance]
         public List<ProtoId<LatheRecipePrototype>> DynamicRecipes = new();
 
         /// <summary>

--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/engidrobe.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/engidrobe.yml
@@ -20,4 +20,4 @@
     ClothingHandsEngiWarmers: 1 # Floofstation
     ClothingUnderSocksEngi: 1 # Floofstation
     ClothingUniformEngiThong: 1 # Floofstation
-    ClothingUncategorizedHarnessSafety: 1 # Floofstation
+    ClothingUncategorizedHarnessSafety: 3 # Floofstation

--- a/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
@@ -203,7 +203,6 @@
       - LeashBasic # FloofStation
       - ClothingEyesHypnoVisor # FloofStation
       - ToolRadioHandheld # Floofstation
-      - HarnessSafety # FloofStation
   - type: EmagLatheRecipes
     emagStaticRecipes:
       - BoxLethalshot
@@ -1159,7 +1158,9 @@
   - type: Lathe
     idleState: icon
     runningState: icon
-    # Static recipes are inherited from the autolathe. This only adds some dynamic ones.
+    # Static recipes are inherited from the autolathe. See LatheComponent.
+    staticRecipes:
+      - HarnessSafety # FloofStation
     dynamicRecipes:
       # Machines and computers
       - TurboItemRechargerCircuitboard
@@ -1233,7 +1234,7 @@
   - type: Lathe
     idleState: icon
     runningState: icon
-    # Static recipes are inherited from the autolathe. This only adds some dynamic ones.
+    # Static recipes are inherited from the autolathe. See LatheComponent.
     dynamicRecipes:
     # Weapons and tools
     - WeaponGrapplingGun

--- a/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
@@ -203,6 +203,7 @@
       - LeashBasic # FloofStation
       - ClothingEyesHypnoVisor # FloofStation
       - ToolRadioHandheld # Floofstation
+      - HarnessSafety # FloofStation
   - type: EmagLatheRecipes
     emagStaticRecipes:
       - BoxLethalshot

--- a/Resources/Prototypes/_Floof/Recipes/Lathes/clothing.yml
+++ b/Resources/Prototypes/_Floof/Recipes/Lathes/clothing.yml
@@ -68,3 +68,12 @@
   materials:
     Cloth: 500
     Durathread: 300
+
+- type: latheRecipe
+  id: HarnessSafety
+  result: ClothingUncategorizedHarnessSafety
+  category: Tools
+  completetime: 4
+  materials:
+    Cloth: 250 # Two utility belts plus some connecting straps
+    Steel: 50 # Because buckles


### PR DESCRIPTION
Also bumps the amount of harnesses in the EngiDrobe.

I want the flock of harnessed engineers to be real.

![image](https://github.com/user-attachments/assets/7db3d6c9-a386-4f21-b607-dd1f5be04563)

# Changelog

:cl:
- add: Safety harnesses can now be researched and crafted in the Engineering TechFab.
- tweak: A few more safety harnesses were added to the EngiDrobe 
