### PR TITLE
Bite Interaction and some Interaction Verb Fixes

### DIFF
--- a/Content.Server/InteractionVerbs/Actions/ModifyHealthAction.cs
+++ b/Content.Server/InteractionVerbs/Actions/ModifyHealthAction.cs
@@ -10,6 +10,11 @@ public sealed partial class ModifyHealthAction : InteractionAction
     [DataField(required: true)] public DamageSpecifier Damage = default!;
     [DataField] public bool IgnoreResistance = false;
 
+    /// <summary>
+    ///     Floofstation - a random factor applied to the damage.
+    /// </summary>
+    [DataField] public InteractionVerbPrototype.RangeSpecifier RandomFactor = new() { Min = 0.75f, Max = 1.25f };
+
     public override bool IsAllowed(InteractionArgs args, InteractionVerbPrototype proto, VerbDependencies deps)
     {
         return deps.EntMan.HasComponent<DamageableComponent>(args.Target);
@@ -23,7 +28,8 @@ public sealed partial class ModifyHealthAction : InteractionAction
 
     public override bool Perform(InteractionArgs args, InteractionVerbPrototype proto, VerbDependencies deps)
     {
+        var damage = Damage * RandomFactor.Random(deps.Random); // Floof
         return deps.EntMan.System<DamageableSystem>()
-            .TryChangeDamage(args.Target, Damage, IgnoreResistance, origin: args.User) is not null;
+            .TryChangeDamage(args.Target, damage, IgnoreResistance, origin: args.User) is not null; // Floof - changed Damage to damage
     }
 }

--- a/Content.Shared/InteractionVerbs/InteractionAction.cs
+++ b/Content.Shared/InteractionVerbs/InteractionAction.cs
@@ -58,9 +58,5 @@ public abstract partial class InteractionAction
         [Dependency] public readonly IGameTiming Timing = default!;
         [Dependency] public readonly ISerializationManager Serialization = default!;
         [Dependency] public readonly EntityWhitelistSystem WhitelistSystem = default!;
-
-        // Floof section
-        [Dependency] public readonly SlotBlockerSystem SlotBlocker = default!;
-        // Floof section end
     }
 }

--- a/Content.Shared/InteractionVerbs/InteractionAction.cs
+++ b/Content.Shared/InteractionVerbs/InteractionAction.cs
@@ -1,3 +1,4 @@
+using Content.Shared._Floof.Clothing.SlotBlocker;
 using Content.Shared.Whitelist;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Random;
@@ -57,5 +58,9 @@ public abstract partial class InteractionAction
         [Dependency] public readonly IGameTiming Timing = default!;
         [Dependency] public readonly ISerializationManager Serialization = default!;
         [Dependency] public readonly EntityWhitelistSystem WhitelistSystem = default!;
+
+        // Floof section
+        [Dependency] public readonly SlotBlockerSystem SlotBlocker = default!;
+        // Floof section end
     }
 }

--- a/Content.Shared/InteractionVerbs/InteractionAction.cs
+++ b/Content.Shared/InteractionVerbs/InteractionAction.cs
@@ -57,6 +57,8 @@ public abstract partial class InteractionAction
         [Dependency] public readonly IRobustRandom Random = default!;
         [Dependency] public readonly IGameTiming Timing = default!;
         [Dependency] public readonly ISerializationManager Serialization = default!;
-        [Dependency] public readonly EntityWhitelistSystem WhitelistSystem = default!;
+        // Floof - changed this to dynamically resolve the system, otehrwise IoC would inject a weird instance of this class that is never initialized, leading to obscure bugs.
+        // If more *System references get added, make sure to convert them to this format. IoC doesn't support injecting entity systems.
+        public EntityWhitelistSystem WhitelistSystem => EntMan.System<EntityWhitelistSystem>();
     }
 }

--- a/Content.Shared/InteractionVerbs/InteractionVerbPrototype.cs
+++ b/Content.Shared/InteractionVerbs/InteractionVerbPrototype.cs
@@ -155,6 +155,12 @@ public sealed partial class InteractionVerbPrototype : IPrototype, IInheritingPr
     // Floofstation section
     [DataField]
     public bool RequiresConsciousness = true;
+
+    /// <summary>
+    ///     The true "requires can interact", checks if the user is not cuffed and is not otherwise incapacitated.
+    /// </summary>
+    [DataField("checkInteractionBlocker")]
+    public bool RequiresCanInteract = true;
     // Floofstation section end
 
     /// <summary>

--- a/Content.Shared/InteractionVerbs/InteractionVerbPrototype.cs
+++ b/Content.Shared/InteractionVerbs/InteractionVerbPrototype.cs
@@ -237,10 +237,7 @@ public sealed partial class InteractionVerbPrototype : IPrototype, IInheritingPr
         public bool SoundPerceivedByOthers = true;
 
         [DataField]
-        public AudioParams SoundParams = new AudioParams()
-        {
-            Variation = 0.1f
-        };
+        public AudioParams? SoundParams = null; // Floof - null by default
     }
 
     [Serializable, Flags]

--- a/Content.Shared/InteractionVerbs/InteractionVerbPrototype.cs
+++ b/Content.Shared/InteractionVerbs/InteractionVerbPrototype.cs
@@ -2,6 +2,7 @@ using Content.Shared.DoAfter;
 using Content.Shared.InteractionVerbs.Events;
 using Robust.Shared.Audio;
 using Robust.Shared.Prototypes;
+using Robust.Shared.Random;
 using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom.Prototype.Array;
 using Robust.Shared.Utility;
 
@@ -194,6 +195,13 @@ public sealed partial class InteractionVerbPrototype : IPrototype, IInheritingPr
         {
             DebugTools.Assert(!Inverse, "Inverse ranges do not support clamping.");
             return Math.Clamp(value, Min, Max);
+        }
+
+        // Floofstation
+        public float Random(IRobustRandom random)
+        {
+            DebugTools.Assert(!Inverse, "Inverse ranges do not support randomization.");
+            return Min > Max ? random.NextFloat(Max, Min) : random.NextFloat(Min, Max);
         }
     }
 

--- a/Content.Shared/InteractionVerbs/InteractionVerbPrototype.cs
+++ b/Content.Shared/InteractionVerbs/InteractionVerbPrototype.cs
@@ -151,6 +151,11 @@ public sealed partial class InteractionVerbPrototype : IPrototype, IInheritingPr
     [DataField]
     public bool RequiresHands = false;
 
+    // Floofstation section
+    [DataField]
+    public bool RequiresConsciousness = true;
+    // Floofstation section end
+
     /// <summary>
     ///     Whether this verb requires the user to be able to access the target normally (with their hands or otherwise).
     /// </summary>

--- a/Content.Shared/InteractionVerbs/Requirements/AssortedRequirements.cs
+++ b/Content.Shared/InteractionVerbs/Requirements/AssortedRequirements.cs
@@ -17,7 +17,7 @@ public sealed partial class EntityWhitelistRequirement : InteractionRequirement
 
     public override bool IsMet(InteractionArgs args, InteractionVerbPrototype proto, InteractionAction.VerbDependencies deps) =>
         !deps.WhitelistSystem.IsWhitelistFail(Whitelist, args.Target)
-            && !deps.WhitelistSystem.IsBlacklistPass(Blacklist, args.Target);
+         && !deps.WhitelistSystem.IsBlacklistPass(Blacklist, args.Target);
 }
 
 /// <summary>

--- a/Content.Shared/InteractionVerbs/SharedInteractionVerbsSystem.cs
+++ b/Content.Shared/InteractionVerbs/SharedInteractionVerbsSystem.cs
@@ -275,6 +275,13 @@ public abstract class SharedInteractionVerbsSystem : EntitySystem
             return false;
         }
 
+        // Floofstation - added this block
+        if (proto.RequiresConsciousness && !_actionBlocker.CanConsciouslyPerformAction(args.User))
+        {
+            errorLocale = "interaction-verb-unconscious";
+            return false;
+        }
+
         if (!args.CanInteract || proto.RequiresCanAccess && !args.CanAccess || !proto.Range.IsInRange(distance))
         {
             errorLocale = "interaction-verb-cannot-reach";

--- a/Content.Shared/InteractionVerbs/SharedInteractionVerbsSystem.cs
+++ b/Content.Shared/InteractionVerbs/SharedInteractionVerbsSystem.cs
@@ -159,9 +159,9 @@ public abstract class SharedInteractionVerbsSystem : EntitySystem
             Broadcast = true,
             BreakOnHandChange = proto.RequiresHands,
             NeedHand = proto.RequiresHands,
-            RequireCanInteract = proto.RequiresCanAccess,
+            RequireCanInteract = proto.RequiresCanInteract, // Floof - actual CanInteract
             Delay = delay,
-            Event = new InteractionVerbDoAfterEvent(proto.ID, args)
+            Event = new InteractionVerbDoAfterEvent(proto.ID, args),
         };
 
         var isSuccess = _doAfters.TryStartDoAfter(doAfter);

--- a/Content.Shared/InteractionVerbs/SharedInteractionVerbsSystem.cs
+++ b/Content.Shared/InteractionVerbs/SharedInteractionVerbsSystem.cs
@@ -421,10 +421,10 @@ public abstract class SharedInteractionVerbsSystem : EntitySystem
         if (specifier.Sound is { } sound)
         {
             // TODO we have a choice between having an accurate sound source or saving on an entity spawn...
-            _audio.PlayEntity(sound, Filter.Entities(user, target), target, false, specifier.SoundParams);
+            _audio.PlayEntity(sound, Filter.Entities(user, target), target, false, specifier.SoundParams ?? sound.Params); // Floof - use sound params if no custom ones are provided
 
             if (specifier.SoundPerceivedByOthers)
-                _audio.PlayEntity(sound, othersFilter, othersTarget, false, specifier.SoundParams);
+                _audio.PlayEntity(sound, othersFilter, othersTarget, false, specifier.SoundParams ?? sound.Params); // Floof - use sound params if no custom ones are provided
         }
     }
 

--- a/Content.Shared/InteractionVerbs/SharedInteractionVerbsSystem.cs
+++ b/Content.Shared/InteractionVerbs/SharedInteractionVerbsSystem.cs
@@ -282,7 +282,8 @@ public abstract class SharedInteractionVerbsSystem : EntitySystem
             return false;
         }
 
-        if (!args.CanInteract || proto.RequiresCanAccess && !args.CanAccess || !proto.Range.IsInRange(distance))
+        // Floof - added RequiresCanInteract
+        if (proto.RequiresCanInteract && !args.CanInteract || proto.RequiresCanAccess && !args.CanAccess || !proto.Range.IsInRange(distance))
         {
             errorLocale = "interaction-verb-cannot-reach";
             return false;

--- a/Content.Shared/_Floof/InteractionVerbs/Requirements/SlotObstructionRequirement.cs
+++ b/Content.Shared/_Floof/InteractionVerbs/Requirements/SlotObstructionRequirement.cs
@@ -60,7 +60,7 @@ public sealed partial class SlotObstructionRequirement : InteractionRequirement
 
             for (var i = 0; i < slots.Length; i++)
             {
-                if (!slots[i].SlotFlags.HasFlag(Slot))
+                if ((slots[i].SlotFlags & Slot) == 0)
                     continue;
 
                 var obstructed = false;
@@ -70,7 +70,7 @@ public sealed partial class SlotObstructionRequirement : InteractionRequirement
                         deps.EntMan.TryGetComponent<MaskComponent>(clothing, out var mask) && mask.IsToggled)
                         continue;
 
-                    obstructed = deps.WhitelistSystem.IsWhitelistPass(ObstructorWhitelist, clothing);
+                    obstructed = ObstructorWhitelist == null || deps.WhitelistSystem.IsWhitelistPass(ObstructorWhitelist, clothing);
                 }
 
                 // A matching slot is found. We assume there can only be one.

--- a/Content.Shared/_Floof/InteractionVerbs/Requirements/SlotObstructionRequirement.cs
+++ b/Content.Shared/_Floof/InteractionVerbs/Requirements/SlotObstructionRequirement.cs
@@ -1,0 +1,97 @@
+using Content.Shared._Floof.Clothing.SlotBlocker;
+using Content.Shared.Clothing.Components;
+using Content.Shared.InteractionVerbs;
+using Content.Shared.Inventory;
+using Content.Shared.Whitelist;
+using Robust.Shared.Serialization;
+
+namespace Content.Shared._Floof.InteractionVerbs.Requirements;
+
+
+/// <summary>
+///     Requires the target to have the slot obstructed (or not obstructed) by anything (e.g. a mask) that passes the whitelist
+///     and (optionally) not have it blocked.
+/// </summary>
+[Serializable, NetSerializable]
+public sealed partial class SlotObstructionRequirement : InvertableInteractionRequirement
+{
+    /// <summary>
+    ///     If true, the user is checked. Otherwise, the target.
+    /// </summary>
+    [DataField] public bool CheckUser = true;
+
+    [DataField] public SlotFlags Slot;
+
+    /// <summary>
+    ///     When to fail this condition. If the entity has no matching slot, it is assumed to be non-obstructed.
+    /// </summary>
+    [DataField] public bool
+        MustBeObstructed = false,
+        MustNotBeObstructed = true;
+
+    [DataField] public EntityWhitelist? ObstructorWhitelist;
+
+    /// <summary>
+    ///     Whether to ignore e.g. a mask that has been pulled down.
+    /// </summary>
+    [DataField] public bool IgnoreIfPulledDown = true;
+
+    /// <summary>
+    ///     Whether the slot must/must not be blocked. See <see cref="SlotBlockerSystem"/> for more details.
+    /// </summary>
+    [DataField] public bool
+        MustBeBlocked = false,
+        MustNotBeBlocked = true;
+
+
+    public override bool IsMet(InteractionArgs args, InteractionVerbPrototype proto, InteractionAction.VerbDependencies deps)
+    {
+        var target = CheckUser ? args.User : args.Target;
+        if (!deps.EntMan.TryGetComponent(target, out InventoryComponent? inventory))
+            return MustNotBeObstructed;
+
+        var checkBlockers = MustBeBlocked || MustNotBeBlocked;
+        var checkObstruction = MustBeObstructed || MustNotBeObstructed;
+
+        if (checkObstruction)
+        {
+            var slots = inventory.Slots;
+            var containers = inventory.Containers;
+
+            for (var i = 0; i < slots.Length; i++)
+            {
+                if (!slots[i].SlotFlags.HasFlag(Slot))
+                    continue;
+
+                var obstructed = false;
+                if (containers[i].ContainedEntity is { } clothing)
+                {
+                    if (IgnoreIfPulledDown &&
+                        deps.EntMan.TryGetComponent<MaskComponent>(clothing, out var mask) && mask.IsToggled)
+                        continue;
+
+                    obstructed = deps.WhitelistSystem.IsWhitelistPass(ObstructorWhitelist, clothing);
+                }
+
+                // A matching slot is found. We assume there can only be one.
+                if (MustBeObstructed && !obstructed || MustNotBeObstructed && obstructed)
+                    return false;
+            }
+        }
+
+        if (checkBlockers)
+        {
+            var blocked = deps.SlotBlocker.IsSlotObstructed(
+                (target, inventory),
+                null,
+                SlotBlockerSystem.CheckType.IgnoreBlockerPreference,
+                Slot,
+                out _);
+
+            if (MustBeBlocked && !blocked || MustNotBeBlocked && blocked)
+                return false;
+        }
+
+        return true;
+    }
+}

--- a/Content.Shared/_Floof/InteractionVerbs/Requirements/SlotObstructionRequirement.cs
+++ b/Content.Shared/_Floof/InteractionVerbs/Requirements/SlotObstructionRequirement.cs
@@ -13,7 +13,7 @@ namespace Content.Shared._Floof.InteractionVerbs.Requirements;
 ///     and (optionally) not have it blocked.
 /// </summary>
 [Serializable, NetSerializable]
-public sealed partial class SlotObstructionRequirement : InvertableInteractionRequirement
+public sealed partial class SlotObstructionRequirement : InteractionRequirement
 {
     /// <summary>
     ///     If true, the user is checked. Otherwise, the target.
@@ -81,7 +81,8 @@ public sealed partial class SlotObstructionRequirement : InvertableInteractionRe
 
         if (checkBlockers)
         {
-            var blocked = deps.SlotBlocker.IsSlotObstructed(
+            var blockerSys = deps.EntMan.System<SlotBlockerSystem>();
+            var blocked = blockerSys.IsSlotObstructed(
                 (target, inventory),
                 null,
                 SlotBlockerSystem.CheckType.IgnoreBlockerPreference,

--- a/Resources/Locale/en-US/_Floof/interaction/verbs/misc.ftl
+++ b/Resources/Locale/en-US/_Floof/interaction/verbs/misc.ftl
@@ -1,0 +1,8 @@
+interaction-Bite-name = Bite
+interaction-Bite-description = Show them your appreciation for their work. Requires your mouth to be free.
+interaction-Bite-success-self-popup = You bite {THE($target)}.
+interaction-Bite-success-target-popup = {THE($user)} bites you. Ow-w!
+interaction-Bite-success-others-popup = {THE($user)} bites {THE($target)}.
+interaction-Bite-fail-self-popup = You cannot bite {THE($target)}!
+interaction-Bite-fail-target-popup = {THE($user)} tries to bite you, and fails
+# No "fail-others" popup

--- a/Resources/Locale/en-US/_Floof/interaction/verbs/noop.ftl
+++ b/Resources/Locale/en-US/_Floof/interaction/verbs/noop.ftl
@@ -9,9 +9,3 @@ interaction-Lick-description = Lick your co-worker. Requires your mouth to be fr
 interaction-Lick-success-self-popup = You lick {THE($target)}.
 interaction-Lick-success-target-popup = {THE($user)} licks you.
 interaction-Lick-success-others-popup = {THE($user)} licks {THE($target)}.
-
-interaction-Bite-name = Bite
-interaction-Bite-description = Show them your appreciation for their work. Requires your mouth to be free.
-interaction-Bite-success-self-popup = You bite {THE($target)}.
-interaction-Bite-success-target-popup = {THE($user)} bites you. Ow-w!
-interaction-Bite-success-others-popup = {THE($user)} bites {THE($target)}.

--- a/Resources/Locale/en-US/_Floof/interaction/verbs/noop.ftl
+++ b/Resources/Locale/en-US/_Floof/interaction/verbs/noop.ftl
@@ -1,11 +1,17 @@
 interaction-Kiss-name = Kiss
-interaction-Kiss-description = A kiss melts the pains away.
+interaction-Kiss-description = A kiss to melt the pain away. Requires your mouth to be free.
 interaction-Kiss-success-self-popup = You kiss {THE($target)}.
 interaction-Kiss-success-target-popup = {THE($user)} kisses you.
 interaction-Kiss-success-others-popup = {THE($user)} kisses {THE($target)}.
 
 interaction-Lick-name = Lick
-interaction-Lick-description = Lick your co-worker, what HR?.
+interaction-Lick-description = Lick your co-worker. Requires your mouth to be free.
 interaction-Lick-success-self-popup = You lick {THE($target)}.
 interaction-Lick-success-target-popup = {THE($user)} licks you.
 interaction-Lick-success-others-popup = {THE($user)} licks {THE($target)}.
+
+interaction-Bite-name = Bite
+interaction-Bite-description = Show them your appreciation for their work. Requires your mouth to be free.
+interaction-Bite-success-self-popup = You bite {THE($target)}.
+interaction-Bite-success-target-popup = {THE($user)} bites you. Ow-w!
+interaction-Bite-success-others-popup = {THE($user)} bites {THE($target)}.

--- a/Resources/Locale/en-US/interaction/verbs/core.ftl
+++ b/Resources/Locale/en-US/interaction/verbs/core.ftl
@@ -5,3 +5,6 @@ interaction-verb-too-weak = You are too weak to use this verb.
 interaction-verb-invalid-target = You cannot use this verb on that target.
 interaction-verb-no-hands = You have no usable hands.
 interaction-verb-cannot-reach = You cannot reach there.
+
+# Floofstation
+interaction-verb-unconscious = You cannot use this verb while unconscious.

--- a/Resources/Prototypes/Interactions/help_interactions.yml
+++ b/Resources/Prototypes/Interactions/help_interactions.yml
@@ -75,7 +75,7 @@
   parent: [BaseHelp, BaseGlobal]
   priority: -5
   delay: 0.8
-  cooldown: 10 # Slightly abusable
+  cooldown: 3 # Slightly abusable # Floof - further reduced
   effectDelayed: null
   hideByRequirement: true
   requirement:

--- a/Resources/Prototypes/Interactions/mood_interactions.yml
+++ b/Resources/Prototypes/Interactions/mood_interactions.yml
@@ -14,6 +14,7 @@
     # TODO: this should pull the target closer or sumth, but I need to code that action first
     !type:MoodAction
     effect: BeingHugged
+  effectFailure: null # Floof
 
 # Petting someone (people) - improves the mood of the target
 - type: Interaction
@@ -35,6 +36,7 @@
   action:
     !type:MoodAction
     effect: BeingPet
+  effectFailure: null # Floof
 
 # Petting someone (animals) - improves the mood of the user and the target
 - type: Interaction
@@ -57,4 +59,5 @@
       action:
         !type:MoodAction
         effect: PetAnimal
+  effectFailure: null # Floof
 

--- a/Resources/Prototypes/Interactions/noop_interactions.yml
+++ b/Resources/Prototypes/Interactions/noop_interactions.yml
@@ -4,6 +4,7 @@
   priority: 4
   requiresHands: false
   requiresCanInteract: false
+  checkInteractionBlocker: false # Floof
   contactInteraction: false
   allowSelfInteract: true
   icon: /Textures/Interface/Actions/eyeopen.png

--- a/Resources/Prototypes/Interactions/noop_interactions.yml
+++ b/Resources/Prototypes/Interactions/noop_interactions.yml
@@ -51,7 +51,7 @@
   parent: BaseHands
   priority: 20
   effectSuccess:
-    popup: VisibleNoChat
+    popup: Visible
     sound: {collection: FenceRattle}
   action:
     !type:NoOpAction

--- a/Resources/Prototypes/Interactions/self_interactions.yml
+++ b/Resources/Prototypes/Interactions/self_interactions.yml
@@ -36,6 +36,9 @@
 - type: Interaction
   id: MakeSleepSelf
   parent: [SelfInteractionBase, MakeSleepOther]
+  cooldown: 5 # Floof
+  checkInteractionBlocker: false # Floof - don't check CanInteract
+  requiresHands: false # Floof
   delay: 4.5
   requirement:
     !type:ComplexRequirement

--- a/Resources/Prototypes/_Floof/Interactions/base.yml
+++ b/Resources/Prototypes/_Floof/Interactions/base.yml
@@ -2,6 +2,7 @@
   id: BaseMouth
   abstract: true
   priority: -15
-  requiresCanInteract: false
+  requiresCanInteract: true # Do check CanAccess
+  checkInteractionBlocker: false # Don't check CanInteract
   requiresHands: false
   requiresConsciousness: true

--- a/Resources/Prototypes/_Floof/Interactions/base.yml
+++ b/Resources/Prototypes/_Floof/Interactions/base.yml
@@ -1,0 +1,7 @@
+- type: Interaction
+  id: BaseMouth
+  abstract: true
+  priority: -15
+  requiresCanInteract: false
+  requiresHands: false
+  requiresConsciousness: true

--- a/Resources/Prototypes/_Floof/Interactions/misc_interactions.yml
+++ b/Resources/Prototypes/_Floof/Interactions/misc_interactions.yml
@@ -21,7 +21,7 @@
     - !type:ModifyHealthAction
       randomFactor: {min: 0.5, max: 1.5}
       damage:
-        types: {Pierce: 5}
+        types: {Piercing: 5}
     # TEMPLATE: in case someone decides to add a "masochist trait" or something like that
     #- !type:ConditionalAction
     #  condition:

--- a/Resources/Prototypes/_Floof/Interactions/misc_interactions.yml
+++ b/Resources/Prototypes/_Floof/Interactions/misc_interactions.yml
@@ -3,6 +3,7 @@
   parent: [BaseGlobal, BaseMouth]
   priority: -15 # Non-erp but generally not something you'd want to do to strangers
   delay: 0.4
+  cooldown: 8
   range: {max: 0.666} # Very close-range
   hideByRequirement: true
   requirement:

--- a/Resources/Prototypes/_Floof/Interactions/misc_interactions.yml
+++ b/Resources/Prototypes/_Floof/Interactions/misc_interactions.yml
@@ -1,0 +1,27 @@
+- type: Interaction
+  id: Bite
+  parent: [BaseGlobal, BaseMouth]
+  priority: -15 # Non-erp but generally not something you'd wanna do to strangers
+  delay: 0.4
+  range: {max: 0.666} # Very close-range
+  hideByRequirement: true
+  requirement:
+    !type:ComplexRequirement
+    requirements:
+    - !type:EntityWhitelistRequirement
+      whitelist:
+        components: [MobState, Food] # Don't go around biting inanimate objects.
+    - !type:SlotObstructionRequirement
+      slot: MASK
+  action:
+  - !type:ModifyHealthAction
+    randomFactor: {min: 0.5, max: 1.5}
+    damage:
+      types: {Pierce: 5}
+  effectSuccess:
+    popup: Obvious
+    sound:
+      path: /Audio/Effects/bite.ogg
+      params:
+        volume: 0.6
+        maxDistance: 4

--- a/Resources/Prototypes/_Floof/Interactions/misc_interactions.yml
+++ b/Resources/Prototypes/_Floof/Interactions/misc_interactions.yml
@@ -4,6 +4,7 @@
   priority: -15 # Non-erp but generally not something you'd want to do to strangers
   delay: 0.4
   cooldown: 5
+  globalCooldown: true
   range: {max: 0.666} # Very close-range
   hideByRequirement: true
   requirement:

--- a/Resources/Prototypes/_Floof/Interactions/misc_interactions.yml
+++ b/Resources/Prototypes/_Floof/Interactions/misc_interactions.yml
@@ -38,4 +38,5 @@
       params:
         volume: 0.6
         maxDistance: 4
-  effectFailure: null
+  effectFailure:
+    popup: Subtle

--- a/Resources/Prototypes/_Floof/Interactions/misc_interactions.yml
+++ b/Resources/Prototypes/_Floof/Interactions/misc_interactions.yml
@@ -15,10 +15,21 @@
     - !type:SlotObstructionRequirement
       slot: MASK
   action:
-    !type:ModifyHealthAction
-    randomFactor: {min: 0.5, max: 1.5}
-    damage:
-      types: {Pierce: 5}
+    !type:ComplexAction
+    actions:
+    - !type:ModifyHealthAction
+      randomFactor: {min: 0.5, max: 1.5}
+      damage:
+        types: {Pierce: 5}
+    # TEMPLATE: in case someone decides to add a "masochist trait" or something like that
+    #- !type:ConditionalAction
+    #  condition:
+    #    !type:EntityWhitelistRequirement
+    #    whitelist:
+    #      components: [Masochist] # Just an example. Could be a tag or a different comp.
+    #  true:
+    #    !type:MoodAction
+    #    effect: ??? # Some positive mood effect here
   effectSuccess:
     popup: Obvious
     sound:

--- a/Resources/Prototypes/_Floof/Interactions/misc_interactions.yml
+++ b/Resources/Prototypes/_Floof/Interactions/misc_interactions.yml
@@ -36,7 +36,7 @@
     sound:
       path: /Audio/Effects/bite.ogg
       params:
-        volume: 0.6
+        volume: -3
         maxDistance: 4
   effectFailure:
     popup: Subtle

--- a/Resources/Prototypes/_Floof/Interactions/misc_interactions.yml
+++ b/Resources/Prototypes/_Floof/Interactions/misc_interactions.yml
@@ -3,7 +3,7 @@
   parent: [BaseGlobal, BaseMouth]
   priority: -15 # Non-erp but generally not something you'd want to do to strangers
   delay: 0.4
-  cooldown: 8
+  cooldown: 5
   range: {max: 0.666} # Very close-range
   hideByRequirement: true
   requirement:

--- a/Resources/Prototypes/_Floof/Interactions/misc_interactions.yml
+++ b/Resources/Prototypes/_Floof/Interactions/misc_interactions.yml
@@ -1,7 +1,7 @@
 - type: Interaction
   id: Bite
   parent: [BaseGlobal, BaseMouth]
-  priority: -15 # Non-erp but generally not something you'd wanna do to strangers
+  priority: -15 # Non-erp but generally not something you'd want to do to strangers
   delay: 0.4
   range: {max: 0.666} # Very close-range
   hideByRequirement: true
@@ -25,3 +25,4 @@
       params:
         volume: 0.6
         maxDistance: 4
+  effectFailure: null

--- a/Resources/Prototypes/_Floof/Interactions/misc_interactions.yml
+++ b/Resources/Prototypes/_Floof/Interactions/misc_interactions.yml
@@ -14,7 +14,7 @@
     - !type:SlotObstructionRequirement
       slot: MASK
   action:
-  - !type:ModifyHealthAction
+    !type:ModifyHealthAction
     randomFactor: {min: 0.5, max: 1.5}
     damage:
       types: {Pierce: 5}

--- a/Resources/Prototypes/_Floof/Interactions/mood_interactions.yml
+++ b/Resources/Prototypes/_Floof/Interactions/mood_interactions.yml
@@ -1,15 +1,18 @@
 - type: Interaction
   id: Kiss
-  parent: [BaseGlobal, BaseHands]
+  parent: [BaseGlobal, BaseMouth]
   priority: -1
   delay: 0.4
   range: {max: 1}
   hideByRequirement: true
-  requiresHands: false # why are we inheriting from BaseHands again???
-  requiresCanInteract: false
   requirement:
-    !type:MobStateRequirement
-    inverted: true
+    !type:ComplexRequirement
+    requirements:
+    - !type:EntityWhitelistRequirement
+      whitelist:
+        components: [MobState] # Don't go around kissing inanimate objects.
+    - !type:SlotObstructionRequirement
+      slot: MASK
   action:
     !type:MoodAction
     effect: BeingKissed
@@ -19,16 +22,20 @@
 
 - type: Interaction
   id: Lick
-  parent: [BaseGlobal, BaseHands]
+  parent: [BaseGlobal, BaseMouth]
   priority: -2
   delay: 0.7
   range: {max: 1}
   hideByRequirement: true
-  requiresHands: false
-  requiresCanInteract: false
   requirement:
-    !type:MobStateRequirement
-    inverted: true
+    !type:ComplexRequirement
+    requirements:
+    - !type:EntityWhitelistRequirement
+      whitelist:
+        components: [MobState, Anomaly, Food]
+        tags: [Window] # yes.
+    - !type:SlotObstructionRequirement
+      slot: MASK
   action:
     !type:MoodAction
     effect: BeingLicked

--- a/Resources/Prototypes/_Floof/Interactions/mood_interactions.yml
+++ b/Resources/Prototypes/_Floof/Interactions/mood_interactions.yml
@@ -19,6 +19,7 @@
   effectSuccess:
     popup: Obvious
     sound: {path: /Audio/_Floof/Lewd/kiss.ogg}
+  effectFailure: null
 
 - type: Interaction
   id: Lick
@@ -42,3 +43,4 @@
   effectSuccess:
     popup: Obvious
     sound: {path: /Audio/_Floof/Lewd/lick.ogg}
+  effectFailure: null


### PR DESCRIPTION
# Description
Adds a new bite interaction. A relatively fast and close-range interaction that deals between 2.5 and 7.5 pierce and has a cooldown of 5 seconds (on average will deal at most 1 damage per second if the user perfectly spams it every 5 seconds, in reality will be lower). Requires your mouth to not be obstructed (a mask or a muzzle would stop you from using it), but does not require free hands.

I think it serves as a fun way to retaliate if you are cuffed and your captor is standing too close. Also could be used in ERP context and whatnot.

Also:
- Adds the same behavior to lick and kiss interactions. They no longer require your hands to be free (you can use them while cuffed), but now require your mouth to be unobstructed.
- Likewise, makes it so that looking at things does not require free hands or being able to interact otherwise.
- Allows you to lick windows and anomalies, for the funny; and kiss/lick/bite food for dramatic effect. Neither of those interactions do anything other than show popups.
- Adds two new field to InteractionVerbPrototype that define whether the verb should check the user's consciousness in order to be performable and whether CanInteract should be checked (previously the latter was never checked and the latter was checked awlays).
- Fixes petting, hugging, and other no-op interactions having failure effects ("X fails to do Y"), but having no defined locales for them - by removing the said effects.

---

# TODO
- [X] Add fun
- [X] Sleep
- [X] Test fun
- [X] Fix fun
- [X] Test fun again
- [X] Realize the ~~third~~ fourth step didn't help and fix again

---

<details><summary><h1>Media</h1></summary>
<p>

Basics:

https://github.com/user-attachments/assets/73f1e160-158e-4df2-8e26-9939e69db305

Interactions that don't require hands:

https://github.com/user-attachments/assets/b0914620-2f96-4866-965a-eed1c44eb1b5

Addendum:


https://github.com/user-attachments/assets/00d1ed01-ecbe-4a79-ab37-543ee2aa5b97




</p>
</details>

# Changelog
- add: Added a new interaction - bite. Deals minor piercing damage and can only be used in very close range and with a long cooldown.
- tweak: Bite, Lick, Kiss, and LookAt interactions can now be used even while you are cuffed or otherwise cannot use hands. The first three of them instead require your mouth to be free, however (e.g. a muzzle or a helmet would stop you).
- tweak: You can now lick windows and anomalies. Yum.
