### PR TITLE
Holymelon Halo to Loadout

### DIFF
--- a/Resources/Prototypes/_Floof/Loadouts/Generic/head.yml
+++ b/Resources/Prototypes/_Floof/Loadouts/Generic/head.yml
@@ -205,6 +205,7 @@
   id: LoadoutHeadHatHolyWatermelon
   category: Head
   cost: 1
+  canBeHeirloom: true
   exclusive: true
   items:
     - ClothingHeadHatHolyWatermelon

--- a/Resources/Prototypes/_Floof/Loadouts/Generic/head.yml
+++ b/Resources/Prototypes/_Floof/Loadouts/Generic/head.yml
@@ -200,3 +200,14 @@
   requirements:
     - !type:CharacterItemGroupRequirement
       group: LoadoutHead
+
+ - type: loadout
+  id: LoadoutHeadHatHolyWatermelon
+  category: Head
+  cost: 1
+  exclusive: true
+  items:
+    - ClothingHeadHatHolyWatermelon
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: LoadoutHead

--- a/Resources/Prototypes/_Floof/Loadouts/Generic/head.yml
+++ b/Resources/Prototypes/_Floof/Loadouts/Generic/head.yml
@@ -200,8 +200,8 @@
   requirements:
     - !type:CharacterItemGroupRequirement
       group: LoadoutHead
-
- - type: loadout
+      
+- type: loadout
   id: LoadoutHeadHatHolyWatermelon
   category: Head
   cost: 1


### PR DESCRIPTION
# Description

Originally I was gonna add butcher-able to the holymelon to get the halo from Goobstation but turns out the code is exactly the same, just no one has figured out that you need to butcher interact it with a knife instead of cutting it.

So, this just adds it to the loadout, which allows it to be renamed and stuff.

# Changelog
:cl:
- add: Holymelon Halo to Loadout