### PR TITLE
Change Dragon Briefing and Fix Uncommented Dragon System Changes

### DIFF
--- a/Content.Server/Dragon/DragonSystem.cs
+++ b/Content.Server/Dragon/DragonSystem.cs
@@ -97,6 +97,13 @@ public sealed partial class DragonSystem : EntitySystem
 
             comp.RiftAccumulator += frameTime;
 
+            // Floofstation - Removed to disable dragon disappearing without rifts
+            // // Delete it, naughty dragon!
+            // if (comp.RiftAccumulator >= comp.RiftMaxAccumulator)
+            // {
+            //     Roar(uid, comp);
+            //     QueueDel(uid);
+            // }
 
         }
     }

--- a/Resources/Locale/en-US/dragon/dragon.ftl
+++ b/Resources/Locale/en-US/dragon/dragon.ftl
@@ -2,4 +2,4 @@ dragon-round-end-agent-name = dragon
 
 objective-issuer-dragon = [color=#7567b6]Space Dragon[/color]
 
-dragon-role-briefing = dragon-role-briefing = Summon 3 carp rifts and take over this quadrant; or don't, and spend some time seeing the sights, meeting the locals, or building an interesting horde. It's not like you'll disappear without those rifts.
+dragon-role-briefing = Summon 3 carp rifts and take over this quadrant; or don't, and spend some time seeing the sights, meeting the locals, or building an interesting horde. It's not like you'll disappear without those rifts.

--- a/Resources/Locale/en-US/dragon/dragon.ftl
+++ b/Resources/Locale/en-US/dragon/dragon.ftl
@@ -2,4 +2,4 @@ dragon-round-end-agent-name = dragon
 
 objective-issuer-dragon = [color=#7567b6]Space Dragon[/color]
 
-dragon-role-briefing = Summon 3 carp rifts and take over this quadrant!
+dragon-role-briefing = dragon-role-briefing = Summon 3 carp rifts and take over this quadrant; or don't, and spend some time seeing the sights, meeting the locals, or building an interesting horde. It's not like you'll disappear without those rifts.

--- a/Resources/Locale/en-US/ghost/roles/ghost-role-component.ftl
+++ b/Resources/Locale/en-US/ghost/roles/ghost-role-component.ftl
@@ -157,7 +157,7 @@ ghost-role-information-ifrit-wizard-name = Ifrit (Wizard Summon)
 ghost-role-information-ifrit-wizard-description = Listen to your owner. Don't tank damage. Punch people hard.
 
 ghost-role-information-space-dragon-name = Space dragon
-ghost-role-information-space-dragon-description = create 3 carp rifts and protect your nest!
+ghost-role-information-space-dragon-description = Summon 3 carp rifts and take over this quadrant; or don't, and spend some time seeing the sights, meeting the locals, or building an interesting horde. It's not like you'll disappear without those rifts.
 ghost-role-information-space-dragon-dungeon-description = Defend the expedition dungeon with your fishy comrades!
 
 ghost-role-information-cluwne-name = Cluwne

--- a/Resources/Locale/en-US/objectives/conditions/carp-rifts.ftl
+++ b/Resources/Locale/en-US/objectives/conditions/carp-rifts.ftl
@@ -1,2 +1,2 @@
 objective-carp-rifts-title = Open {$count} carp rifts
-objective-carp-rifts-description = Use the rift action to open {$count} rifts and ensure they do not get destroyed. If you don't open a rift after 5 minutes, you get killed.
+objective-carp-rifts-description = Use the rift action to open {$count} rifts and ensure they do not get destroyed. Rifts are NOT necessary for your survival.


### PR DESCRIPTION
# Description

Adds to the dragon briefing to specify that the player does not have to worry about rift timers on this server.

Adds back previously deleted code and comments it out with an explanation for why this block of code was removed. Also properly tags this as a floofstation change.

---

# Changelog

<!--
You can add an author after the `:cl:` to change the name that appears in the changelog (ex: `:cl: Death`)
Leaving it blank will default to your GitHub display name
This includes all available types for the changelog
-->

:cl: sprkl
- tweak: Space dragons are made more aware they won't vanish without rifts.
