### PR TITLE
Fix Duplicate Lathe Recipes

### DIFF
--- a/Content.Shared/Lathe/EmagLatheComponent.cs
+++ b/Content.Shared/Lathe/EmagLatheComponent.cs
@@ -14,7 +14,7 @@ namespace Content.Shared.Lathe
         /// All of the dynamic recipes that the lathe is capable to get using EMAG
         /// </summary>
         [DataField, AlwaysPushInheritance, AutoNetworkedField]
-        public List<ProtoId<LatheRecipePrototype>> EmagDynamicRecipes = new();
+        public HashSet<ProtoId<LatheRecipePrototype>> EmagDynamicRecipes = new();
 
         // FloofStation Modified
         // Ditto from EmagDynamicRecipes
@@ -22,6 +22,6 @@ namespace Content.Shared.Lathe
         /// All of the static recipes that the lathe is capable to get using EMAG
         /// </summary>
         [DataField, AlwaysPushInheritance, AutoNetworkedField]
-        public List<ProtoId<LatheRecipePrototype>> EmagStaticRecipes = new();
+        public HashSet<ProtoId<LatheRecipePrototype>> EmagStaticRecipes = new();
     }
 }

--- a/Content.Shared/Lathe/LatheComponent.cs
+++ b/Content.Shared/Lathe/LatheComponent.cs
@@ -11,12 +11,12 @@ namespace Content.Shared.Lathe
     {
         // FloofStation Modified
         // AlwaysPushInheritance added so lathes that use the AutoLathe as their
-        // parent could add on some extra recipes.
+        // parent could add on some extra recipes, and changed the type to HashSet.
         /// <summary>
         /// All of the recipes that the lathe has by default
         /// </summary>
         [DataField, AlwaysPushInheritance]
-        public List<ProtoId<LatheRecipePrototype>> StaticRecipes = new();
+        public HashSet<ProtoId<LatheRecipePrototype>> StaticRecipes = new();
 
         // FloofStation Modified
         // Ditto from StaticRecipes.
@@ -24,7 +24,7 @@ namespace Content.Shared.Lathe
         /// All of the recipes that the lathe is capable of researching
         /// </summary>
         [DataField, AlwaysPushInheritance]
-        public List<ProtoId<LatheRecipePrototype>> DynamicRecipes = new();
+        public HashSet<ProtoId<LatheRecipePrototype>> DynamicRecipes = new();
 
         /// <summary>
         /// The lathe's construction queue


### PR DESCRIPTION
# Description
Refactors LatheComponent and EmagLatheComponent to use HashSets isntead of Lists, thus excluding the possibility of adding duplicate entries. It's an unspoken rule that you should never use List and AlwaysPushInheritance together, that was forgotten during the last change (in the safety harness PR)


<details><summary><h1>Media</h1></summary>
<p>

![image](https://github.com/user-attachments/assets/b60bef69-6b60-4fec-b6cd-80ad782c60fb)

![image](https://github.com/user-attachments/assets/7a2b4003-b0e3-456d-b544-8ba5354ffc60)

![image](https://github.com/user-attachments/assets/84935740-7fb0-470a-9e45-34371fc03a0a)


</p>
</details>

# Changelog
:cl:
- fix: Departmental techfabs should no longer contain duplicate recipes
