### PR TITLE
Upstream Merge #1828/#2008/#2011/#2382 | 10 Point Trait Buff + Trait Touch Ups

### DIFF
--- a/Resources/Locale/en-US/traits/traits.ftl
+++ b/Resources/Locale/en-US/traits/traits.ftl
@@ -260,17 +260,22 @@ trait-description-LightStep =
 trait-name-Swashbuckler = Swashbuckler
 trait-description-Swashbuckler =
     You are an expert in swordsmanship, wielding swords, knives, and other blades with unrivaled finesse.
-    Your melee Slash bonus is increased to 35%, but your melee Blunt bonus is reduced to 20%.
+    Your melee Slash bonus is increased to 35%, but your melee Blunt bonus is reduced to 25%.
 
 trait-name-Spearmaster = Spearmaster
 trait-description-Spearmaster =
     You have an outstanding proficiency with spears, wielding them as an extension of your body.
-    Your melee Piercing bonus is increased to 35%, but your melee Blunt bonus is reduced to 20%.
+    Your melee Piercing bonus is increased to 35%, but your melee Blunt bonus is reduced to 25%.
 
 trait-name-WeaponsGeneralist = Weapons Generalist
 trait-description-WeaponsGeneralist =
     You are a jack of all trades with melee weapons, enabling you to be versatile with your weapon arsenal.
-    Your melee damage bonus for all Brute damage types (Blunt, Slash, Piercing) becomes 25%.
+    Your melee damage bonus for all Brute damage types (Blunt, Slash, Piercing) becomes 30%.
+
+trait-name-Mystic = Mystic
+trait-description-Mystic =
+    You are trained in Mysticism instead of melee combat, reducing your melee capabilities but drastically increasing your psionic potential.
+    Your melee damage bonus for all Brute damage types (Blunt, Slash, Piercing) becomes 5%, but your Potentia gain is drastically increased.
 
 trait-name-Singer = Singer
 trait-description-Singer = You are naturally capable of singing simple melodies with your voice.

--- a/Resources/Prototypes/Psionics/psionics.yml
+++ b/Resources/Prototypes/Psionics/psionics.yml
@@ -453,7 +453,7 @@
       assayFeedback: power-overwhelming-power-feedback
     - !type:AddPsionicPsychognomicDescriptors
       psychognomicDescriptor: OVERWHELMING
-  powerSlotCost: 2
+  powerSlotCost: 0
 
 - type: psionicPower
   id: LowDampening

--- a/Resources/Prototypes/Traits/disabilities.yml
+++ b/Resources/Prototypes/Traits/disabilities.yml
@@ -255,6 +255,10 @@
       inverted: true
       species:
         - IPC
+    - !type:CharacterTraitRequirement
+      inverted: true
+      traits:
+        - PlateletFactories
   functions:
     - !type:TraitAddComponent
       components:

--- a/Resources/Prototypes/Traits/mental.yml
+++ b/Resources/Prototypes/Traits/mental.yml
@@ -36,12 +36,12 @@
     - !type:TraitReplaceComponent
       components:
         - type: PotentiaModifier
-          potentiaMultiplier: 1.25
+          potentiaMultiplier: 1.5
 
 - type: trait
   id: LowPotential
   category: Mental
-  points: 4
+  points: 5
   requirements:
     - !type:CharacterLogicOrRequirement
       requirements:
@@ -75,7 +75,7 @@
     - !type:TraitReplaceComponent
       components:
         - type: PotentiaModifier
-          potentiaMultiplier: 0.75
+          potentiaMultiplier: 0.5
 
 - type: trait
   id: LowAmplification
@@ -253,7 +253,7 @@
 - type: trait
   id: DispelPower
   category: Mental
-  points: -6
+  points: -4
   requirements:
     - !type:CharacterLogicOrRequirement
       requirements:
@@ -286,7 +286,7 @@
 - type: trait
   id: MetapsionicPower
   category: Mental
-  points: -4
+  points: -2
   requirements:
     - !type:CharacterLogicOrRequirement
       requirements:
@@ -355,7 +355,7 @@
 - type: trait
   id: PsychognomyPower
   category: Mental
-  points: -3
+  points: -1
   requirements:
     - !type:CharacterLogicOrRequirement
       requirements:

--- a/Resources/Prototypes/Traits/physical.yml
+++ b/Resources/Prototypes/Traits/physical.yml
@@ -451,30 +451,17 @@
 - type: trait
   id: StrikingCalluses
   category: Physical
-  points: -4
+  points: -2
   requirements:
     - !type:CharacterJobRequirement
       inverted: true
       jobs:
         - Prisoner # Bionics should be "Confiscated" from long term prisoners.
-        - Gladiator # Floof
-    - !type:CharacterSpeciesRequirement
-      species:
-        - Human # Entirely arbitrary, I've decided I want a trait unique to humans. Since they don't normally get anything exciting.
-                # When we get the Character Records system in, I also want to make this require certain Backgrounds.
     - !type:CharacterTraitRequirement
       inverted: true
       traits:
         - Claws
         - Talons
-    - !type:CharacterLogicOrRequirement
-      requirements:
-        - !type:CharacterTraitRequirement
-          traits:
-            - MartialArtist
-        - !type:CharacterJobRequirement
-          jobs:
-            - Boxer
   functions:
     - !type:TraitReplaceComponent
       components:
@@ -485,7 +472,7 @@
           animation: WeaponArcFist
           damage:
             types:
-              Blunt: 6
+              Blunt: 7
 
 - type: trait
   id: Spinarette
@@ -508,7 +495,7 @@
       components:
         - type: Sericulture
           action: ActionSericulture
-          productionLength: 2
+          productionLength: 1
           entityProduced: MaterialWebSilk1
           hungerCost: 1
     - !type:TraitAddTag
@@ -718,6 +705,7 @@
     - !type:CharacterDepartmentRequirement
       departments:
         - Security
+        - Command
     - !type:CharacterTraitRequirement
       traits:
         - CyberEyes

--- a/Resources/Prototypes/Traits/physical.yml
+++ b/Resources/Prototypes/Traits/physical.yml
@@ -554,11 +554,11 @@
           damageCap: 400
           damage:
             groups:
-              Brute: -0.35
-              Burn: -0.35
+              Brute: -0.30
+              Burn: -0.30
               Airloss: -0.25
-              Toxin: -0.35
-              Genetic: -0.35
+              Toxin: -0.30
+              Genetic: -0.2
         - type: BloodDeficiency # Incredibly actually works
           bloodLossPercentage: -0.025
 

--- a/Resources/Prototypes/Traits/physical.yml
+++ b/Resources/Prototypes/Traits/physical.yml
@@ -553,6 +553,10 @@
       inverted: true
       species:
         - IPC
+    - !type:CharacterTraitRequirement
+      inverted: true
+      traits:
+        - BloodDeficiency
   functions: # TODO: Code Platelet factories as an actual obtainable implant, and replace this with TraitAddImplant
     - !type:TraitReplaceComponent
       components:
@@ -560,14 +564,16 @@
           allowedStates:
           - Alive
           - Critical
-          damageCap: 200
+          damageCap: 400
           damage:
             groups:
-              Brute: -0.07
-              Burn: -0.07
-              Airloss: -0.07
-              Toxin: -0.07
-              Genetic: -0.07
+              Brute: -0.35
+              Burn: -0.35
+              Airloss: -0.25
+              Toxin: -0.35
+              Genetic: -0.35
+        - type: BloodDeficiency # Incredibly actually works
+          bloodLossPercentage: -0.025
 
 - type: trait
   id: DermalArmor

--- a/Resources/Prototypes/Traits/species.yml
+++ b/Resources/Prototypes/Traits/species.yml
@@ -5,8 +5,8 @@
   functions:
     - !type:TraitReplaceComponent
       components:
-      - type: OniDamageModifier
-        modifiers:
+      - type: BonusMeleeDamage
+        damageModifierSet:
           coefficients:
             Blunt: 1.25
             Slash: 1.35
@@ -30,8 +30,8 @@
   functions:
     - !type:TraitReplaceComponent
       components:
-      - type: OniDamageModifier
-        modifiers:
+      - type: BonusMeleeDamage
+        damageModifierSet:
           coefficients:
             Blunt: 1.25
             Slash: 1.25
@@ -55,8 +55,8 @@
   functions:
     - !type:TraitReplaceComponent
       components:
-      - type: OniDamageModifier
-        modifiers:
+      - type: BonusMeleeDamage
+        damageModifierSet:
           coefficients:
             Blunt: 1.30
             Slash: 1.30
@@ -80,8 +80,8 @@
   functions:
     - !type:TraitReplaceComponent
       components:
-      - type: OniDamageModifier
-        modifiers:
+      - type: BonusMeleeDamage
+        damageModifierSet:
           coefficients:
             Blunt: 1.05
             Slash: 1.05

--- a/Resources/Prototypes/Traits/species.yml
+++ b/Resources/Prototypes/Traits/species.yml
@@ -1,17 +1,17 @@
 - type: trait
   id: Swashbuckler
   category: Physical
-  points: -2
+  points: -1
   functions:
     - !type:TraitReplaceComponent
       components:
-      - type: BonusMeleeDamage # Floof - Oni refactor
-        damageModifierSet:
+      - type: OniDamageModifier
+        modifiers:
           coefficients:
-            Blunt: 1.2
+            Blunt: 1.25
             Slash: 1.35
-            Piercing: 1.2
-            Asphyxiation: 1.35 # Floof - since these traits override the damage modifier set, asphxiation needs re-added. Not that it uh, does anything?
+            Piercing: 1.25
+            Asphyxiation: 1.35
   requirements:
     - !type:CharacterSpeciesRequirement
       species:
@@ -21,21 +21,22 @@
       traits:
         - Spearmaster
         - WeaponsGeneralist
-
+        - Mystic
+        
 - type: trait
   id: Spearmaster
   category: Physical
-  points: -2
+  points: -1
   functions:
     - !type:TraitReplaceComponent
       components:
-      - type: BonusMeleeDamage # Floof - oni refector
-        damageModifierSet:
+      - type: OniDamageModifier
+        modifiers:
           coefficients:
-            Blunt: 1.2
-            Slash: 1.2
+            Blunt: 1.25
+            Slash: 1.25
             Piercing: 1.35
-            Asphyxiation: 1.35 # Floof
+            Asphyxiation: 1.35
   requirements:
     - !type:CharacterSpeciesRequirement
       species:
@@ -45,21 +46,22 @@
       traits:
         - Swashbuckler
         - WeaponsGeneralist
+        - Mystic
 
 - type: trait
   id: WeaponsGeneralist
   category: Physical
-  points: -2
+  points: -1
   functions:
     - !type:TraitReplaceComponent
       components:
-      - type: BonusMeleeDamage # Floof - Oni refactor
-        damageModifierSet:
+      - type: OniDamageModifier
+        modifiers:
           coefficients:
-            Blunt: 1.25
-            Slash: 1.25
-            Piercing: 1.25
-            Asphyxiation: 1.35 # Floof
+            Blunt: 1.30
+            Slash: 1.30
+            Piercing: 1.30
+            Asphyxiation: 1.35
   requirements:
     - !type:CharacterSpeciesRequirement
       species:
@@ -69,4 +71,42 @@
       traits:
         - Swashbuckler
         - Spearmaster
+        - Mystic
 
+- type: trait
+  id: Mystic
+  category: Mental
+  points: -1
+  functions:
+    - !type:TraitReplaceComponent
+      components:
+      - type: OniDamageModifier
+        modifiers:
+          coefficients:
+            Blunt: 1.05
+            Slash: 1.05
+            Piercing: 1.05
+            Asphyxiation: 1.05
+      - type: PotentiaModifier
+        potentiaMultiplier: 1.5
+  requirements:
+    - !type:CharacterSpeciesRequirement
+      species:
+        - Oni
+    - !type:CharacterTraitRequirement
+      inverted: true
+      traits:
+        - Swashbuckler
+        - Spearmaster
+        - WeaponsGeneralist
+    - !type:CharacterLogicOrRequirement
+      requirements:
+        - !type:CharacterTraitRequirement
+          traits:
+            - LatentPsychic
+        - !type:CharacterJobRequirement
+          jobs:
+            - Chaplain
+            - Librarian
+            - ResearchDirector
+            - ForensicMantis


### PR DESCRIPTION
# Description

Upstream Merge which changes the big 10 pointer traits to be more impactful rather then newbie traps.

This changes Platelet Factories to the one EE is currently using, which provides 5 times the healing (4 times airloss) [#1828](https://github.com/Simple-Station/Einstein-Engines/pull/1828) and greatly improved natural blood regeneration. [#2382](https://github.com/Simple-Station/Einstein-Engines/pull/2382)

Also changes Power Overwhelming to no longer use 2 spell slots, which made people unable to get new spells.  [#2011](https://github.com/Simple-Station/Einstein-Engines/pull/2011) Does not include the full #2011 pull, as I'm pretty sure we'll spend all week arguing over healing word being a round start trait.

Tweaks to Psionics cost, effectively useless/niche round start powers are slightly cheaper, 

Striking Calluses no longer has a bazillion restrictions, +1 damage and is cheaper. (changed from the original to use the wide punch we have here)

Spinarette works a little faster now.

Fixes the Oni Traits numbers too [#2008](https://github.com/Simple-Station/Einstein-Engines/pull/2008)

Added Oni Mystic Trait, which is high potential but you give up most of your melee bonuses (30% down to 5%) 

I started this as a fix for the 10 cost traits, and ended up having to merge the rest of the stuff along with it so it doesn't cause issues.

# Changelog

:cl:

- tweak: Platelet Factories buffed from 0.07 to 0.35 (0.25 airloss) and improves natural blood regeneration.
- tweak: Power Overwhelming no longer uses 2 spell slots. (For those who don't understand the esoteric psionics system, makes it so you don't have to drink 3 times as many drugs for your first spell)
- tweak: Striking Calluses doesn't have 3 different requirements anymore, does a little more damage and costs less.
- tweak: Spinarette spins slightly faster.
- tweak: Roundstart psionic powers are slightly cheaper (because they're niche/useless)
- tweak: Low/High Potential are now lower and higher.
- tweak: Oni traits aren't a debuff anymore.
- added: Oni Mystic trait for the Shrine Maidens, nerfs Oni melee bonus in exchange for potentia gain.