### PR TITLE
Fix the Conflict Between Slot Blocking and Loadouts

### DIFF
--- a/Content.Shared/Inventory/Events/EquipAttemptEvents.cs
+++ b/Content.Shared/Inventory/Events/EquipAttemptEvents.cs
@@ -32,6 +32,11 @@ public abstract class EquipAttemptBase : CancellableEntityEventArgs
     /// </summary>
     public string? Reason;
 
+    /// <summary>
+    ///     Floofstation - whether this is done in a way that bypasses accessibility checks, e.g. by an aghost or via loadouts.
+    /// </summary>
+    public bool BypassAccessCheck = false;
+
     public EquipAttemptBase(EntityUid equipee, EntityUid equipTarget, EntityUid equipment,
         SlotDefinition slotDefinition)
     {

--- a/Content.Shared/Inventory/Events/UnequipAttemptEvent.cs
+++ b/Content.Shared/Inventory/Events/UnequipAttemptEvent.cs
@@ -32,6 +32,11 @@ public abstract class UnequipAttemptEventBase : CancellableEntityEventArgs
     /// </summary>
     public string? Reason;
 
+    /// <summary>
+    ///     Floofstation - whether this is done in a way that bypasses accessibility checks, e.g. by an aghost or via loadouts.
+    /// </summary>
+    public bool BypassAccessCheck = false;
+
     public UnequipAttemptEventBase(EntityUid unequipee, EntityUid unEquipTarget, EntityUid equipment,
         SlotDefinition slotDefinition)
     {

--- a/Content.Shared/Inventory/InventorySystem.Equip.cs
+++ b/Content.Shared/Inventory/InventorySystem.Equip.cs
@@ -279,6 +279,7 @@ public abstract partial class InventorySystem
         }
 
         var attemptEvent = new IsEquippingAttemptEvent(actor, target, itemUid, slotDefinition);
+        attemptEvent.BypassAccessCheck = bypassAccessCheck; // Floof - done in a less destructive way
         RaiseLocalEvent(target, attemptEvent, true);
         if (attemptEvent.Cancelled)
         {
@@ -299,6 +300,7 @@ public abstract partial class InventorySystem
         }
 
         var itemAttemptEvent = new BeingEquippedAttemptEvent(actor, target, itemUid, slotDefinition);
+        itemAttemptEvent.BypassAccessCheck = bypassAccessCheck; // Floof - done in a less destructive way
         RaiseLocalEvent(itemUid, itemAttemptEvent, true);
         if (itemAttemptEvent.Cancelled)
         {

--- a/Content.Shared/_Floof/Clothing/SlotBlocker/SlotBlockerSystem.cs
+++ b/Content.Shared/_Floof/Clothing/SlotBlocker/SlotBlockerSystem.cs
@@ -1,8 +1,12 @@
 using Content.Shared.Clothing.Components;
 using Content.Shared.Examine;
+using Content.Shared.GameTicking;
+using Content.Shared.Interaction.Components;
 using Content.Shared.Inventory;
 using Content.Shared.Inventory.Events;
 using Content.Shared.Whitelist;
+using Robust.Shared.Network;
+using Robust.Shared.Player;
 
 
 namespace Content.Shared._Floof.Clothing.SlotBlocker;
@@ -14,9 +18,10 @@ public sealed class SlotBlockerSystem : EntitySystem
 
     [Dependency] private readonly InventorySystem _inventory = default!;
     [Dependency] private readonly EntityWhitelistSystem _whitelist = default!;
+    [Dependency] private readonly INetManager _net = default!;
+    [Dependency] private readonly ISharedPlayerManager _player = default!;
 
-    private EntityQuery<SlotBlockerComponent> _blockerQuery = default!;
-    private EntityQuery<ClothingComponent> _clothingQuery = default!;
+    private EntityQuery<SlotBlockerComponent> _blockerQuery;
 
     public override void Initialize()
     {
@@ -28,7 +33,6 @@ public sealed class SlotBlockerSystem : EntitySystem
         SubscribeLocalEvent<SlotBlockerComponent, BeingUnequippedAttemptEvent>(OnCheckBlockedUnequip);
 
         _blockerQuery = GetEntityQuery<SlotBlockerComponent>();
-        _clothingQuery = GetEntityQuery<ClothingComponent>();
     }
 
     private void OnMapInitSanityCheck(Entity<SlotBlockerComponent> ent, ref MapInitEvent args)
@@ -60,6 +64,8 @@ public sealed class SlotBlockerSystem : EntitySystem
     private void OnCheckSlotBlockingEquip(Entity<InventorySlotBlockingComponent> ent, ref IsEquippingAttemptEvent args)
     {
         if (args.Cancelled
+            || args.BypassAccessCheck
+            || HasComp<BypassInteractionChecksComponent>(args.Equipee)
             || _blockerQuery.HasComp(ent) // This will be handled in OnCheckBlockedEquip
             || !TryComp<InventoryComponent>(args.EquipTarget, out var inventory)
             || !IsSlotObstructed((args.EquipTarget, inventory), args.Equipment, CheckType.Equip, args.SlotFlags, out var reason))
@@ -72,6 +78,8 @@ public sealed class SlotBlockerSystem : EntitySystem
     private void OnCheckSlotBlockingUnequip(Entity<InventorySlotBlockingComponent> ent, ref IsUnequippingAttemptEvent args)
     {
         if (args.Cancelled
+            || args.BypassAccessCheck
+            || HasComp<BypassInteractionChecksComponent>(args.Unequipee)
             || _blockerQuery.HasComp(ent) // This will be handled in OnCheckBlockedUnequip
             || !TryComp<InventoryComponent>(args.UnEquipTarget, out var inventory)
             || !IsSlotObstructed((args.UnEquipTarget, inventory), args.Equipment, CheckType.Unequip, args.SlotFlags, out var reason))
@@ -84,6 +92,8 @@ public sealed class SlotBlockerSystem : EntitySystem
     private void OnCheckBlockedEquip(Entity<SlotBlockerComponent> ent, ref BeingEquippedAttemptEvent args)
     {
         if (args.Cancelled
+            || args.BypassAccessCheck
+            || HasComp<BypassInteractionChecksComponent>(args.Equipee)
             || !TryComp<InventoryComponent>(args.EquipTarget, out var inventory)
             || !IsSlotObstructed((args.EquipTarget, inventory), ent!, CheckType.Equip, args.SlotFlags, out var reason))
             return;
@@ -95,6 +105,8 @@ public sealed class SlotBlockerSystem : EntitySystem
     private void OnCheckBlockedUnequip(Entity<SlotBlockerComponent> ent, ref BeingUnequippedAttemptEvent args)
     {
         if (args.Cancelled
+            || args.BypassAccessCheck
+            || HasComp<BypassInteractionChecksComponent>(args.Unequipee)
             || !TryComp<InventoryComponent>(args.UnEquipTarget, out var inventory)
             || !IsSlotObstructed((args.UnEquipTarget, inventory), ent!, CheckType.Unequip, args.SlotFlags, out var reason))
             return;
@@ -119,10 +131,14 @@ public sealed class SlotBlockerSystem : EntitySystem
         SlotFlags targetSlot,
         out string? reason)
     {
+        // If client-side and not currently attached to the entity being checked, skip the check.
+        reason = null;
+        if (_net.IsClient && _player.LocalEntity != ent.Owner)
+            return false;
+
         if (equipment is { Comp: null }) // If entity is specified but comp is not, try to resolve it
             equipment = (equipment.Value, _blockerQuery.CompOrNull(equipment.Value));
 
-        reason = null;
         if (equipment?.Comp?.IgnoreOtherBlockers == true)
             return false;
 


### PR DESCRIPTION
# Description
Adds a new field to EquipAttemptEvent, BypassAccessCheck, and forwards the value of "bypassAccessChecks" in TryEquip through this field. This field is set to true when equipping items via loadouts, so slot blocking is no longer checked there.

Also makes it so that admin ghosts can ignore slot blocking as well, and prevents the client from predicting slot blocking on all entities other than the one it's attached to.

<details><summary><h1>Media</h1></summary>
<p>

After spawning with loadouts:

![image](https://github.com/user-attachments/assets/4a8fbf66-8aaa-44e4-8ed2-cd6f578cca0e)


</p>
</details>

# Changelog
:cl:
- fix: Slot blocking is not longer checked when applying loadouts.
