### PR TITLE
Fix Anomaly Scan Data Copying

### DIFF
--- a/Content.Server/Anomaly/AnomalySystem.Scanner.cs
+++ b/Content.Server/Anomaly/AnomalySystem.Scanner.cs
@@ -98,7 +98,7 @@ public sealed partial class AnomalySystem
             });
 
         // If interacting with another scanner, copy the anomaly data
-        if (component.ScannedAnomaly is not { Valid: true }
+        if ((component.ScannedAnomaly is not { Valid: true } || Deleted(component.ScannedAnomaly))
             && TryComp<AnomalyScannerComponent>(args.Target, out var otherScanner)
             && otherScanner.ScannedAnomaly is {} otherAnomaly)
         {

--- a/Content.Server/Anomaly/AnomalySystem.Scanner.cs
+++ b/Content.Server/Anomaly/AnomalySystem.Scanner.cs
@@ -98,7 +98,7 @@ public sealed partial class AnomalySystem
             });
 
         // If interacting with another scanner, copy the anomaly data
-        if ((component.ScannedAnomaly is not { Valid: true } || Deleted(component.ScannedAnomaly))
+        if ((component.ScannedAnomaly is not { Valid: true } || Deleted(component.ScannedAnomaly)) // Floof edit - added the deleted? clause
             && TryComp<AnomalyScannerComponent>(args.Target, out var otherScanner)
             && otherScanner.ScannedAnomaly is {} otherAnomaly)
         {


### PR DESCRIPTION
# Description
Fixes anomaly scanners not being able to copy anomaly scans if they were used to scan/copy an anomaly before

Needs testing

# Changelog
:cl:
- fix: Anomaly scanners can now copy scans even if they were previously used to scan an anomaly.
