### PR TITLE
Remove Hijack and Improve Kill Group

### DIFF
--- a/Resources/Prototypes/DeltaV/Objectives/traitor.yml
+++ b/Resources/Prototypes/DeltaV/Objectives/traitor.yml
@@ -62,5 +62,5 @@
     unique: false
   - type: TargetObjective
     title: objective-condition-teach-person-title
-  - type: PickRandomHead
+  - type: PickRandomPerson
   - type: TeachLessonCondition

--- a/Resources/Prototypes/Objectives/objectiveGroups.yml
+++ b/Resources/Prototypes/Objectives/objectiveGroups.yml
@@ -32,15 +32,16 @@
   id: TraitorObjectiveGroupKill
   weights:
     # KillRandomPersonObjective: 1 # DeltaV Replaced for Teach Lesson
-    TeachLessonRandomPersonObjective: 1
-    KillRandomHeadObjective: 0.25
+    # TeachLessonRandomPersonObjective: 1 # Floof - Disabled until constent system is made for targets
+    # KillRandomHeadObjective: 0.25 # Floof - Replaced with TeachLessonRandomHeadObjective
+    TeachLessonRandomHeadObjective: 1 # Floof - Replaces KillRandomHeadObjective
 
 - type: weightedRandom
   id: TraitorObjectiveGroupState
   weights:
     EscapeShuttleObjective: 1
     # DieObjective: 0.05 # Floof - No DAGD
-    HijackShuttleObjective: 0.02
+    # HijackShuttleObjective: 0.02 # Floof - No Hijack EVAC Shuttle
 
 - type: weightedRandom
   id: TraitorObjectiveGroupSocial

--- a/Resources/Prototypes/_Floof/Objectives/traitor.yml
+++ b/Resources/Prototypes/_Floof/Objectives/traitor.yml
@@ -1,0 +1,13 @@
+- type: entity
+  parent: [BaseTraitorObjective, BaseTeachLessonObjective]
+  id: TeachLessonRandomHeadObjective
+  description: Kill them, and show everyone we mean business. They only need to die once.
+  components:
+  - type: Objective
+    difficulty: 3.0
+    unique: true
+  - type: TargetObjective
+    title: objective-condition-teach-person-title
+  - type: PickRandomHead
+  - type: TeachLessonCondition
+


### PR DESCRIPTION
# Description

Removes the objective to hijack the evacuation shuttle.

Reverts changes to TeachLessonRandomPersonObjective in preparation for a target consent toggle.

Removes TeachLessonRandomPersonObjective from the pool until a target consent toggle is added.

Adds the TeachLessonRandomHeadObjective which behaves exactly as the modified TLRPO did, but with increased difficulty and made a unique objective.

Adds TeachLessonRandomHeadObjective to the traitor objective pool.

---

# Changelog

:cl: sprkl
- remove: The Syndicate will no longer ask agents to hijack the evac shuttle.
