### PR TITLE
Remove Automatic Page Switching when the Action Bar Overflows

### DIFF
--- a/Content.Client/UserInterface/Systems/Actions/ActionUIController.cs
+++ b/Content.Client/UserInterface/Systems/Actions/ActionUIController.cs
@@ -648,7 +648,8 @@ public sealed class ActionUIController : UIController, IOnStateChanged<GameplayS
                         nextPage[i] = actionId;
                         break;
                     }
-                ChangePage(_currentPageIndex + 1); //TODO: Make this a client config?
+                // Floof - wtf
+                // ChangePage(_currentPageIndex + 1); //TODO: Make this a client config?
             }
     }
 


### PR DESCRIPTION
# Description
Who even thought it was a great idea?

Well, upon further inspection, turns out it *is* a work around another ugly feature: when the action bar overflows, new actions are placed onto the *next page* rather than the first free page. So if both your first and your second pages are full, and you are on the first page, and the action bar overflows, the new action will simply not be added anywhere. But this workaround wouldn't help unless you are actively equipping items and the number of actions given by those items is enough to fill both the first and the second page of the action bar.

<details>
<summary><h1>Media or smth</h1></summary>

https://github.com/user-attachments/assets/be12e61e-e6cd-4ced-8a61-b07c8f7ba736

</details>

# Changelog
:cl:
- remove: The action bar (hotbar) will no longer automatically switch to the next page when it overflows (overflowing actions will still appear on the next page, but you will need to switch manually)