### PR TITLE
Goblin Update - Remote Clickers

### DIFF
--- a/Resources/Prototypes/_DEN/Entities/Objects/Fun/clicker.yml
+++ b/Resources/Prototypes/_DEN/Entities/Objects/Fun/clicker.yml
@@ -27,3 +27,12 @@
       path: /Audio/_DEN/clicker.ogg
   - type: UseDelay
     delay: 1.5
+  - type: TriggerOnSignal # Floofstation 
+  - type: DeviceNetwork
+    deviceNetId: Wireless
+    receiveFrequencyId: BasicDevice
+  - type: WirelessNetworkConnection
+    range: 200
+  - type: DeviceLinkSink
+    ports:
+    - Trigger


### PR DESCRIPTION
# Description

Added Remote Trigger for Clickers

Long Answer: I added code from an igniter to the Clicker toy which will allow it to be linked to a remote (honestly should jack up the range on those when we add bead vibrator toys) so one may remotely trigger a clicker. Why you might ask, to do funny things to the clicker trained.

# Changelog

:cl:
- tweak: 🙉 

