### PR TITLE
Kitsune Fixes + EE 1709

### DIFF
--- a/Content.Server/Cloning/CloningSystem.Utility.cs
+++ b/Content.Server/Cloning/CloningSystem.Utility.cs
@@ -327,7 +327,9 @@ public sealed partial class CloningSystem
                 pref = pref.WithFlavorText(flavorText);
 
             _humanoidSystem.LoadProfile(mob, pref);
+            return;
         }
+        _humanoidSystem.LoadProfile(mob, pref);
     }
 
     /// <summary>

--- a/Content.Server/Humanoid/Systems/HumanoidAppearanceSystem.cs
+++ b/Content.Server/Humanoid/Systems/HumanoidAppearanceSystem.cs
@@ -20,43 +20,6 @@ public sealed partial class HumanoidAppearanceSystem : SharedHumanoidAppearanceS
         SubscribeLocalEvent<HumanoidAppearanceComponent, GetVerbsEvent<Verb>>(OnVerbsRequest);
     }
 
-    // this was done enough times that it only made sense to do it here
-
-    /// <summary>
-    ///     Clones a humanoid's appearance to a target mob, provided they both have humanoid components.
-    /// </summary>
-    /// <param name="source">Source entity to fetch the original appearance from.</param>
-    /// <param name="target">Target entity to apply the source entity's appearance to.</param>
-    /// <param name="sourceHumanoid">Source entity's humanoid component.</param>
-    /// <param name="targetHumanoid">Target entity's humanoid component.</param>
-    public void CloneAppearance(EntityUid source, EntityUid target, HumanoidAppearanceComponent? sourceHumanoid = null,
-        HumanoidAppearanceComponent? targetHumanoid = null)
-    {
-        if (!Resolve(source, ref sourceHumanoid) || !Resolve(target, ref targetHumanoid))
-        {
-            return;
-        }
-
-        targetHumanoid.Species = sourceHumanoid.Species;
-        targetHumanoid.SkinColor = sourceHumanoid.SkinColor;
-        targetHumanoid.EyeColor = sourceHumanoid.EyeColor;
-        targetHumanoid.Age = sourceHumanoid.Age;
-        targetHumanoid.Height = sourceHumanoid.Height;
-        targetHumanoid.Width = sourceHumanoid.Width;
-        SetSex(target, sourceHumanoid.Sex, false, targetHumanoid);
-        targetHumanoid.CustomBaseLayers = new(sourceHumanoid.CustomBaseLayers);
-        targetHumanoid.MarkingSet = new(sourceHumanoid.MarkingSet);
-
-        targetHumanoid.Gender = sourceHumanoid.Gender;
-        if (TryComp<GrammarComponent>(target, out var grammar))
-        {
-            grammar.Gender = sourceHumanoid.Gender;
-        }
-
-        targetHumanoid.LastProfileLoaded = sourceHumanoid.LastProfileLoaded;
-        Dirty(target, targetHumanoid);
-    }
-
     /// <summary>
     ///     Removes a marking from a humanoid by ID.
     /// </summary>

--- a/Content.Server/Speech/EntitySystems/VocalSystem.cs
+++ b/Content.Server/Speech/EntitySystems/VocalSystem.cs
@@ -54,7 +54,7 @@ public sealed class VocalSystem : EntitySystem
 
     private void OnSexChanged(EntityUid uid, VocalComponent component, SexChangedEvent args)
     {
-        LoadSounds(uid, component);
+        LoadSounds(uid, component, args.NewSex);
     }
 
     private void OnEmote(EntityUid uid, VocalComponent component, ref EmoteEvent args)

--- a/Content.Server/_DV/Abilities/Kitsune/KitsuneSystem.cs
+++ b/Content.Server/_DV/Abilities/Kitsune/KitsuneSystem.cs
@@ -6,9 +6,11 @@ using Content.Shared._DV.Abilities.Kitsune;
 using Content.Shared.Access.Components;
 using Content.Shared.Access.Systems;
 using Content.Shared.Damage.Components;
+using Content.Shared.Humanoid;
 using Content.Shared.NPC.Components;
 using Content.Shared.NPC.Systems;
 using Content.Shared.Polymorph;
+using Content.Shared.Speech.Components;
 using Robust.Shared.Player;
 
 namespace Content.Server._DV.Abilities.Kitsune;
@@ -52,6 +54,9 @@ public sealed class KitsuneSystem : SharedKitsuneSystem
             foxfire.Kitsune = newEntity;
             Dirty(fireUid, foxfire);
         }
+
+        if (TryComp<HumanoidAppearanceComponent>(oldEntity, out var humanoidAppearance))
+            RaiseLocalEvent(newEntity, new SexChangedEvent(Sex.Unsexed, humanoidAppearance.Sex));
 
         // Code after this point will not run when reverting to human form.
         if (HasComp<KitsuneFoxComponent>(oldEntity))

--- a/Content.Server/_DV/Abilities/Kitsune/KitsuneSystem.cs
+++ b/Content.Server/_DV/Abilities/Kitsune/KitsuneSystem.cs
@@ -40,6 +40,7 @@ public sealed class KitsuneSystem : SharedKitsuneSystem
             return;
 
         newKitsune.Color = oldKitsune.Color;
+        newKitsune.ColorLight = oldKitsune.ColorLight;
         _appearance.SetData(newEntity, KitsuneColorVisuals.Color, newKitsune.Color ?? Color.Orange);
 
         // Ensure that the fox fire action state is transferred properly.

--- a/Content.Shared/Humanoid/SharedHumanoidAppearanceSystem.cs
+++ b/Content.Shared/Humanoid/SharedHumanoidAppearanceSystem.cs
@@ -138,6 +138,36 @@ public abstract class SharedHumanoidAppearanceSystem : EntitySystem
     }
 
     /// <summary>
+    ///     Clones a humanoid's appearance to a target mob, provided they both have humanoid components.
+    /// </summary>
+    /// <param name="source">Source entity to fetch the original appearance from.</param>
+    /// <param name="target">Target entity to apply the source entity's appearance to.</param>
+    /// <param name="sourceHumanoid">Source entity's humanoid component.</param>
+    /// <param name="targetHumanoid">Target entity's humanoid component.</param>
+    public void CloneAppearance(EntityUid source, EntityUid target, HumanoidAppearanceComponent? sourceHumanoid = null,
+        HumanoidAppearanceComponent? targetHumanoid = null)
+    {
+        if (!Resolve(source, ref sourceHumanoid) || !Resolve(target, ref targetHumanoid))
+            return;
+
+        targetHumanoid.Species = sourceHumanoid.Species;
+        targetHumanoid.SkinColor = sourceHumanoid.SkinColor;
+        targetHumanoid.EyeColor = sourceHumanoid.EyeColor;
+        targetHumanoid.Age = sourceHumanoid.Age;
+        SetSex(target, sourceHumanoid.Sex, false, targetHumanoid);
+        targetHumanoid.CustomBaseLayers = new(sourceHumanoid.CustomBaseLayers);
+        targetHumanoid.MarkingSet = new(sourceHumanoid.MarkingSet);
+
+        targetHumanoid.Gender = sourceHumanoid.Gender;
+        if (TryComp<GrammarComponent>(target, out var grammar))
+            grammar.Gender = sourceHumanoid.Gender;
+
+        targetHumanoid.LastProfileLoaded = sourceHumanoid.LastProfileLoaded; // DeltaV - let paradox anomaly be cloned
+
+        Dirty(target, targetHumanoid);
+    }
+
+    /// <summary>
     ///     Sets the visibility for multiple layers at once on a humanoid's sprite.
     /// </summary>
     /// <param name="uid">Humanoid mob's UID</param>

--- a/Content.Shared/_DV/Abilities/Kitsune/KitsuneComponent.cs
+++ b/Content.Shared/_DV/Abilities/Kitsune/KitsuneComponent.cs
@@ -30,6 +30,12 @@ public sealed partial class KitsuneComponent : Component
     [DataField, AutoNetworkedField] public List<EntityUid> ActiveFoxFires = [];
 
     [DataField, AutoNetworkedField] public Color? Color;
+
+    /// <summary>
+    /// Represents a light coming from a light source.
+    /// As such it has its value maximised while not touching hue or saturation.
+    /// </summary>
+    [DataField, AutoNetworkedField] public Color? ColorLight;
 }
 
 [Serializable, NetSerializable]

--- a/Content.Shared/_DV/Abilities/Kitsune/SharedKitsuneSystem.cs
+++ b/Content.Shared/_DV/Abilities/Kitsune/SharedKitsuneSystem.cs
@@ -28,6 +28,22 @@ public abstract class SharedKitsuneSystem : EntitySystem
         if (TryComp<HumanoidAppearanceComponent>(ent, out var humanComp))
         {
             ent.Comp.Color = humanComp.EyeColor;
+
+            var lightColor = ent.Comp.Color.Value;
+            var max = MathF.Max(lightColor.R, MathF.Max(lightColor.G, lightColor.B));
+            // Don't let it divide by 0
+            if (max == 0)
+            {
+                lightColor = new Color(1, 1, 1, lightColor.A);
+            }
+            else
+            {
+                var factor = 1 / max;
+                lightColor.R *= factor;
+                lightColor.G *= factor;
+                lightColor.B *= factor;
+            }
+            ent.Comp.ColorLight = lightColor;
         }
     }
 
@@ -62,9 +78,7 @@ public abstract class SharedKitsuneSystem : EntitySystem
         Dirty(fireEnt, fireComp);
         Dirty(ent);
 
-        _light.SetColor(fireEnt, ent.Comp.Color ?? Color.Purple);
-
-        args.Handled = true;
+        _light.SetColor(fireEnt, ent.Comp.ColorLight ?? Color.Purple);
     }
 
     private void OnFoxfireShutdown(Entity<FoxfireComponent> ent, ref ComponentShutdown args)

--- a/Resources/Prototypes/DeltaV/Entities/Mobs/Species/kitsune.yml
+++ b/Resources/Prototypes/DeltaV/Entities/Mobs/Species/kitsune.yml
@@ -10,7 +10,7 @@
       fix1:
         shape: !type:PhysShapeCircle
           radius: 0.35
-        density: 50
+        density: 140 # Floof - M3739 - #981 - Was originally 50. Later found out from SolStar that this was unintended. Given the same density as the Felinids.
         restitution: 0.0
         mask:
         - MobMask


### PR DESCRIPTION
<!--
This is a semi-strict format, you can add/remove sections as needed but the order/format should be kept the same
Remove these comments before submitting
-->

# Description

<!--
Explain this PR in as much detail as applicable

Some example prompts to consider:
How might this affect the game? The codebase?
What might be some alternatives to this?
How/Who does this benefit/hurt [the game/codebase]?
-->

This PR aims to implement @SolStar2's fixes, namely DV 3724,  3725, and 3726.

3725, and 3726 was applied successfully. 3724, however, was found to be a solution to be an issue we do not possess: an issue found to be unrelated to the Kitsune existed in our codebase revolving around the cloning system, which would later be resolved by implementing EE 1709 by 'VMSolidus', which fixed an issue resulting in the clone not properly copying the appearance of the original person.

Upon testing after implementation of 1709 showed that 3724 was redundant as it properly transferred colors over to the cloned kitsune's fox form and fox fire. It should be worth noting that 3724 was DV's solution to ensure the cloned kitsune will retain their fox form and fox fire's colors. And therefore is noted down as such for future reference, in the event where an upstream merge causes the issue to finally appear on our end in a similar nature.

Another change is purely backend, Wizden 35017 by 'poklj' would move `CloneAppearance` from `HumanoidAppearanceSystem` to `SharedHumanoidAppearanceSystem`. This is because the Changelings added back in Wizden's 34002 had their `SharedSystem` requiring the ability to modify someone's appearance.

While we do not have Changelings in our own build, this was originally a prerequisite for 3724, but as 3724 was found to be redundant, it has been kept for the possibility of compatibility with future additions.

Wizden 35017 is able to be removed upon the request of maintainers.

Addendum:
After further discussion with SolStar, the kitsune's density has been changed to be the same as the Felinids.

<!--
This is default collapsed, readers click to expand it and see all your media
The PR media section can get very large at times, so this is a good way to keep it clean
The title is written using HTML tags
The title must be within the <summary> tags or you won't see it
-->

<details><summary><h1>Media</h1></summary>
<p>

![image](https://github.com/user-attachments/assets/b4785f06-5bf8-4e1e-8020-b3223623f2f4)
![image](https://github.com/user-attachments/assets/b04c683d-6ad3-4d4b-9274-edfe1d9c89ca)

</p>
</details>

---

# Changelog

<!--
You can add an author after the `:cl:` to change the name that appears in the changelog (ex: `:cl: Death`)
Leaving it blank will default to your GitHub display name
This includes all available types for the changelog
-->

:cl: DeltaV SolStar, Einstein Engines VMSolidus, M3739
- fix: Cloning should now properly replicate the original body's appearance.
- fix: Female kitsune should now no longer laugh like a man when in fox form.
- fix: Kitsune foxfire will now emit light, regardless of how dark the color is.
- fix: Kitsune should now no longer weigh as much as a feather.
