### PR TITLE
Laser Bounty Fix

### DIFF
--- a/Resources/Prototypes/Catalog/Bounties/bounties.yml
+++ b/Resources/Prototypes/Catalog/Bounties/bounties.yml
@@ -524,6 +524,11 @@
     whitelist:
       components:
       - HitscanBatteryAmmoProvider
+    blacklist:  # Floof to prevent powercells from being able to complete the bounty
+      tags:
+      - PowerCell
+      - PowerCellSmall
+      - PotatoBattery
 
 - type: cargoBounty
   id: BountyFood


### PR DESCRIPTION

# Description
adds a Blacklist so Powercells cant be used to complete the bounty 
Description.

:cl:
- fix: Fixed the hitscan bounty