### PR TITLE
Project Mortality: Comeback

### DIFF
--- a/Content.Server/Medical/CPR/CPRSystem.cs
+++ b/Content.Server/Medical/CPR/CPRSystem.cs
@@ -6,6 +6,7 @@ using Content.Shared.Atmos.Rotting;
 using Content.Shared.Damage;
 using Content.Shared.DoAfter;
 using Content.Shared.Inventory;
+using Content.Shared.Traits.Assorted.Components;
 using Content.Shared.Medical;
 using Content.Shared.Mobs;
 using Content.Shared.Mobs.Components;
@@ -111,6 +112,7 @@ public sealed class CPRSystem : EntitySystem
                 (EntityUid)args.Target, performer.Comp.DoAfterDuration * performer.Comp.RotReductionMultiplier);
 
         if (_robustRandom.Prob(performer.Comp.ResuscitationChance)
+            && !HasComp<UnrevivableComponent>(args.Target.Value) // Floofstation - unrevivable
             && _mobThreshold.TryGetThresholdForState((EntityUid)args.Target, MobState.Dead, out var threshold)
             && TryComp<DamageableComponent>(args.Target, out var damageableComponent)
             && TryComp<MobStateComponent>(args.Target, out var state)


### PR DESCRIPTION
# Description
Turns out https://github.com/Fansana/floofstation1/pull/797 reverted the changes to the CPR system introduced in #700. This is the second PR in the series, following #1034 

This prevents the CPR system from reviving unrevivable people.

# Changelog
:cl:
- fix: CPR can no longer revive unrevivable people. Again.
