### PR TITLE
Remove Deathgasp Emote From the Emote Menu

### DIFF
--- a/Resources/Prototypes/Voice/speech_emotes.yml
+++ b/Resources/Prototypes/Voice/speech_emotes.yml
@@ -251,13 +251,13 @@
 - type: emote
   id: DefaultDeathgasp
   name: chat-emote-name-deathgasp
-  icon: Interface/Emotes/deathgasp.png
-  whitelist:
-    components:
-    - MobState
-  blacklist:
-    tags:
-    - SiliconEmotes
+  icon: Interface/Emotes/deathgasp.png # Floof, remove deathgasp whitelist
+  # whitelist:
+    # components:
+    # - MobState
+  # blacklist:
+    # tags:
+    # - SiliconEmotes
   chatMessages: ["chat-emote-msg-deathgasp"]
   chatTriggers:
   - deathgasp
@@ -271,10 +271,10 @@
 - type: emote
   id: SiliconDeathgasp
   name: chat-emote-name-deathgasp
-  icon: Interface/Emotes/deathgasp.png
-  whitelist:
-    tags:
-    - SiliconEmotes
+  icon: Interface/Emotes/deathgasp.png # Floof, remove deathgasp whitelist
+  # whitelist:
+    # tags:
+    # - SiliconEmotes
   chatMessages: ["chat-emote-msg-deathgasp-silicon"]
   chatTriggers:
   - sdeathgasp

--- a/Resources/Prototypes/Voice/speech_emotes.yml
+++ b/Resources/Prototypes/Voice/speech_emotes.yml
@@ -252,6 +252,7 @@
   id: DefaultDeathgasp
   name: chat-emote-name-deathgasp
   icon: Interface/Emotes/deathgasp.png # Floof, remove deathgasp whitelist
+  available: false # floof
   # whitelist:
     # components:
     # - MobState
@@ -272,6 +273,7 @@
   id: SiliconDeathgasp
   name: chat-emote-name-deathgasp
   icon: Interface/Emotes/deathgasp.png # Floof, remove deathgasp whitelist
+  available: false # floof
   # whitelist:
     # tags:
     # - SiliconEmotes


### PR DESCRIPTION
<!--
This is a semi-strict format, you can add/remove sections as needed but the order/format should be kept the same
Remove these comments before submitting
-->

# Description
The deathgasp emote is prohibited via the rules, yet it's still able to be used as an emote in the menu?
This PR removes the emote from the emote menu. It will still work when a mob dies, however.

![image](https://github.com/user-attachments/assets/43a39cab-d125-47f7-ad35-bbd67f50b613)
![image](https://github.com/user-attachments/assets/efcef0be-1811-4e0f-ad7b-81c0f7a5ab7e)
Doesn't appear in the emote menu.



:cl:
- remove: Removed being able to use the deathgasp emote from the emote menu.
