### PR TITLE
Task Kitsunebi (Fix Foxfires, Locale)

### DIFF
--- a/Content.Server/_DV/Abilities/Kitsune/KitsuneSystem.cs
+++ b/Content.Server/_DV/Abilities/Kitsune/KitsuneSystem.cs
@@ -76,7 +76,7 @@ public sealed class KitsuneSystem : SharedKitsuneSystem
             _faction.AddFactions(newEntity, factions.Factions);
         }
 
-        _popup.PopupEntity(Loc.GetString("kitsune-popup-morph-message-others", ("entity", args.NewEntity)), args.NewEntity, Filter.PvsExcept(args.NewEntity), true);
+        _popup.PopupEntity(Loc.GetString("kitsune-popup-morph-message-others", ("target", args.NewEntity)), args.NewEntity, Filter.PvsExcept(args.NewEntity), true);
         _popup.PopupEntity(Loc.GetString("kitsune-popup-morph-message-user"), args.NewEntity, args.NewEntity);
     }
 

--- a/Content.Server/_DV/Abilities/Kitsune/KitsuneSystem.cs
+++ b/Content.Server/_DV/Abilities/Kitsune/KitsuneSystem.cs
@@ -76,7 +76,7 @@ public sealed class KitsuneSystem : SharedKitsuneSystem
             _faction.AddFactions(newEntity, factions.Factions);
         }
 
-        _popup.PopupEntity(Loc.GetString("kitsune-popup-morph-message-others", ("target", args.NewEntity)), args.NewEntity, Filter.PvsExcept(args.NewEntity), true);
+        _popup.PopupEntity(Loc.GetString("kitsune-popup-morph-message-others", ("target", args.NewEntity)), args.NewEntity, Filter.PvsExcept(args.NewEntity), true); // Floof - M3739 - #1030
         _popup.PopupEntity(Loc.GetString("kitsune-popup-morph-message-user"), args.NewEntity, args.NewEntity);
     }
 

--- a/Content.Shared/_DV/Abilities/Kitsune/SharedKitsuneSystem.cs
+++ b/Content.Shared/_DV/Abilities/Kitsune/SharedKitsuneSystem.cs
@@ -63,13 +63,12 @@ public abstract class SharedKitsuneSystem : EntitySystem
             _popup.PopupEntity(Loc.GetString("fox-no-hands"), ent, ent);
             return;
         }
-
+        // Floof - M3739 - KitsuneFixes - Do not allow additional fox fires if they have no charges. They will have to wait.
         if (_actions.GetCharges(ent.Comp.FoxfireAction) <= 0)
         {
             _popup.PopupEntity(Loc.GetString("fox-no-charges"), ent, ent);
             return;
         }
-
         // Floof - M3739 - KitsuneFixes3 - This... is probably the least intrusive solution to the infinite foxfire problem.
         // Ensure that the number of active fox fires does not exceed 3. If there is 3 or more, remove the oldest one.
         if (ent.Comp.ActiveFoxFires.Count >= 3)
@@ -82,7 +81,7 @@ public abstract class SharedKitsuneSystem : EntitySystem
         var fireComp = EnsureComp<FoxfireComponent>(fireEnt);
         fireComp.Kitsune = ent;
         ent.Comp.ActiveFoxFires.Add(fireEnt);
-        _actions.RemoveCharges(ent.Comp.FoxfireAction, 1);
+        _actions.RemoveCharges(ent.Comp.FoxfireAction, 1); // Floof - M3739 - KitsuneFixes3
         Dirty(fireEnt, fireComp);
         Dirty(ent);
 

--- a/Content.Shared/_DV/Abilities/Kitsune/SharedKitsuneSystem.cs
+++ b/Content.Shared/_DV/Abilities/Kitsune/SharedKitsuneSystem.cs
@@ -63,13 +63,13 @@ public abstract class SharedKitsuneSystem : EntitySystem
             _popup.PopupEntity(Loc.GetString("fox-no-hands"), ent, ent);
             return;
         }
-        // Floof - M3739 - KitsuneFixes - Do not allow additional fox fires if they have no charges. They will have to wait.
+        // Floof - M3739 - #1030 - Do not allow additional fox fires if they have no charges. They will have to wait.
         if (_actions.GetCharges(ent.Comp.FoxfireAction) <= 0)
         {
             _popup.PopupEntity(Loc.GetString("fox-no-charges"), ent, ent);
             return;
         }
-        // Floof - M3739 - KitsuneFixes3 - This... is probably the least intrusive solution to the infinite foxfire problem.
+        // Floof - M3739 - #1030 - This... is probably the least intrusive solution to the infinite foxfire problem.
         // Ensure that the number of active fox fires does not exceed max charges.
         if (!TryComp<InstantActionComponent>(ent.Comp.FoxfireAction, out var instantActionComp))
             return;
@@ -83,7 +83,7 @@ public abstract class SharedKitsuneSystem : EntitySystem
         var fireComp = EnsureComp<FoxfireComponent>(fireEnt);
         fireComp.Kitsune = ent;
         ent.Comp.ActiveFoxFires.Add(fireEnt);
-        _actions.RemoveCharges(ent.Comp.FoxfireAction, 1); // Floof - M3739 - KitsuneFixes3
+        _actions.RemoveCharges(ent.Comp.FoxfireAction, 1); // Floof - M3739 - #1030
         Dirty(fireEnt, fireComp);
         Dirty(ent);
 

--- a/Content.Shared/_DV/Abilities/Kitsune/SharedKitsuneSystem.cs
+++ b/Content.Shared/_DV/Abilities/Kitsune/SharedKitsuneSystem.cs
@@ -64,8 +64,15 @@ public abstract class SharedKitsuneSystem : EntitySystem
             return;
         }
 
-        // This caps the amount of fox fire summons at a time to the charge count, deleting the oldest fire when exceeded.
-        if (_actions.GetCharges(ent.Comp.FoxfireAction) < 1)
+        if (_actions.GetCharges(ent.Comp.FoxfireAction) <= 0)
+        {
+            _popup.PopupEntity(Loc.GetString("fox-no-charges"), ent, ent);
+            return;
+        }
+
+        // Floof - M3739 - KitsuneFixes3 - This... is probably the least intrusive solution to the infinite foxfire problem.
+        // Ensure that the number of active fox fires does not exceed 3. If there is 3 or more, remove the oldest one.
+        if (ent.Comp.ActiveFoxFires.Count >= 3)
         {
             QueueDel(ent.Comp.ActiveFoxFires[0]);
             ent.Comp.ActiveFoxFires.RemoveAt(0);
@@ -75,6 +82,7 @@ public abstract class SharedKitsuneSystem : EntitySystem
         var fireComp = EnsureComp<FoxfireComponent>(fireEnt);
         fireComp.Kitsune = ent;
         ent.Comp.ActiveFoxFires.Add(fireEnt);
+        _actions.RemoveCharges(ent.Comp.FoxfireAction, 1);
         Dirty(fireEnt, fireComp);
         Dirty(ent);
 

--- a/Content.Shared/_DV/Abilities/Kitsune/SharedKitsuneSystem.cs
+++ b/Content.Shared/_DV/Abilities/Kitsune/SharedKitsuneSystem.cs
@@ -70,8 +70,10 @@ public abstract class SharedKitsuneSystem : EntitySystem
             return;
         }
         // Floof - M3739 - KitsuneFixes3 - This... is probably the least intrusive solution to the infinite foxfire problem.
-        // Ensure that the number of active fox fires does not exceed 3. If there is 3 or more, remove the oldest one.
-        if (ent.Comp.ActiveFoxFires.Count >= 3)
+        // Ensure that the number of active fox fires does not exceed max charges.
+        if (!TryComp<InstantActionComponent>(ent.Comp.FoxfireAction, out var instantActionComp))
+            return;
+        if (ent.Comp.ActiveFoxFires.Count >= instantActionComp.MaxCharges)
         {
             QueueDel(ent.Comp.ActiveFoxFires[0]);
             ent.Comp.ActiveFoxFires.RemoveAt(0);

--- a/Resources/Locale/en-US/deltav/actions/kitsune.ftl
+++ b/Resources/Locale/en-US/deltav/actions/kitsune.ftl
@@ -3,3 +3,4 @@ kitsune-popup-morph-message-other = {$target} shifts their form
 kitsune-popup-morph-message-user = You shift your form
 kitsune-popup-cant-morph-stamina = You are too exhausted!
 fox-no-hands = You can't make a wisp without a hand
+fox-no-charge = You can't make another wisp!

--- a/Resources/Locale/en-US/deltav/actions/kitsune.ftl
+++ b/Resources/Locale/en-US/deltav/actions/kitsune.ftl
@@ -3,4 +3,5 @@ kitsune-popup-morph-message-others = {$target} shifts their form
 kitsune-popup-morph-message-user = You shift your form
 kitsune-popup-cant-morph-stamina = You are too exhausted!
 fox-no-hands = You can't make a wisp without a hand
+# Floof - M3739 - #1030 - fox-no-charges
 fox-no-charges = You can't make another wisp!

--- a/Resources/Locale/en-US/deltav/actions/kitsune.ftl
+++ b/Resources/Locale/en-US/deltav/actions/kitsune.ftl
@@ -1,6 +1,6 @@
 petting-success-soft-floofy-kitsune = You gently pat {THE($target)}
-kitsune-popup-morph-message-other = {$target} shifts their form
+kitsune-popup-morph-message-others = {$target} shifts their form
 kitsune-popup-morph-message-user = You shift your form
 kitsune-popup-cant-morph-stamina = You are too exhausted!
 fox-no-hands = You can't make a wisp without a hand
-fox-no-charge = You can't make another wisp!
+fox-no-charges = You can't make another wisp!

--- a/Resources/Prototypes/DeltaV/Entities/Objects/Specific/Species/kitsune.yml
+++ b/Resources/Prototypes/DeltaV/Entities/Objects/Specific/Species/kitsune.yml
@@ -41,4 +41,6 @@
       behaviors:
       - !type:DoActsBehavior
         acts: ["Destruction"]
+  - type: TimedDespawn # Floof - M3739 - KitsuneFixes3 - poor man's cooldown, sadge. Maybe someday I'll do this a better way.
+    lifetime: 120
   - type: InteractionOutline

--- a/Resources/Prototypes/DeltaV/Entities/Objects/Specific/Species/kitsune.yml
+++ b/Resources/Prototypes/DeltaV/Entities/Objects/Specific/Species/kitsune.yml
@@ -41,6 +41,6 @@
       behaviors:
       - !type:DoActsBehavior
         acts: ["Destruction"]
-  - type: TimedDespawn # Floof - M3739 - KitsuneFixes3 - poor man's cooldown, sadge. Maybe someday I'll do this a better way.
+  - type: TimedDespawn # Floof - M3739 - #1030 - poor man's cooldown, sadge. Maybe someday I'll do this a better way.
     lifetime: 120
   - type: InteractionOutline


### PR DESCRIPTION
<!--
This is a semi-strict format, you can add/remove sections as needed but the order/format should be kept the same
Remove these comments before submitting
-->

# Description

<!--
Explain this PR in as much detail as applicable

Some example prompts to consider:
How might this affect the game? The codebase?
What might be some alternatives to this?
How/Who does this benefit/hurt [the game/codebase]?
-->

This PR aims to fix the issue where foxfire can be infinitely placed, along with a fix for a FTL entry not firing properly.

If the number of active foxfires exceed the max charges of the foxfire ability, it will remove one. If you do not have enough charges, it will not fire the ability and instead tell you the fact you cannot make more.

Made each spawned foxfire actually remove a single charge. And foxfires now expire after 2 minutes of being placed.

---

<!--
This is default collapsed, readers click to expand it and see all your media
The PR media section can get very large at times, so this is a good way to keep it clean
The title is written using HTML tags
The title must be within the <summary> tags or you won't see it
-->

<details><summary><h1>Media</h1></summary>
<p>

![image](https://github.com/user-attachments/assets/0edeaa55-6d31-4312-8c88-bf0fa783dce9)
![image](https://github.com/user-attachments/assets/a4b1d9fd-e57f-44d4-b68e-c120ece4bb19)
![image](https://github.com/user-attachments/assets/18e282be-1e1a-466c-a163-d7d0fa625a9f)

</p>
</details>

---

# Changelog

<!--
You can add an author after the `:cl:` to change the name that appears in the changelog (ex: `:cl: Death`)
Leaving it blank will default to your GitHub display name
This includes all available types for the changelog
-->

:cl: M3739
- fix: Kitsune can no longer place infinite foxfires.
- fix: You will now see the proper message when a kitsune shifts into fox form.
