### PR TITLE
Id Lockable Airlocks

### DIFF
--- a/Content.Shared/_Floof/Lock/DoorLockSystem.cs
+++ b/Content.Shared/_Floof/Lock/DoorLockSystem.cs
@@ -1,0 +1,33 @@
+using Content.Shared.Doors;
+using Content.Shared.Emag.Components;
+using Content.Shared.Lock;
+using Content.Shared.Popups;
+using Robust.Shared.Network;
+
+
+namespace Content.Shared._Floof.Lock;
+
+
+/// <summary>
+///     Prevents locked doors from being opened.
+/// </summary>
+public sealed class DoorLockSystem : EntitySystem
+{
+    [Dependency] private readonly INetManager _net = default!;
+    [Dependency] private readonly SharedPopupSystem _popup = default!;
+
+    public override void Initialize()
+    {
+        SubscribeLocalEvent<LockComponent, BeforeDoorOpenedEvent>(OnDoorOpenAttempt);
+    }
+
+    private void OnDoorOpenAttempt(Entity<LockComponent> ent, ref BeforeDoorOpenedEvent args)
+    {
+        if (!ent.Comp.Locked || ent.Comp.BreakOnEmag && HasComp<EmaggedComponent>(ent))
+            return;
+
+        args.Cancel();
+        if (args.User is {} user && _net.IsServer)
+            _popup.PopupCursor(Loc.GetString("entity-storage-component-locked-message"), user);
+    }
+}

--- a/Resources/Prototypes/_Floof/Entities/Structures/Doors/Airlocks/lockable_airlock.yml
+++ b/Resources/Prototypes/_Floof/Entities/Structures/Doors/Airlocks/lockable_airlock.yml
@@ -1,0 +1,24 @@
+# Does not reveal info and has no masters
+- type: entity
+  id: AirlockLockableBaseNoAccess
+  parent: [IdLockableBaseNoAccess, Airlock]
+  name: Lockable Airlock
+  abstract: true
+  components:
+  - type: Lock
+    locked: false
+
+# Reveals info and has Captain and HoP as masters
+- type: entity
+  id: AirlockLockableBase
+  parent: [IdLockableBase, Airlock]
+  name: Lockable Airlock
+  abstract: true
+
+# Dorms airlock
+- type: entity
+  id: AirlockLockableDorms
+  name: dorms airlock
+  description: It opens, it closes, and it can be locked to your ID card.
+  suffix: ID lockable
+  parent: AirlockLockableBase

--- a/Resources/Prototypes/_Floof/Entities/Structures/Doors/Airlocks/lockable_airlock.yml
+++ b/Resources/Prototypes/_Floof/Entities/Structures/Doors/Airlocks/lockable_airlock.yml
@@ -11,7 +11,7 @@
 # Reveals info and has Captain and HoP as masters
 - type: entity
   id: AirlockLockableBase
-  parent: [IdLockableBase, Airlock]
+  parent: [IdLockableBase, AirlockLockableBaseNoAccess]
   name: Lockable Airlock
   abstract: true
 


### PR DESCRIPTION
# Description
Adds support for LockComponent on doors, adds some basic related prototypes.

Right now adds only one single dorms airlock prototype which is ID-lockable, it should help with privacy issues related to dorms.

# TODO
- [X] Test this
- [ ] Annoy mappers to map those if they want to

<details><summary><h1>Media</h1></summary>
<p>




https://github.com/user-attachments/assets/757203a7-4946-4384-a2d4-a95b1c88c4a9



</p>
</details>

# Changelog
:cl:
- add: Airlocks can now have ID locks installed on them. Currently only available to mappers.
