### PR TITLE
Harpies Can Wear Shoes and Jumpsuits

### DIFF
--- a/Content.Shared/Roles/StartingGearPrototype.cs
+++ b/Content.Shared/Roles/StartingGearPrototype.cs
@@ -50,7 +50,7 @@ public sealed partial class StartingGearPrototype : IPrototype, IInheritingProto
             switch (slot)
             {
                 case "jumpsuit" when profile.Clothing == ClothingPreference.Jumpskirt && !string.IsNullOrEmpty(InnerClothingSkirt):
-                case "jumpsuit" when profile.Species == "Harpy" && !string.IsNullOrEmpty(InnerClothingSkirt):
+                //case "jumpsuit" when profile.Species == "Harpy" && !string.IsNullOrEmpty(InnerClothingSkirt):
                 case "jumpsuit" when profile.Species == "Lamia" && !string.IsNullOrEmpty(InnerClothingSkirt):
                     return InnerClothingSkirt;
                 case "back" when profile.Backpack == BackpackPreference.Satchel && !string.IsNullOrEmpty(Satchel):

--- a/Resources/Prototypes/Entities/Mobs/Species/harpy.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/harpy.yml
@@ -36,6 +36,7 @@
         visible: false
       - map: [ "id" ]
       - map: [ "gloves" ]
+      - map: [ "shoes" ]
       - map: [ "ears" ]
       - map: [ "outerClothing" ]
       - map: [ "eyes" ]
@@ -107,9 +108,9 @@
     baseWalkSpeed: 3
     baseSprintSpeed: 5.5
     weightlessAcceleration: 2.5
-  - type: Inventory
-    speciesId: harpy
-    templateId: digitigrade
+#  - type: Inventory
+#    speciesId: harpy
+#    templateId: digitigrade
   - type: HarpyVisuals
   - type: UltraVision
   - type: Tag
@@ -148,9 +149,9 @@
   components:
   - type: HumanoidAppearance
     species: Harpy
-  - type: Inventory
-    speciesId: harpy
-    templateId: digitigrade
+#  - type: Inventory
+#    speciesId: harpy
+#    templateId: digitigrade
   - type: Sprite
     #scale: 0.9, 0.9 Floofstation - while this doesn't technically cause any issues, this creates potential instability if changes to the heightAdjust system are made. As someone who made changes to the heightAdjust system, this can be very confusing.
     layers:
@@ -173,6 +174,7 @@
       - map: ["enum.HumanoidVisualLayers.RHand"]
       - map: [ "id" ]
       - map: [ "gloves" ]
+      - map: [ "shoes" ]
       - map: [ "ears" ]
       - map: [ "outerClothing" ]
       - map: [ "eyes" ]

--- a/Resources/Prototypes/Entities/Mobs/Species/harpy.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/harpy.yml
@@ -108,7 +108,7 @@
     baseWalkSpeed: 3
     baseSprintSpeed: 5.5
     weightlessAcceleration: 2.5
-#  - type: Inventory
+#  - type: Inventory #floof disabled, this component adds inventory slot restrictions to harpies
 #    speciesId: harpy
 #    templateId: digitigrade
   - type: HarpyVisuals

--- a/Resources/Prototypes/_Floof/Loadouts/Generic/shoes.yml
+++ b/Resources/Prototypes/_Floof/Loadouts/Generic/shoes.yml
@@ -10,7 +10,6 @@
       inverted: true
       species:
         - Diona
-        - Harpy
   items:
     - ClothingUnderSocksPlain
 
@@ -26,7 +25,6 @@
       inverted: true
       species:
         - Diona
-        - Harpy
   items:
     - ClothingUnderSocksStripedPurple
 
@@ -42,7 +40,6 @@
       inverted: true
       species:
         - Diona
-        - Harpy
   items:
     - ClothingUnderSocksStripedRainbow
 
@@ -58,7 +55,6 @@
       inverted: true
       species:
         - Diona
-        - Harpy
   items:
     - ClothingUnderSocksCoder
 
@@ -74,7 +70,6 @@
       inverted: true
       species:
         - Diona
-        - Harpy
   items:
     - ClothingUnderSocksCoderValid
 
@@ -90,6 +85,5 @@
       inverted: true
       species:
         - Diona
-        - Harpy
   items:
     - ClothingUnderSocksBee

--- a/Resources/Prototypes/_Floof/Loadouts/Jobs/Command/captain.yml
+++ b/Resources/Prototypes/_Floof/Loadouts/Jobs/Command/captain.yml
@@ -22,7 +22,6 @@
     inverted: true
     species:
     - Diona
-    - Harpy
   - !type:CharacterJobRequirement
     jobs:
     - Captain

--- a/Resources/Prototypes/_Floof/Loadouts/Jobs/Command/uncategorized.yml
+++ b/Resources/Prototypes/_Floof/Loadouts/Jobs/Command/uncategorized.yml
@@ -23,7 +23,6 @@
     inverted: true
     species:
     - Diona
-    - Harpy
   - !type:CharacterDepartmentRequirement
     departments:
     - Command

--- a/Resources/Prototypes/_Floof/Loadouts/Jobs/Engineering/chiefEngineer.yml
+++ b/Resources/Prototypes/_Floof/Loadouts/Jobs/Engineering/chiefEngineer.yml
@@ -57,7 +57,6 @@
     inverted: true
     species:
     - Diona
-    - Harpy
   - !type:CharacterJobRequirement
     jobs:
     - ChiefEngineer

--- a/Resources/Prototypes/_Floof/Loadouts/Jobs/Engineering/uncategorized.yml
+++ b/Resources/Prototypes/_Floof/Loadouts/Jobs/Engineering/uncategorized.yml
@@ -22,7 +22,6 @@
     inverted: true
     species:
     - Diona
-    - Harpy
   - !type:CharacterDepartmentRequirement
     departments:
     - Engineering

--- a/Resources/Prototypes/_Floof/Loadouts/Jobs/Epistemics/chaplain.yml
+++ b/Resources/Prototypes/_Floof/Loadouts/Jobs/Epistemics/chaplain.yml
@@ -89,7 +89,6 @@
     inverted: true
     species:
     - Diona
-    - Harpy
   - !type:CharacterJobRequirement
     jobs:
     - Chaplain

--- a/Resources/Prototypes/_Floof/Loadouts/Jobs/Epistemics/mystagogue.yml
+++ b/Resources/Prototypes/_Floof/Loadouts/Jobs/Epistemics/mystagogue.yml
@@ -22,7 +22,6 @@
     inverted: true
     species:
     - Diona
-    - Harpy
   - !type:CharacterJobRequirement
     jobs:
     - ResearchDirector

--- a/Resources/Prototypes/_Floof/Loadouts/Jobs/Epistemics/psionicMantis.yml
+++ b/Resources/Prototypes/_Floof/Loadouts/Jobs/Epistemics/psionicMantis.yml
@@ -22,7 +22,6 @@
     inverted: true
     species:
     - Diona
-    - Harpy
   - !type:CharacterJobRequirement
     jobs:
     - ForensicMantis

--- a/Resources/Prototypes/_Floof/Loadouts/Jobs/Epistemics/uncategorized.yml
+++ b/Resources/Prototypes/_Floof/Loadouts/Jobs/Epistemics/uncategorized.yml
@@ -22,7 +22,6 @@
     inverted: true
     species:
     - Diona
-    - Harpy
   - !type:CharacterDepartmentRequirement
     departments:
     - Epistemics

--- a/Resources/Prototypes/_Floof/Loadouts/Jobs/Logistics/courier.yml
+++ b/Resources/Prototypes/_Floof/Loadouts/Jobs/Logistics/courier.yml
@@ -24,7 +24,6 @@
     inverted: true
     species:
     - Diona
-    - Harpy
   - !type:CharacterJobRequirement
     jobs:
     - MailCarrier

--- a/Resources/Prototypes/_Floof/Loadouts/Jobs/Logistics/logisticsOfficer.yml
+++ b/Resources/Prototypes/_Floof/Loadouts/Jobs/Logistics/logisticsOfficer.yml
@@ -23,7 +23,6 @@
     inverted: true
     species:
     - Diona
-    - Harpy
   - !type:CharacterJobRequirement
     jobs:
     - Quartermaster

--- a/Resources/Prototypes/_Floof/Loadouts/Jobs/Logistics/salvageSpecialist.yml
+++ b/Resources/Prototypes/_Floof/Loadouts/Jobs/Logistics/salvageSpecialist.yml
@@ -161,6 +161,5 @@
       inverted: true
       species:
         - Diona
-        - Harpy
 
 # Uniforms

--- a/Resources/Prototypes/_Floof/Loadouts/Jobs/Logistics/uncategorized.yml
+++ b/Resources/Prototypes/_Floof/Loadouts/Jobs/Logistics/uncategorized.yml
@@ -23,7 +23,6 @@
     inverted: true
     species:
     - Diona
-    - Harpy
   - !type:CharacterDepartmentRequirement
     departments:
     - Logistics

--- a/Resources/Prototypes/_Floof/Loadouts/Jobs/Medical/chemist.yml
+++ b/Resources/Prototypes/_Floof/Loadouts/Jobs/Medical/chemist.yml
@@ -65,7 +65,6 @@
       inverted: true
       species:
         - Diona
-        - Harpy
 
 - type: loadout
   id: LoadoutClothingUnderSocksChemists
@@ -84,7 +83,6 @@
       inverted: true
       species:
         - Diona
-        - Harpy
 
 # Uniforms
 - type: loadout

--- a/Resources/Prototypes/_Floof/Loadouts/Jobs/Medical/chiefMedicalOfficer.yml
+++ b/Resources/Prototypes/_Floof/Loadouts/Jobs/Medical/chiefMedicalOfficer.yml
@@ -23,7 +23,6 @@
     inverted: true
     species:
     - Diona
-    - Harpy
   - !type:CharacterJobRequirement
     jobs:
     - ChiefMedicalOfficer

--- a/Resources/Prototypes/_Floof/Loadouts/Jobs/Medical/paramedic.yml
+++ b/Resources/Prototypes/_Floof/Loadouts/Jobs/Medical/paramedic.yml
@@ -188,7 +188,6 @@
       inverted: true
       species:
         - Diona
-        - Harpy
 
 # Uniforms
 - type: loadout

--- a/Resources/Prototypes/_Floof/Loadouts/Jobs/Medical/seniorPhysician.yml
+++ b/Resources/Prototypes/_Floof/Loadouts/Jobs/Medical/seniorPhysician.yml
@@ -52,6 +52,5 @@
       inverted: true
       species:
         - Diona
-        - Harpy
 
 # Uniforms

--- a/Resources/Prototypes/_Floof/Loadouts/Jobs/Medical/uncategorized.yml
+++ b/Resources/Prototypes/_Floof/Loadouts/Jobs/Medical/uncategorized.yml
@@ -193,7 +193,6 @@
       inverted: true
       species:
         - Diona
-        - Harpy
 
 - type: loadout
   id: LoadoutMedicalShoesWinter
@@ -212,7 +211,6 @@
       inverted: true
       species:
         - Diona
-        - Harpy
 
 - type: loadout
   id: LoadoutMedicalShoesWinterGenetics
@@ -232,7 +230,6 @@
       inverted: true
       species:
         - Diona
-        - Harpy
 
 - type: loadout
   id: LoadoutMedicalShoesWinterViro
@@ -252,7 +249,6 @@
       inverted: true
       species:
         - Diona
-        - Harpy
 
 - type: loadout
   id: LoadoutClothingUnderSocksMedic
@@ -271,7 +267,6 @@
       inverted: true
       species:
         - Diona
-        - Harpy
 
 # Uniforms
 - type: loadout

--- a/Resources/Prototypes/_Floof/Loadouts/Jobs/Security/corpsman.yml
+++ b/Resources/Prototypes/_Floof/Loadouts/Jobs/Security/corpsman.yml
@@ -105,7 +105,6 @@
       inverted: true
       species:
         - Diona
-        - Harpy
 
 # Uniforms
 - type: loadout

--- a/Resources/Prototypes/_Floof/Loadouts/Jobs/Security/detective.yml
+++ b/Resources/Prototypes/_Floof/Loadouts/Jobs/Security/detective.yml
@@ -22,7 +22,6 @@
     inverted: true
     species:
     - Diona
-    - Harpy
   - !type:CharacterJobRequirement
     jobs:
     - Detective

--- a/Resources/Prototypes/_Floof/Loadouts/Jobs/Security/headOfSecurity.yml
+++ b/Resources/Prototypes/_Floof/Loadouts/Jobs/Security/headOfSecurity.yml
@@ -22,7 +22,6 @@
     inverted: true
     species:
     - Diona
-    - Harpy
   - !type:CharacterJobRequirement
     jobs:
     - HeadOfSecurity

--- a/Resources/Prototypes/_Floof/Loadouts/Jobs/Security/uncategorized.yml
+++ b/Resources/Prototypes/_Floof/Loadouts/Jobs/Security/uncategorized.yml
@@ -149,7 +149,6 @@
     inverted: true
     species:
     - Diona
-    - Harpy
   - !type:CharacterDepartmentRequirement
     departments:
     - Security

--- a/Resources/Prototypes/_Floof/Loadouts/Jobs/Service/bartender.yml
+++ b/Resources/Prototypes/_Floof/Loadouts/Jobs/Service/bartender.yml
@@ -22,7 +22,6 @@
     inverted: true
     species:
     - Diona
-    - Harpy
   - !type:CharacterJobRequirement
     jobs:
     - Bartender

--- a/Resources/Prototypes/_Floof/Loadouts/Jobs/Service/chef.yml
+++ b/Resources/Prototypes/_Floof/Loadouts/Jobs/Service/chef.yml
@@ -22,7 +22,6 @@
     inverted: true
     species:
     - Diona
-    - Harpy
   - !type:CharacterJobRequirement
     jobs:
     - Chef

--- a/Resources/Prototypes/_Floof/Loadouts/Jobs/Service/janitor.yml
+++ b/Resources/Prototypes/_Floof/Loadouts/Jobs/Service/janitor.yml
@@ -213,7 +213,6 @@
       inverted: true
       species:
         - Diona
-        - Harpy
     - !type:CharacterJobRequirement
       jobs:
         - Janitor
@@ -232,7 +231,6 @@
       inverted: true
       species:
         - Diona
-        - Harpy
     - !type:CharacterJobRequirement
       jobs:
         - Janitor
@@ -251,7 +249,6 @@
       inverted: true
       species:
         - Diona
-        - Harpy
     - !type:CharacterJobRequirement
       jobs:
         - Janitor

--- a/Resources/Prototypes/_Floof/Loadouts/Jobs/Service/mime.yml
+++ b/Resources/Prototypes/_Floof/Loadouts/Jobs/Service/mime.yml
@@ -22,7 +22,6 @@
     inverted: true
     species:
     - Diona
-    - Harpy
   - !type:CharacterJobRequirement
     jobs:
     - Mime

--- a/Resources/Prototypes/_Floof/Loadouts/Jobs/Service/musician.yml
+++ b/Resources/Prototypes/_Floof/Loadouts/Jobs/Service/musician.yml
@@ -22,7 +22,6 @@
     inverted: true
     species:
     - Diona
-    - Harpy
   - !type:CharacterJobRequirement
     jobs:
     - Musician

--- a/Resources/Prototypes/_Floof/Loadouts/Jobs/Service/uncategorized.yml
+++ b/Resources/Prototypes/_Floof/Loadouts/Jobs/Service/uncategorized.yml
@@ -22,7 +22,6 @@
     inverted: true
     species:
     - Diona
-    - Harpy
   - !type:CharacterDepartmentRequirement
     departments:
     - Civilian


### PR DESCRIPTION
# Description

This PR disables the inventory component in the harpy mob prototype. This is a hack solution that allows them to equip shoes and jumpsuits. In addition, this PR aims to lifts restrictions to harpies footwear in the loadout menu. 

Why? 
I believe this was an unnecessary restriction and stifles player expression. Ive had witnessed multiple harpy mains gripe about the inability to wear shoes and normal jumpsuits, sometimes to the point they dress up humans or other races to mimic a harpy instead. This PR aims to address this issue. 


# SEE FURTHER JUSTIFICATION BELOW IN COMMENTS

![image](https://github.com/user-attachments/assets/10d97c54-fd1b-4472-b16f-54cabeff7247)
![image](https://github.com/user-attachments/assets/c9eadef8-3fc6-482a-8e86-1634ab0a7982)
![image](https://github.com/user-attachments/assets/c828eb78-46be-4be5-b5dc-a9f8942f80fa)
![image](https://github.com/user-attachments/assets/b54f313b-c8a3-48f7-a29b-81324d116436)
![image](https://github.com/user-attachments/assets/0325baf0-4b30-4ba8-b240-f2072b07e667)
![image](https://github.com/user-attachments/assets/6b8cab1f-163d-4d95-9b0a-a315f049b782)


# Changelog

:cl: Crow
- tweak: Harpies can now wear jumpsuits and shoes