### PR TITLE
Fix the Assay Power System

### DIFF
--- a/Content.Server/Abilities/Psionics/Abilities/AssayPowerSystem.cs
+++ b/Content.Server/Abilities/Psionics/Abilities/AssayPowerSystem.cs
@@ -40,13 +40,15 @@ public sealed class AssayPowerSystem : EntitySystem
             return;
 
         var ev = new AssayDoAfterEvent(_gameTiming.CurTime, args.FontSize, args.FontColor);
-        _doAfterSystem.TryStartDoAfter(new DoAfterArgs(EntityManager, args.Performer, args.UseDelay - TimeSpan.FromSeconds(psionic.CurrentAmplification), ev, args.Performer, args.Target, args.Performer)
+        var doAfterArgs = new DoAfterArgs(EntityManager, args.Performer, args.UseDelay - TimeSpan.FromSeconds(psionic.CurrentAmplification), ev, args.Performer, args.Target, args.Performer)
         {
             BlockDuplicate = true,
             BreakOnMove = true,
             BreakOnDamage = true,
-        }, out var doAfterId);
-        psionic.DoAfter = doAfterId;
+        };
+
+        if (!_doAfterSystem.TryStartDoAfter(doAfterArgs, out var doAfterId))
+            return;
 
         _popups.PopupEntity(Loc.GetString(args.PopupTarget, ("entity", args.Target)), args.Performer, PopupType.Medium);
 


### PR DESCRIPTION
# Description
SharedDoAfterSystem would sometimes return an invalid DoAfterId from TryStartDoAfter if some conditions were not met. The assay power system ignored the success value of this function, causing the user to permanently get stuck in the "channeling power" mode if the do-after failed to start.

Code taken from upstream: https://github.com/Simple-Station/Einstein-Engines/blob/master/Content.Server/Abilities/Psionics/Abilities/AssayPowerSystem.cs

# Changelog
:cl:
- fix: The Assay psionic power should no longer cause the user to get stuck in the "channeling power" mode.
