### PR TITLE
Kitsune Hotfix (Give Topicals BiologicalMetaphysical Damage Containers)

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Materials/materials.yml
+++ b/Resources/Prototypes/Entities/Objects/Materials/materials.yml
@@ -84,6 +84,7 @@
   - type: Healing
     damageContainers:
       - Biological
+      - BiologicalMetaphysical # Floof - M3739 - KitsuneFixes2
     damage:
       types:
         Slash: -0.5

--- a/Resources/Prototypes/Entities/Objects/Materials/materials.yml
+++ b/Resources/Prototypes/Entities/Objects/Materials/materials.yml
@@ -84,7 +84,7 @@
   - type: Healing
     damageContainers:
       - Biological
-      - BiologicalMetaphysical # Floof - M3739 - KitsuneFixes2
+      - BiologicalMetaphysical # Floof - M3739 - #1006
     damage:
       types:
         Slash: -0.5

--- a/Resources/Prototypes/Entities/Objects/Specific/Medical/healing.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Medical/healing.yml
@@ -30,6 +30,7 @@
   - type: Healing
     damageContainers:
       - Biological
+      - BiologicalMetaphysical # Floof - M3739 - KitsuneFixes2
     damage:
       types:
         Heat: -5
@@ -81,6 +82,7 @@
   - type: Healing
     damageContainers:
       - Biological
+      - BiologicalMetaphysical # Floof - M3739 - KitsuneFixes2
     damage:
       types:
         Heat: -10
@@ -121,6 +123,7 @@
   - type: Healing
     damageContainers:
       - Biological
+      - BiologicalMetaphysical # Floof - M3739 - KitsuneFixes2
     damage:
       groups:
         Brute: -15 # was 5 (-15 Brute) for each, Buffed due to limb damage changes # Floof - reverted
@@ -170,6 +173,7 @@
   - type: Healing
     damageContainers:
       - Biological
+      - BiologicalMetaphysical # Floof - M3739 - KitsuneFixes2
     damage:
       groups:
         Brute: -30 # was 10 for each, now 20 for each type in the group, Buffed due to Limb Damage Changes # Floof - reverted
@@ -208,6 +212,7 @@
   - type: Healing
     damageContainers:
       - Biological
+      - BiologicalMetaphysical # Floof - M3739 - KitsuneFixes2
     damage:
       types:
         Bloodloss: -0.5 #lowers bloodloss damage, was .5, buffed due to Limb Damage Changes # Floof - reverted
@@ -244,6 +249,7 @@
     - type: Healing
       damageContainers:
         - Biological
+        - BiologicalMetaphysical # Floof - M3739 - KitsuneFixes2
       damage:
         groups:
           Brute: 5 # Tourniquets HURT!
@@ -275,6 +281,7 @@
     selfHealPenaltyMultiplier: 1.5 # Floof - useful gauze
     damageContainers:
       - Biological
+      - BiologicalMetaphysical # Floof - M3739 - KitsuneFixes2
     damage:
       types:
         Slash: -5 # Was 5 # Floof - reverted

--- a/Resources/Prototypes/Entities/Objects/Specific/Medical/healing.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Medical/healing.yml
@@ -30,7 +30,7 @@
   - type: Healing
     damageContainers:
       - Biological
-      - BiologicalMetaphysical # Floof - M3739 - KitsuneFixes2
+      - BiologicalMetaphysical # Floof - M3739 - #1006
     damage:
       types:
         Heat: -5
@@ -82,7 +82,7 @@
   - type: Healing
     damageContainers:
       - Biological
-      - BiologicalMetaphysical # Floof - M3739 - KitsuneFixes2
+      - BiologicalMetaphysical # Floof - M3739 - #1006
     damage:
       types:
         Heat: -10
@@ -123,7 +123,7 @@
   - type: Healing
     damageContainers:
       - Biological
-      - BiologicalMetaphysical # Floof - M3739 - KitsuneFixes2
+      - BiologicalMetaphysical # Floof - M3739 - #1006
     damage:
       groups:
         Brute: -15 # was 5 (-15 Brute) for each, Buffed due to limb damage changes # Floof - reverted
@@ -173,7 +173,7 @@
   - type: Healing
     damageContainers:
       - Biological
-      - BiologicalMetaphysical # Floof - M3739 - KitsuneFixes2
+      - BiologicalMetaphysical # Floof - M3739 - #1006
     damage:
       groups:
         Brute: -30 # was 10 for each, now 20 for each type in the group, Buffed due to Limb Damage Changes # Floof - reverted
@@ -212,7 +212,7 @@
   - type: Healing
     damageContainers:
       - Biological
-      - BiologicalMetaphysical # Floof - M3739 - KitsuneFixes2
+      - BiologicalMetaphysical # Floof - M3739 - #1006
     damage:
       types:
         Bloodloss: -0.5 #lowers bloodloss damage, was .5, buffed due to Limb Damage Changes # Floof - reverted
@@ -249,7 +249,7 @@
     - type: Healing
       damageContainers:
         - Biological
-        - BiologicalMetaphysical # Floof - M3739 - KitsuneFixes2
+        - BiologicalMetaphysical # Floof - M3739 - #1006
       damage:
         groups:
           Brute: 5 # Tourniquets HURT!
@@ -281,7 +281,7 @@
     selfHealPenaltyMultiplier: 1.5 # Floof - useful gauze
     damageContainers:
       - Biological
-      - BiologicalMetaphysical # Floof - M3739 - KitsuneFixes2
+      - BiologicalMetaphysical # Floof - M3739 - #1006
     damage:
       types:
         Slash: -5 # Was 5 # Floof - reverted

--- a/Resources/Prototypes/Traits/physical.yml
+++ b/Resources/Prototypes/Traits/physical.yml
@@ -687,9 +687,11 @@
         - type: ShowHealthBars
           damageContainers:
           - Biological
+          - BiologicalMetaphysical # Floof - M3739 - #1006
         - type: ShowHealthIcons
           damageContainers:
           - Biological
+          - BiologicalMetaphysical # Floof - M3739 - #1006
 
 - type: trait
   id: CyberEyesDiagnostic
@@ -748,9 +750,11 @@
         - type: ShowHealthIcons
           damageContainers:
           - Biological
+          - BiologicalMetaphysical # Floof - M3739 - #1006
         - type: ShowHealthBars
           damageContainers:
           - Biological
+          - BiologicalMetaphysical # Floof - M3739 - #1006
           - Inorganic
           - Silicon
 


### PR DESCRIPTION
<!--
This is a semi-strict format, you can add/remove sections as needed but the order/format should be kept the same
Remove these comments before submitting
-->

# Description

<!--
Explain this PR in as much detail as applicable

Some example prompts to consider:
How might this affect the game? The codebase?
What might be some alternatives to this?
How/Who does this benefit/hurt [the game/codebase]?
-->

Currently, there is a bug with the kitsune that prevents them from being valid targets of topicals due to the topicals looking for the `Biological` damage container, instead of the `BiologicalMetaphysical` damage container.

This PR aims to amend that by altering all topicals to now work on entities that possess the `BiologicalMetaphysical` damage container. While they may be mythological, mysterious, or otherwise supernatural, they bleed the same as the rest of us.

Addendum: This fix also includes changes to cybereyes medhud and omnihud to allow for reading a kitsune's health via `BiologicalMetaphysical`.

<!--
This is default collapsed, readers click to expand it and see all your media
The PR media section can get very large at times, so this is a good way to keep it clean
The title is written using HTML tags
The title must be within the <summary> tags or you won't see it
-->

<details><summary><h1>Media</h1></summary>
<p>

![image](https://github.com/user-attachments/assets/b03d7819-8792-4c93-b174-5067d12fab91)
![image](https://github.com/user-attachments/assets/f13178d5-c7e9-4e84-b52f-4b7dfd16aa78)

</p>
</details>

---

# Changelog

<!--
You can add an author after the `:cl:` to change the name that appears in the changelog (ex: `:cl: Death`)
Leaving it blank will default to your GitHub display name
This includes all available types for the changelog
-->

:cl: M3739
- fix: Kitsune can now be healed by topicals.
