### PR TITLE
Upstream Merge #2255 | Bionic Arm Rework

### DIFF
--- a/Resources/Locale/en-US/traits/misc.ftl
+++ b/Resources/Locale/en-US/traits/misc.ftl
@@ -1,5 +1,5 @@
 examine-cybereyes-message = {CAPITALIZE(POSS-ADJ($entity))} eyes shine with a faint inner light.
 examine-dermal-armor-message = {CAPITALIZE(POSS-ADJ($entity))} skin seems to be made of a sturdy, yet flexible plastic.
-examine-bionic-arm-message = {CAPITALIZE(POSS-ADJ($entity))} limbs emit an ever present faint chirp of servomotors.
+examine-bionic-arm-message = {CAPITALIZE(POSS-ADJ($entity))} arms emit an ever present faint chirp of servomotors.
 examine-bionic-leg-message = {CAPITALIZE(POSS-ADJ($entity))} legs emit an ever present faint chirp of servomotors.
 examine-thermal-vision-message = {CAPITALIZE(POSS-ADJ($entity))} eyes periodically pulse with a menacing red glare.

--- a/Resources/Locale/en-US/traits/misc.ftl
+++ b/Resources/Locale/en-US/traits/misc.ftl
@@ -1,6 +1,6 @@
 examine-cybereyes-message = {CAPITALIZE(POSS-ADJ($entity))} eyes shine with a faint inner light.
 examine-dermal-armor-message = {CAPITALIZE(POSS-ADJ($entity))} skin seems to be made of a sturdy, yet flexible plastic.
-examine-bionic-arm-message = {CAPITALIZE(POSS-ADJ($entity))} arms emit an ever present faint chirp of servomotors. A engraved marking on the shoulder states this restricted cybernetic augmentation is Central Command licensed.
+examine-bionic-arm-message = {CAPITALIZE(POSS-ADJ($entity))} arms emit an ever present faint chirp of servomotors. A engraved marking on the shoulder states that this restricted cybernetic augmentation is Central Command licensed.
 examine-bionic-leg-message = {CAPITALIZE(POSS-ADJ($entity))} legs emit an ever present faint chirp of servomotors.
 examine-thermal-vision-message = {CAPITALIZE(POSS-ADJ($entity))} eyes periodically pulse with a menacing red glare.
 examine-pry-arm-message = {CAPITALIZE(POSS-ADJ($entity))} arms emit an ever present faint chirp of servomotors.

--- a/Resources/Locale/en-US/traits/misc.ftl
+++ b/Resources/Locale/en-US/traits/misc.ftl
@@ -1,5 +1,6 @@
 examine-cybereyes-message = {CAPITALIZE(POSS-ADJ($entity))} eyes shine with a faint inner light.
 examine-dermal-armor-message = {CAPITALIZE(POSS-ADJ($entity))} skin seems to be made of a sturdy, yet flexible plastic.
-examine-bionic-arm-message = {CAPITALIZE(POSS-ADJ($entity))} arms emit an ever present faint chirp of servomotors.
+examine-bionic-arm-message = {CAPITALIZE(POSS-ADJ($entity))} arms emit an ever present faint chirp of servomotors. A engraved marking on the shoulder states this restricted cybernetic augmentation is Central Command licensed.
 examine-bionic-leg-message = {CAPITALIZE(POSS-ADJ($entity))} legs emit an ever present faint chirp of servomotors.
 examine-thermal-vision-message = {CAPITALIZE(POSS-ADJ($entity))} eyes periodically pulse with a menacing red glare.
+examine-pry-arm-message = {CAPITALIZE(POSS-ADJ($entity))} arms emit an ever present faint chirp of servomotors.

--- a/Resources/Locale/en-US/traits/misc.ftl
+++ b/Resources/Locale/en-US/traits/misc.ftl
@@ -1,6 +1,6 @@
 examine-cybereyes-message = {CAPITALIZE(POSS-ADJ($entity))} eyes shine with a faint inner light.
 examine-dermal-armor-message = {CAPITALIZE(POSS-ADJ($entity))} skin seems to be made of a sturdy, yet flexible plastic.
-examine-bionic-arm-message = {CAPITALIZE(POSS-ADJ($entity))} arms emit an ever present faint chirp of servomotors. A engraved marking on the shoulder states that this restricted cybernetic augmentation is Central Command licensed.
+examine-bionic-arm-message = {CAPITALIZE(POSS-ADJ($entity))} arms emit an ever present faint chirp of servomotors. A engraved marking on the shoulder stating that this restricted cybernetic augmentation is Central Command licensed.
 examine-bionic-leg-message = {CAPITALIZE(POSS-ADJ($entity))} legs emit an ever present faint chirp of servomotors.
 examine-thermal-vision-message = {CAPITALIZE(POSS-ADJ($entity))} eyes periodically pulse with a menacing red glare.
 examine-pry-arm-message = {CAPITALIZE(POSS-ADJ($entity))} arms emit an ever present faint chirp of servomotors.

--- a/Resources/Locale/en-US/traits/misc.ftl
+++ b/Resources/Locale/en-US/traits/misc.ftl
@@ -1,6 +1,6 @@
 examine-cybereyes-message = {CAPITALIZE(POSS-ADJ($entity))} eyes shine with a faint inner light.
 examine-dermal-armor-message = {CAPITALIZE(POSS-ADJ($entity))} skin seems to be made of a sturdy, yet flexible plastic.
-examine-bionic-arm-message = {CAPITALIZE(POSS-ADJ($entity))} arms emit an ever present faint chirp of servomotors. A engraved marking on the shoulder stating that this restricted cybernetic augmentation is Central Command licensed.
+examine-bionic-arm-message = {CAPITALIZE(POSS-ADJ($entity))} arms emit an ever present faint chirp of servomotors. An engraved marking on the shoulder states that this restricted cybernetic augmentation is Central Command licensed.
 examine-bionic-leg-message = {CAPITALIZE(POSS-ADJ($entity))} legs emit an ever present faint chirp of servomotors.
 examine-thermal-vision-message = {CAPITALIZE(POSS-ADJ($entity))} eyes periodically pulse with a menacing red glare.
 examine-pry-arm-message = {CAPITALIZE(POSS-ADJ($entity))} arms emit an ever present faint chirp of servomotors.

--- a/Resources/Locale/en-US/traits/traits.ftl
+++ b/Resources/Locale/en-US/traits/traits.ftl
@@ -517,3 +517,9 @@ trait-name-BionicLeg = Bionic Legs
 trait-description-BionicLeg =
     One or more of your limbs have been replaced with an expensive, state of the art bionic. It could be either one made of highly realistic synthflesh,
     or a more obvious metal limb. This limb provides enhanced speed to it's user, allowing you to run away from situations faster or get to a place faster.
+
+trait-name-BionicPryArm = Prybar Prosthetics
+trait-description-BionicPryArm =
+    Your arms have been reinforced with steel and hydraulics. You can force your way out of some unpleasant situations.
+    This trait gives you cybernetic DX-1 Pryarms, which let you pry open unpowered doors easily.
+    (They essentially function like a crowbar)

--- a/Resources/Prototypes/Traits/physical.yml
+++ b/Resources/Prototypes/Traits/physical.yml
@@ -516,7 +516,7 @@
         - SpiderCraft
 
 - type: trait
-  id: BionicArm
+  id: BionicPryArm
   category: Physical
   points: -3 # Floof - since you can't get free JoL anymore
   requirements:
@@ -868,3 +868,40 @@
 #        - description: examine-thermal-vision-message
 #          fontSize: 12
 #          requireDetailRange: true
+
+- type: trait
+  id: BionicArm
+  category: Physical
+  points: -8
+  requirements:
+    - !type:CharacterLogicOrRequirement
+      requirements:
+      - !type:CharacterJobRequirement
+        jobs:
+         - Paramedic
+         - SeniorPhysician # Floofstation - Physicians have Paramedic access here
+      - !type:CharacterDepartmentRequirement
+          departments:
+          - Security
+          - Command
+          - Dignitary
+    - !type:CharacterTraitRequirement
+      inverted: true
+      traits:
+        - BionicPryArm
+  functions:
+    - !type:TraitCyberneticLimbReplacement
+      removeBodyPart: Arm
+      partSymmetry: Left
+      protoId: JawsOfLifeLeftArm
+      slotId: "left arm"
+    - !type:TraitCyberneticLimbReplacement
+      removeBodyPart: Arm
+      partSymmetry: Right
+      protoId: JawsOfLifeRightArm
+      slotId: "right arm"
+    - !type:TraitPushDescription
+      descriptionExtensions:
+        - description: examine-bionic-arm-message
+          fontSize: 12
+          requireDetailRange: true

--- a/Resources/Prototypes/Traits/physical.yml
+++ b/Resources/Prototypes/Traits/physical.yml
@@ -524,6 +524,8 @@
       inverted: true
       jobs:
         - Prisoner # Bionics should be "Confiscated" from long term prisoners.
+        - Anomaly
+        - Gladiator
     - !type:CharacterTraitRequirement
       inverted: true
       traits:
@@ -890,6 +892,7 @@
           - Security
           - Command
           - Dignitary
+          - Engineering # Floofstation - Weird this wasn't upstream
     - !type:CharacterTraitRequirement
       inverted: true
       traits:

--- a/Resources/Prototypes/Traits/physical.yml
+++ b/Resources/Prototypes/Traits/physical.yml
@@ -518,23 +518,30 @@
 - type: trait
   id: BionicPryArm
   category: Physical
-  points: -3 # Floof - since you can't get free JoL anymore
+  points: -2
   requirements:
     - !type:CharacterJobRequirement
       inverted: true
       jobs:
         - Prisoner # Bionics should be "Confiscated" from long term prisoners.
-        - Gladiator
-        - Anomaly
+    - !type:CharacterTraitRequirement
+      inverted: true
+      traits:
+        - BionicArm
   functions:
-    - !type:TraitAddComponent
-      components:
-        - type: Prying
-          speedModifier: 1
-          pryPowered: false # Floof
+    - !type:TraitCyberneticLimbReplacement
+      removeBodyPart: Arm
+      partSymmetry: Left
+      protoId: CrowbarLeftArm
+      slotId: "left arm"
+    - !type:TraitCyberneticLimbReplacement
+      removeBodyPart: Arm
+      partSymmetry: Right
+      protoId: CrowbarRightArm
+      slotId: "right arm"
     - !type:TraitPushDescription
       descriptionExtensions:
-        - description: examine-bionic-arm-message
+        - description: examine-bionic-pryarm-message
           fontSize: 12
           requireDetailRange: true
 

--- a/Resources/Prototypes/Traits/physical.yml
+++ b/Resources/Prototypes/Traits/physical.yml
@@ -543,7 +543,7 @@
       slotId: "right arm"
     - !type:TraitPushDescription
       descriptionExtensions:
-        - description: examine-bionic-arm-message
+        - description: examine-pry-arm-message
           fontSize: 12
           requireDetailRange: true
 

--- a/Resources/Prototypes/Traits/physical.yml
+++ b/Resources/Prototypes/Traits/physical.yml
@@ -627,7 +627,6 @@
       components:
         - type: Flashable # Effectively, removes any flash-vulnerability species traits.
 
-
 - type: trait
   id: FlareShielding
   category: Physical
@@ -641,7 +640,6 @@
       components:
         - type: FlashImmunity
         - type: EyeProtection
-
 
 - type: trait
   id: CyberEyesSecurity

--- a/Resources/Prototypes/Traits/physical.yml
+++ b/Resources/Prototypes/Traits/physical.yml
@@ -543,7 +543,7 @@
       slotId: "right arm"
     - !type:TraitPushDescription
       descriptionExtensions:
-        - description: examine-bionic-pryarm-message
+        - description: examine-bionic-arm-message
           fontSize: 12
           requireDetailRange: true
 

--- a/Resources/Prototypes/Traits/physical.yml
+++ b/Resources/Prototypes/Traits/physical.yml
@@ -891,7 +891,6 @@
         departments:
           - Security
           - Command
-          - Dignitary
           - Engineering # Floofstation - Weird this wasn't upstream
     - !type:CharacterTraitRequirement
       inverted: true

--- a/Resources/Prototypes/Traits/physical.yml
+++ b/Resources/Prototypes/Traits/physical.yml
@@ -888,7 +888,7 @@
          - Paramedic
          - SeniorPhysician # Floofstation - Physicians have Paramedic access here
       - !type:CharacterDepartmentRequirement
-          departments:
+        departments:
           - Security
           - Command
           - Dignitary

--- a/Resources/Prototypes/Traits/physical.yml
+++ b/Resources/Prototypes/Traits/physical.yml
@@ -885,8 +885,8 @@
       requirements:
       - !type:CharacterJobRequirement
         jobs:
-         - Paramedic
-         - SeniorPhysician # Floofstation - Physicians have Paramedic access here
+          - Paramedic
+          - SeniorPhysician # Floofstation - Physicians have Paramedic access here
       - !type:CharacterDepartmentRequirement
         departments:
           - Security

--- a/Resources/Prototypes/_Shitmed/Body/Parts/cybernetic.yml
+++ b/Resources/Prototypes/_Shitmed/Body/Parts/cybernetic.yml
@@ -181,3 +181,25 @@
         - Shard
         - Mousetrap
         - SlipEntity
+
+- type: entity
+  parent: LeftArmCybernetic
+  id: CrowbarLeftArm
+  name: DX-1 left Pryarm
+  description: A cybernetic left arm that can easily pry open unpowered doors.
+  components:
+  - type: BodyPart
+    onAdd:
+    - type: Prying
+      speedModifier: 2
+
+- type: entity
+  parent: RightArmCybernetic
+  id: CrowbarRightArm
+  name: DX-1 right Pryarm
+  description: A cybernetic right arm that can easily pry open unpowered doors.
+  components:
+  - type: BodyPart
+    onAdd:
+    - type: Prying
+      speedModifier: 2


### PR DESCRIPTION
# Description

Bionic Arms reworked to Bionic Pry Arms which means, nothing really changed, except, the arm is actually replaced and EMPable. Lowered cost slightly since they're EMPable tho.

Bionic Arms POWERED PRY returns, but as an actual EMPable arm replacement with job restrictions. No more secure access for tiders.

# Changelog

:cl:
- add: added Bionic Pry Arms Trait, which works like how Bionic Arms works currently on Floof but it can be EMP'd and replaces your actual arms. One point cheaper as a result.
- tweak: Bionic Arms Trait with powered pry returns, as an actual emp-able arm replacement but with heavy job restrictions.

