### PR TITLE
Remove Default Hotbar Loadouts Keybinds

### DIFF
--- a/Resources/keybinds.yml
+++ b/Resources/keybinds.yml
@@ -557,46 +557,47 @@ binds:
 - function: Hotbar9
   type: State
   key: Num9
-- function: Loadout0
-  type: State
-  key: Num0
-  mod1: Shift
-- function: Loadout1
-  type: State
-  key: Num1
-  mod1: Shift
-- function: Loadout2
-  type: State
-  key: Num2
-  mod1: Shift
-- function: Loadout3
-  type: State
-  key: Num3
-  mod1: Shift
-- function: Loadout4
-  type: State
-  key: Num4
-  mod1: Shift
-- function: Loadout5
-  type: State
-  key: Num5
-  mod1: Shift
-- function: Loadout6
-  type: State
-  key: Num6
-  mod1: Shift
-- function: Loadout7
-  type: State
-  key: Num7
-  mod1: Shift
-- function: Loadout8
-  type: State
-  key: Num8
-  mod1: Shift
-- function: Loadout9
-  type: State
-  key: Num9
-  mod1: Shift
+# Floof - removed default bindings for those because people won't stop complaining about them.
+# - function: Loadout0
+#   type: State
+#   key: Num0
+#   mod1: Shift
+# - function: Loadout1
+#   type: State
+#   key: Num1
+#   mod1: Shift
+# - function: Loadout2
+#   type: State
+#   key: Num2
+#   mod1: Shift
+# - function: Loadout3
+#   type: State
+#   key: Num3
+#   mod1: Shift
+# - function: Loadout4
+#   type: State
+#   key: Num4
+#   mod1: Shift
+# - function: Loadout5
+#   type: State
+#   key: Num5
+#   mod1: Shift
+# - function: Loadout6
+#   type: State
+#   key: Num6
+#   mod1: Shift
+# - function: Loadout7
+#   type: State
+#   key: Num7
+#   mod1: Shift
+# - function: Loadout8
+#   type: State
+#   key: Num8
+#   mod1: Shift
+# - function: Loadout9
+#   type: State
+#   key: Num9
+#   mod1: Shift
 - function: LookUp
   type: State
   key: Space


### PR DESCRIPTION
# Description
People are not used to them, some people use shift to sprint (why?), and they don't want to rebind them, something like that. Should still be possible to rebind them in the settings menu.

# Changelog
:cl:
- tweak: Removed default keybinds for switching between hotbar loadouts (shift+num). You can still bind them yourself using the settings menu.
