### PR TITLE
Fix CPR Sound Looping

### DIFF
--- a/Content.Server/Medical/CPR/CPRSystem.cs
+++ b/Content.Server/Medical/CPR/CPRSystem.cs
@@ -87,7 +87,7 @@ public sealed class CPRSystem : EntitySystem
 
         _doAfterSystem.TryStartDoAfter(doAfterArgs);
 
-        var playingStream = _audio.PlayPvs(performer.Comp.CPRSound, performer, AudioParams.Default.WithLoop(true));
+        var playingStream = _audio.PlayPvs(performer.Comp.CPRSound, performer, AudioParams.Default);
         if (!playingStream.HasValue)
             return;
 

--- a/Content.Server/Medical/CPR/CPRSystem.cs
+++ b/Content.Server/Medical/CPR/CPRSystem.cs
@@ -87,7 +87,8 @@ public sealed class CPRSystem : EntitySystem
 
         _doAfterSystem.TryStartDoAfter(doAfterArgs);
 
-        var playingStream = _audio.PlayPvs(performer.Comp.CPRSound, performer, AudioParams.Default);
+        performer.Comp.CPRPlayingStream = _audio.Stop(performer.Comp.CPRPlayingStream); // Floofstation - fix any previous CPR sounds
+        var playingStream = _audio.PlayPvs(performer.Comp.CPRSound, performer, AudioParams.Default.WithLoop(true));
         if (!playingStream.HasValue)
             return;
 


### PR DESCRIPTION
# Description
Fixes infinite CPR sound looping when the performer of the CPR attempts to start a second CPR while the first one is ongoing

# Changelog
:cl:
- fix: CPR sound will no longer loop indefinitely. Hopefully.