### PR TITLE
Space Weapons And Tactics

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/armor.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/armor.yml
@@ -83,17 +83,17 @@
   - type: Armor
     modifiers:
       coefficients:
-        Blunt: 0.6
-        Slash: 0.6
-        Piercing: 0.6
-        Heat: 0.85
+        Blunt: 0.7
+        Slash: 0.7
+        Piercing: 0.7
+        Heat: 0.7
         Radiation: 0.75
         Caustic: 0.85
   - type: ExplosionResistance
     damageCoefficient: 0.50
-  - type: ClothingSpeedModifier # Burdensome for running, but perfect for speedy gliding, even though running is still probably better
-    walkModifier: 0.9
-    sprintModifier: 0.7
+  - type: ClothingSpeedModifier 
+    walkModifier: 0.85
+    sprintModifier: 0.85
   - type: GroupExamine
 
 - type: entity

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/armor.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/armor.yml
@@ -1,5 +1,6 @@
 # Numbers for armor here largely taken from /tg/.
 # NOTE: Half of the kind of armor you're probably thinking of is in vests.yml. These should probably be merged some day.
+# Floof Change
 
 - type: entity
   parent: ClothingOuterBaseMedium

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/armor.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/armor.yml
@@ -84,17 +84,17 @@
   - type: Armor
     modifiers:
       coefficients:
-        Blunt: 0.7
-        Slash: 0.7
-        Piercing: 0.7
-        Heat: 0.7
+        Blunt: 0.7 # Floof Change
+        Slash: 0.7 # Floof Change
+        Piercing: 0.7 # Floof Change
+        Heat: 0.7 # Floof Change
         Radiation: 0.75
         Caustic: 0.85
   - type: ExplosionResistance
     damageCoefficient: 0.50
-  - type: ClothingSpeedModifier # Less heavy then most hardsuits but similar resistances to a standard vest
-    walkModifier: 0.85
-    sprintModifier: 0.85
+  - type: ClothingSpeedModifier # Less heavy then most hardsuits but similar resistances to a standard vest, Floof Change
+    walkModifier: 0.85 # Floof Change
+    sprintModifier: 0.85 # Floof Change
   - type: GroupExamine
 
 - type: entity

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/armor.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/armor.yml
@@ -91,7 +91,7 @@
         Caustic: 0.85
   - type: ExplosionResistance
     damageCoefficient: 0.50
-  - type: ClothingSpeedModifier 
+  - type: ClothingSpeedModifier # Less heavy then most hardsuits but similar resistances to a standard vest
     walkModifier: 0.85
     sprintModifier: 0.85
   - type: GroupExamine


### PR DESCRIPTION
<!--
This is a semi-strict format, you can add/remove sections as needed but the order/format should be kept the same
Remove these comments before submitting
-->

# Description


Changes the SWAT suits ordered by cargo to have less slowdown but also slightly less protection. This allows the SWAT gear to function as a sort of 'light weight combat EVA suit' for security, whilst still not being better then a bloodred or other similar suits. I also think a 'designated lightweight suit pack' is better then security requesting cargo to bulk order corpsman hard suits.
Note : SWAT suits before this were just slightly worse security tacsuits and were mainly only ordered for the helmet and gloves.

---

# TODO

<!--
A list of everything you have to do before this PR is "complete"
You probably won't have to complete everything before merging but it's good to leave future references
-->

- [x] Edit YML

---

<!--
This is default collapsed, readers click to expand it and see all your media
The PR media section can get very large at times, so this is a good way to keep it clean
The title is written using HTML tags
The title must be within the <summary> tags or you won't see it
-->

<details><summary><h1>Media</h1></summary>
<p>

Don't have any, sorry.

</p>
</details>

---

# Changelog

<!--
You can add an author after the `:cl:` to change the name that appears in the changelog (ex: `:cl: Death`)
Leaving it blank will default to your GitHub display name
This includes all available types for the changelog
-->

:cl:
- tweak: SWAT armor has been adjusted to have less armor but also less slowdown, allowing it to be used easily in spaced environments. 
