### PR TITLE
Lower Greytide Virus Event Chance

### DIFF
--- a/Resources/Prototypes/GameRules/events.yml
+++ b/Resources/Prototypes/GameRules/events.yml
@@ -613,5 +613,5 @@
       earliestStart: 15
       minimumPlayers: 5
       maxOccurrences: 1
-      weight: 3
+      weight: 1 # Annoying.
     - type: AirlockVirusRule


### PR DESCRIPTION
# Description
It's a high-impact event that affects all security airlocks, it shouldn't be happening every shift.

# Changelog
:cl:
- fix: Gr3yt1de virus should no longer infect security airlocks every shift.
