### PR TITLE
Rotate Toy Sword Fix

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Fun/toys.yml
+++ b/Resources/Prototypes/Entities/Objects/Fun/toys.yml
@@ -1633,6 +1633,8 @@
   - type: StaminaDamageOnHit
     damage: 8
   - type: MeleeWeapon
+    wideAnimationRotation: -135
+    attackRate: 1.25 # Floofstation - this is hertz, not seconds
     damage:
       types:
         Blunt: 0

--- a/Resources/Prototypes/_Floof/Entities/Objects/Fun/toys.yml
+++ b/Resources/Prototypes/_Floof/Entities/Objects/Fun/toys.yml
@@ -474,6 +474,16 @@
   name: double-bladed toy sword
   description: New Sandy-Cat plastic double-bladed sword! Comes with realistic sound and full color! Looks almost like the real thing!
   components:
+  - type: ItemToggle
+    onUse: false # wielding events control it instead
+    soundActivate:
+      path: /Audio/Weapons/ebladeon.ogg
+      params:
+        volume: 3
+    soundDeactivate:
+      path: /Audio/Weapons/ebladeoff.ogg
+      params:
+        volume: 3
   - type: Sprite
     sprite: Objects/Weapons/Melee/e_sword_double.rsi
     layers:
@@ -486,6 +496,8 @@
   - type: Item
     size: Small
     sprite: Objects/Weapons/Melee/e_sword_double-inhands.rsi
+  - type: Wieldable
+    wieldSound: null # esword light sound instead
   - type: MeleeWeapon
     wideAnimationRotation: -135
     attackRate: .6666


### PR DESCRIPTION
# Description

Fixes Toy sword (and Toy Sabre Child) not having the proper rotation on swing and the wielding sprite for the toy Dsword.

# Changelog

:cl:
- fix: Fixed fun! But actually. Toy Sword rotation fixed and Toy DESword having a working wield sprite.

