### PR TITLE
Fix ID Locks and ID Consoles

### DIFF
--- a/Content.Server/Access/Systems/IdCardConsoleSystem.cs
+++ b/Content.Server/Access/Systems/IdCardConsoleSystem.cs
@@ -135,6 +135,9 @@ public sealed class IdCardConsoleSystem : SharedIdCardConsoleSystem
             _idCard.TryChangeJobDepartment(targetId, job);
         }
 
+        // Floof - moved the station records update up so it doesn't get omitted if the underlying job isn't changed
+        UpdateStationRecord(uid, targetId, newFullName, newJobTitle, job);
+
         if (!newAccessList.TrueForAll(x => component.AccessLevels.Contains(x)))
         {
             _sawmill.Warning($"User {ToPrettyString(uid)} tried to write unknown access tag.");
@@ -169,7 +172,8 @@ public sealed class IdCardConsoleSystem : SharedIdCardConsoleSystem
         _adminLogger.Add(LogType.Action, LogImpact.Medium,
             $"{ToPrettyString(player):player} has modified {ToPrettyString(targetId):entity} with the following accesses: [{string.Join(", ", addedTags.Union(removedTags))}] [{string.Join(", ", newAccessList)}]");
 
-        UpdateStationRecord(uid, targetId, newFullName, newJobTitle, job);
+        // Floof - see above
+        // UpdateStationRecord(uid, targetId, newFullName, newJobTitle, job);
     }
 
     /// <summary>

--- a/Content.Shared/Access/Components/IdCardComponent.cs
+++ b/Content.Shared/Access/Components/IdCardComponent.cs
@@ -23,6 +23,7 @@ public sealed partial class IdCardComponent : Component
 
     private string? _jobTitle;
 
+    [ViewVariables] // Floof
     [Access(typeof(SharedIdCardSystem), typeof(SharedPdaSystem), typeof(SharedAgentIdCardSystem), Other = AccessPermissions.ReadWriteExecute)]
     public string? LocalizedJobTitle { set => _jobTitle = value; get => _jobTitle ?? Loc.GetString(JobTitle ?? string.Empty); }
 

--- a/Content.Shared/Access/Components/IdCardComponent.cs
+++ b/Content.Shared/Access/Components/IdCardComponent.cs
@@ -23,7 +23,7 @@ public sealed partial class IdCardComponent : Component
 
     private string? _jobTitle;
 
-    [ViewVariables] // Floof
+    [AutoNetworkedField, ViewVariables] // Floof
     [Access(typeof(SharedIdCardSystem), typeof(SharedPdaSystem), typeof(SharedAgentIdCardSystem), Other = AccessPermissions.ReadWriteExecute)]
     public string? LocalizedJobTitle { set => _jobTitle = value; get => _jobTitle ?? Loc.GetString(JobTitle ?? string.Empty); }
 

--- a/Content.Shared/_Floof/Lock/IdLockSystem.cs
+++ b/Content.Shared/_Floof/Lock/IdLockSystem.cs
@@ -227,7 +227,7 @@ public sealed class IdLockSystem : EntitySystem
             return;
 
         ent.Comp.State = Engaged;
-        ent.Comp.Info = new() { OwnerName = id.Comp.FullName, OwnerJobTitle = id.Comp.JobTitle };
+        ent.Comp.Info = new() { OwnerName = id.Comp.FullName, OwnerJobTitle = id.Comp.LocalizedJobTitle };
         Dirty(ent);
 
         _popups.PopupPredicted(Loc.GetString("id-lock-locked", ("ent", ent.Owner)), ent, user);
@@ -301,7 +301,7 @@ public sealed class IdLockSystem : EntitySystem
         if (lockable.Comp.State is not Engaged)
             return AccessLevel.CanLock;
 
-        if (lockable.Comp.Info.OwnerName == id.Comp.FullName && lockable.Comp.Info.OwnerJobTitle == id.Comp.JobTitle)
+        if (lockable.Comp.Info.OwnerName == id.Comp.FullName && lockable.Comp.Info.OwnerJobTitle == id.Comp.LocalizedJobTitle)
             return AccessLevel.CanUnlock;
 
         return AccessLevel.None;

--- a/Resources/Prototypes/Entities/Structures/Storage/Closets/Lockers/base_structurelockers.yml
+++ b/Resources/Prototypes/Entities/Structures/Storage/Closets/Lockers/base_structurelockers.yml
@@ -1,6 +1,6 @@
 - type: entity
   id: LockerBase
-  parent: [ClosetBase, IdLockableBaseDisabled] # Floof - added a default-disabled ID lock to all closets
+  parent: [IdLockableBaseDisabled, ClosetBase] # Floof - added a default-disabled ID lock to all closets
   abstract: true
   components:
   - type: AccessReader

--- a/Resources/Prototypes/Entities/Structures/Storage/Closets/Lockers/lockers.yml
+++ b/Resources/Prototypes/Entities/Structures/Storage/Closets/Lockers/lockers.yml
@@ -65,7 +65,7 @@
 
 - type: entity
   id: LockerSalvageSpecialist
-  parent: [LockerBase, IdLockableBaseLogistics] # Floof - added id lock parent
+  parent: [IdLockableBaseLogistics, LockerBase] # Floof - added id lock parent
   name: salvage specialist's equipment
   description: Nevermind the pickaxe.
   components:
@@ -121,7 +121,7 @@
 # Electrical supplies
 - type: entity
   id: LockerElectricalSupplies
-  parent: [LockerBase, IdLockableBaseEngineering] # Floof - added id lock parent
+  parent: [IdLockableBaseEngineering, LockerBase] # Floof - added id lock parent
   name: electrical supplies locker
   components:
   - type: Appearance
@@ -135,7 +135,7 @@
 # Welding supplies
 - type: entity
   id: LockerWeldingSupplies
-  parent: [LockerBase, IdLockableBaseEngineering] # Floof - added id lock parent
+  parent: [IdLockableBaseEngineering, LockerBase] # Floof - added id lock parent
   name: welding supplies locker
   components:
   - type: Appearance
@@ -149,7 +149,7 @@
 # Atmos tech
 - type: entity
   id: LockerAtmospherics
-  parent: [LockerBase, IdLockableBaseEngineering] # Floof - added id lock parent
+  parent: [IdLockableBaseEngineering, LockerBase] # Floof - added id lock parent
   name: atmospheric technician's locker
   components:
   - type: Appearance
@@ -163,7 +163,7 @@
 # Engineer
 - type: entity
   id: LockerEngineer
-  parent: [LockerBase, IdLockableBaseEngineering] # Floof - added id lock parent
+  parent: [IdLockableBaseEngineering, LockerBase] # Floof - added id lock parent
   name: engineer's locker
   components:
   - type: Appearance
@@ -230,7 +230,7 @@
 # Medicine
 - type: entity
   id: LockerMedicine
-  parent: [LockerBase, IdLockableBaseMedical] # Floof - added id lock parent
+  parent: [IdLockableBaseMedical, LockerBase] # Floof - added id lock parent
   name: medicine locker
   description: Filled to the brim with medical junk.
   components:
@@ -245,7 +245,7 @@
 # Medical doctor
 - type: entity
   id: LockerMedical
-  parent: [LockerBase, IdLockableBaseMedical] # Floof - added id lock parent
+  parent: [IdLockableBaseMedical, LockerBase] # Floof - added id lock parent
   name: medical doctor's locker
   components:
   - type: Appearance
@@ -259,7 +259,7 @@
 # Paramedic
 - type: entity
   id: LockerParamedic
-  parent: [LockerBase, IdLockableBaseMedical] # Floof - added id lock parent
+  parent: [IdLockableBaseMedical, LockerBase] # Floof - added id lock parent
   name: paramedic's locker
   components:
   - type: Appearance
@@ -274,7 +274,7 @@
 # Chemical
 - type: entity
   id: LockerChemistry
-  parent: [LockerBase, IdLockableBaseMedical] # Floof - added id lock parent
+  parent: [IdLockableBaseMedical, LockerBase] # Floof - added id lock parent
   name: chemical locker
   components:
   - type: Appearance
@@ -315,7 +315,7 @@
 
 - type: entity
   id: LockerScientist
-  parent: [LockerBase, IdLockableBaseResearch] # Floof - added id lock parent
+  parent: [IdLockableBaseResearch, LockerBase] # Floof - added id lock parent
   name: scientist's locker
   components:
   - type: Appearance
@@ -357,7 +357,7 @@
 # Brigmedic
 - type: entity
   id: LockerBrigmedic
-  parent: [LockerBaseSecure, IdLockableBaseSecurity] # Floof - added id lock parent
+  parent: [IdLockableBaseSecurity, LockerBaseSecure] # Floof - added id lock parent
   name: corpsman locker # DeltaV - rename brigmedic to corpsman
   components:
   - type: Appearance
@@ -371,7 +371,7 @@
 # Security Officer
 - type: entity
   id: LockerSecurity
-  parent: [LockerBaseSecure, IdLockableBaseSecurity] # Floof - added id lock parent
+  parent: [IdLockableBaseSecurity, LockerBaseSecure] # Floof - added id lock parent
   name: security officer's locker
   components:
   - type: Appearance
@@ -398,7 +398,7 @@
 # Detective
 - type: entity
   id: LockerDetective
-  parent: [LockerBooze, IdLockableBaseSecurity] # Floof - added id lock parent
+  parent: [IdLockableBaseSecurity, LockerBooze] # Floof - added id lock parent
   name: detective's cabinet
   description: Usually cold and empty... like your heart.
   components:

--- a/Resources/Prototypes/Entities/Structures/Storage/Crates/base_structurecrates.yml
+++ b/Resources/Prototypes/Entities/Structures/Storage/Crates/base_structurecrates.yml
@@ -100,7 +100,7 @@
   - type: ResistLocker
 
 - type: entity
-  parent: [CrateBaseWeldable, IdLockableBaseDisabled] # Floof - added a default-disabled ID lock to all closets
+  parent: [IdLockableBaseDisabled, CrateBaseWeldable] # Floof - added a default-disabled ID lock to all closets
   id: CrateBaseSecure
   suffix: Secure
   components:

--- a/Resources/Prototypes/_Floof/Entities/Structures/Storage/Closets/Lockers/id_locker.yml
+++ b/Resources/Prototypes/_Floof/Entities/Structures/Storage/Closets/Lockers/id_locker.yml
@@ -5,6 +5,8 @@
   suffix: ID lock
   parent: [IdLockableBase, LockerSteel]
   components:
+  - type: IdLock
+    enabled: true
   - type: Construction
     graph: ClosetSteelSecure
     node: idLockable

--- a/Resources/Prototypes/_Floof/Entities/Structures/Storage/Closets/Lockers/id_locker_base.yml
+++ b/Resources/Prototypes/_Floof/Entities/Structures/Storage/Closets/Lockers/id_locker_base.yml
@@ -35,7 +35,7 @@
 # Why? Because if one CMO was to engage an ID lock on their locker, another CMO could easily open it using their own ID as a master key.
 - type: entity
   id: IdLockableBaseService
-  parent: IdLockableBase
+  parent: IdLockableBaseDisabled
   abstract: true
   components:
   - type: IdLock
@@ -44,7 +44,7 @@
 # The below only list the direct masters. Captain, HoP, and central command master accesses are inherited.
 - type: entity
   id: IdLockableBaseLogistics
-  parent: IdLockableBase
+  parent: IdLockableBaseDisabled
   abstract: true
   components:
   - type: IdLock
@@ -52,7 +52,7 @@
 
 - type: entity
   id: IdLockableBaseMedical
-  parent: IdLockableBase
+  parent: IdLockableBaseDisabled
   abstract: true
   components:
   - type: IdLock
@@ -60,7 +60,7 @@
 
 - type: entity
   id: IdLockableBaseEngineering
-  parent: IdLockableBase
+  parent: IdLockableBaseDisabled
   abstract: true
   components:
   - type: IdLock
@@ -68,7 +68,7 @@
 
 - type: entity
   id: IdLockableBaseResearch
-  parent: IdLockableBase
+  parent: IdLockableBaseDisabled
   abstract: true
   components:
   - type: IdLock
@@ -76,7 +76,7 @@
 
 - type: entity
   id: IdLockableBaseSecurity
-  parent: IdLockableBase
+  parent: IdLockableBaseDisabled
   abstract: true
   components:
   - type: IdLock

--- a/Resources/Prototypes/_Floof/Entities/Structures/Storage/Closets/Lockers/id_locker_base.yml
+++ b/Resources/Prototypes/_Floof/Entities/Structures/Storage/Closets/Lockers/id_locker_base.yml
@@ -10,7 +10,7 @@
     unlockSound:
       path: /Audio/Effects/double_beep.ogg
 
-# A base lockable entity that can be privitized using an ID card.
+# A base nanotrasen-aligned lockable entity that can be privitized using an ID card.
 # Inheritors should provide additional masterAccesses based on the department.
 - type: entity
   id: IdLockableBase
@@ -18,6 +18,7 @@
   abstract: true
   components:
   - type: IdLock
+    revealInfo: true
     masterAccesses: [ CentralCommand, Captain, HeadOfPersonnel ]
 
 # A base lockable entity whose ID lock has to be enabled first (typically via construction)
@@ -47,7 +48,6 @@
   abstract: true
   components:
   - type: IdLock
-    revealInfo: true
     masterAccesses: [ Quartermaster ]
 
 - type: entity


### PR DESCRIPTION
# Description
1. Fixes the bug where ID consoles wouldn't update the target's station records unless their job was changed and the changer had permission to change ALL of their accesses
2. Fixes inheritance issues with id-lockable entities that have lead to all departmental closets inheriting the id lock component from ClosetBase and not from their respective departmental versions, and not revealing the owner's info.
3. Fixes the bug with the ID lock system checking for non-localized job name (which is always null for some reason, all systems use LocalizedJobTitle instead)

<details><summary><h1>Media</h1></summary>
<p>

![image](https://github.com/user-attachments/assets/2ad96581-6cbd-4976-bced-d83472baa5c6)
![image](https://github.com/user-attachments/assets/8335ceea-2597-4b34-be58-8dc68b7feeba)
![image](https://github.com/user-attachments/assets/f8db168f-6c0e-4f5f-8cf3-b5863dbc26f1)
![image](https://github.com/user-attachments/assets/cb1ff4c9-76d6-43f9-bd09-eb57a11615de)
![image](https://github.com/user-attachments/assets/32fc0522-a5b5-4390-9ee1-9513abdc2ada)

</p>
</details>

# Changelog
:cl:
- fix: The ID card console will now correctly update your station records even if your job and accesses stay the same.
- fix: ID-lockable closets and other things should now correctly display the owner's info (unless the locker is anonymous)
