### PR TITLE
Revert "Update PowerCellSystem.Draw.cs (#900)"

### DIFF
--- a/Content.Server/PowerCell/PowerCellSystem.Draw.cs
+++ b/Content.Server/PowerCell/PowerCellSystem.Draw.cs
@@ -30,8 +30,7 @@ public sealed partial class PowerCellSystem
             if (!TryGetBatteryFromSlot(uid, out var batteryEnt, out var battery, slot))
                 continue;
 
-            // TCJ: "Multiplying by frameTime to make this tick-invariant. Otherwise it'll draw 30x to 60x faster than you expect."
-            if (_battery.TryUseCharge(batteryEnt.Value, comp.DrawRate * frameTime, battery))
+            if (_battery.TryUseCharge(batteryEnt.Value, comp.DrawRate, battery))
                 continue;
 
             Toggle.TryDeactivate((uid, toggle));


### PR DESCRIPTION
# Description
Just as I predicted, the power cell draw fix made entities with PowerCellDraw (translators, anomaly locators, etc) draw power 60 times slower than normal.

Translator's battery after 2 minutes of usage:
![image](https://github.com/user-attachments/assets/eef8fcf4-2588-4a47-ac67-d0d9524b9f75)


# Changelog

:cl:
- fix: Reverted the power cell fix you may find mentioned below (above?) in the changelog.
