### PR TITLE
Fix Diona Thirst

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/Species/diona.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/diona.yml
@@ -10,7 +10,7 @@
   - type: Hunger
     baseDecayRate: 0.0083
   - type: Thirst
-    baseDecayRate: 0.0083
+    baseDecayRate: 0.05 # Floofstation, changed from 0.0083 so it's properly half the normal rate.
   - type: Carriable # Carrying system from nyanotrasen.
   - type: Icon
     sprite: Mobs/Species/Diona/parts.rsi


### PR DESCRIPTION
<!--
This is a semi-strict format, you can add/remove sections as needed but the order/format should be kept the same
Remove these comments before submitting
-->

# Description

<!--
Explain this PR in as much detail as applicable

Some example prompts to consider:
How might this affect the game? The codebase?
What might be some alternatives to this?
How/Who does this benefit/hurt [the game/codebase]?
-->

Diona currently get thirsty about 12x slower than the standard rate. According to the Wizden PR that made this change, it was intended to be 2x slower than the standard rate. This fixes that.

I hope you enjoy my dumb fix that literally no one asked for and doesn't matter.

---

# TODO

<!--
A list of everything you have to do before this PR is "complete"
You probably won't have to complete everything before merging but it's good to leave future references
-->

- [x] Tweak Diona thirst baseDecayRate

---

# Changelog

<!--
You can add an author after the `:cl:` to change the name that appears in the changelog (ex: `:cl: Death`)
Leaving it blank will default to your GitHub display name
This includes all available types for the changelog
-->

:cl:
- fix: Diona now get thirsty at the intended rate. They are not cacti.
