### PR TITLE
Feat: Paintable Leashes

### DIFF
--- a/Content.Client/_Floof/Leash/LeashVisualsOverlay.cs
+++ b/Content.Client/_Floof/Leash/LeashVisualsOverlay.cs
@@ -86,9 +86,9 @@ public sealed class LeashVisualsOverlay : Overlay
             var box = new Box2(-width / 2f, -length / 2f, width / 2f, length / 2f);
             var rotate = new Box2Rotated(box.Translated(midPoint), angle, midPoint);
 
-            // Target is always the leash as of now.
+            // Source is always the leash as of now.
             // If it ever changes, make sure to change the visuals comp to include a reference to the leash.
-            var color = _paintQuery.CompOrNull(target)?.Color;
+            var color = _paintQuery.CompOrNull(source)?.Color;
 
             worldHandle.DrawTextureRect(texture, rotate, color);
         }

--- a/Content.Client/_Floof/Leash/LeashVisualsOverlay.cs
+++ b/Content.Client/_Floof/Leash/LeashVisualsOverlay.cs
@@ -1,5 +1,6 @@
 using System.Numerics;
 using Content.Shared.Floofstation.Leash.Components;
+using Content.Shared.Paint;
 using Robust.Client.GameObjects;
 using Robust.Client.Graphics;
 using Robust.Shared.Enums;
@@ -15,6 +16,7 @@ public sealed class LeashVisualsOverlay : Overlay
     private readonly SharedTransformSystem _xform;
     private readonly EntityQuery<TransformComponent> _xformQuery;
     private readonly EntityQuery<SpriteComponent> _spriteQuery;
+    private readonly EntityQuery<PaintedComponent> _paintQuery;
 
     public LeashVisualsOverlay(IEntityManager entMan)
     {
@@ -23,6 +25,7 @@ public sealed class LeashVisualsOverlay : Overlay
         _xform = _entMan.System<SharedTransformSystem>();
         _xformQuery = _entMan.GetEntityQuery<TransformComponent>();
         _spriteQuery = _entMan.GetEntityQuery<SpriteComponent>();
+        _paintQuery = _entMan.GetEntityQuery<PaintedComponent>();
     }
 
     protected override void Draw(in OverlayDrawArgs args)
@@ -83,7 +86,11 @@ public sealed class LeashVisualsOverlay : Overlay
             var box = new Box2(-width / 2f, -length / 2f, width / 2f, length / 2f);
             var rotate = new Box2Rotated(box.Translated(midPoint), angle, midPoint);
 
-            worldHandle.DrawTextureRect(texture, rotate);
+            // Target is always the leash as of now.
+            // If it ever changes, make sure to change the visuals comp to include a reference to the leash.
+            var color = _paintQuery.CompOrNull(target)?.Color;
+
+            worldHandle.DrawTextureRect(texture, rotate, color);
         }
     }
 }

--- a/Resources/Prototypes/_Floof/Loadouts/Generic/items.yml
+++ b/Resources/Prototypes/_Floof/Loadouts/Generic/items.yml
@@ -24,7 +24,8 @@
   id: LoadoutItemLeashBasic
   category: Items
   cost: 2
-  exclusive: true
+  exclusive: false
+  customColorTint: true
   items:
   - LeashBasic
   requirements:
@@ -48,8 +49,8 @@
   cost: 2
   exclusive: false
   items:
-  - CrayonBrush  
-    
+  - CrayonBrush
+
 # Writing
 - type: loadout
   id: LoadoutItemEnvelopes
@@ -86,7 +87,7 @@
   requirements:
     - !type:CharacterItemGroupRequirement
       group: LoadoutWritables
-      
+
 - type: loadout
   id: LoadoutItemStickyNotesGreen
   category: Items


### PR DESCRIPTION
# Description
Makes leashes paintable in the loadouts and adds support for paint in the LeashVisualsOverlay.

Also fixes the new-found bugs that caused leashes to be non-enlongerable and leash verb not appearing when interacting with others.

<details><summary><h1>Media</h1></summary>
<p>

![image](https://github.com/user-attachments/assets/f19072ef-ecb9-4d11-bcb5-d0e70da3dbb3)
![image](https://github.com/user-attachments/assets/4887f92b-881b-4d73-bcac-0cd81d7b4063)
![image](https://github.com/user-attachments/assets/858da67c-c232-444e-abac-e1d5053e38a4)


</p>
</details>

# Changelog
:cl:
- add: Leashes now support custom color tints and being painted.