### PR TITLE
Fix SharedBodySystem Throwing NPE While Applying State

### DIFF
--- a/Content.Shared/Body/Systems/SharedBodySystem.Body.cs
+++ b/Content.Shared/Body/Systems/SharedBodySystem.Body.cs
@@ -254,9 +254,9 @@ public partial class SharedBodySystem
     {
         if (id is null
             || !Resolve(id.Value, ref body, logMissing: false)
-            || body.RootContainer.ContainedEntity is null
             || body is null // Shitmed Change
             || body.RootContainer == default // Shitmed Change
+            || body.RootContainer.ContainedEntity is null // Floof - moved down because it's clearly nullable
             || !Resolve(body.RootContainer.ContainedEntity.Value, ref rootPart))
         {
             yield break;


### PR DESCRIPTION
# Description
Haven't tested & can't reproduce the issue, but this should *HOPEFULLY* fix it. `Body` and `Body.RootContainer` are clearly nullable, but the null checks for them are placed AFTER the non-null-permissive property access, leading to an NPE.

Anyway, that's just my "educated guess", C# won't tell us more about the exception. This just swaps the order checks are performed in and shouldn't break anything.

# Changelog
No cl no fun