### PR TITLE
Fix Shuttle Windows Allowing Grilles Underneath to Stay Electrified

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Windows/shuttle.yml
+++ b/Resources/Prototypes/Entities/Structures/Windows/shuttle.yml
@@ -39,9 +39,6 @@
   - type: IconSmooth
     base: swindow
   - type: Appearance
-  - type: Tag
-    tags:
-      - WeldbotFixableStructure
   - type: DamageVisuals
     thresholds: [4, 8, 12]
     damageDivisor: 28


### PR DESCRIPTION
# Description
The weldbot PR broke them by overriding their tag component. Does anyone still want to ask why I always bother people to use inheritance?

This removes the unnecessary tag component (which is already inherited from the parent)

# Changelog
:cl:
- fix: Shuttle windows should no longer shock people.