### PR TITLE
Upstream Merge #2170 | Loadout And Trait Slot Cost

### DIFF
--- a/Content.Client/Lobby/UI/HumanoidProfileEditor.xaml.cs
+++ b/Content.Client/Lobby/UI/HumanoidProfileEditor.xaml.cs
@@ -1659,7 +1659,7 @@ namespace Content.Client.Lobby.UI
                     continue;
 
                 points += preferenceSelector.Trait.Points;
-                _traitCount += 1;
+                _traitCount += preferenceSelector.Trait.Slots;
             }
 
             TraitPointsBar.Value = points;
@@ -1882,7 +1882,7 @@ namespace Content.Client.Lobby.UI
                     // Make sure they have enough trait points
                     preference = CheckPoints(preference ? selector.Trait.Points : -selector.Trait.Points, preference);
                     // Make sure they have enough trait slots
-                    preference = preference ? _traitCount < _cfgManager.GetCVar(CCVars.GameTraitsMax) : preference;
+                    preference = CheckSlots(preference ? selector.Trait.Slots : -selector.Trait.Slots, preference);
 
                     // Update Preferences
                     Profile = Profile?.WithTraitPreference(selector.Trait.ID, preference);
@@ -1896,6 +1896,13 @@ namespace Content.Client.Lobby.UI
             {
                 var temp = TraitPointsBar.Value + points;
                 return preference ? !(temp < 0) : temp < 0;
+            }
+            
+            bool CheckSlots(int slots, bool preference)
+            {
+                var temp = _traitCount + slots;
+                var max = _cfgManager.GetCVar(CCVars.GameTraitsMax);
+                return preference ? !(temp > max) : temp > max;
             }
         }
 

--- a/Content.Shared/Clothing/Loadouts/Prototypes/LoadoutPrototype.cs
+++ b/Content.Shared/Clothing/Loadouts/Prototypes/LoadoutPrototype.cs
@@ -25,6 +25,12 @@ public sealed partial class LoadoutPrototype : IPrototype
     [DataField]
     public int Cost = 1;
 
+    /// <summary>
+    ///     How many item group selections this uses. Defaulted to 1:1, but can be any number.
+    /// </summary>
+    [DataField]
+    public int Slots = 1;
+
     /// Should this item override other items in the same slot
     [DataField]
     public bool Exclusive;

--- a/Content.Shared/Customization/Systems/CharacterRequirements.Profile.cs
+++ b/Content.Shared/Customization/Systems/CharacterRequirements.Profile.cs
@@ -390,9 +390,16 @@ public sealed partial class CharacterItemGroupRequirement : CharacterRequirement
             .ToList();
         var count = items.Count;
 
-        // If prototype is selected, remove one from the count
+        // If prototype is selected, decrease the count. Or increase it via negative number. Not my monkey, not my circus.
         if (items.ToList().Contains(prototype.ID))
-            count--;
+        {
+            // This disgusting ELIF nest requires an engine PR to make less terrible.
+            if (prototypeManager.TryIndex<LoadoutPrototype>(prototype.ID, out var loadoutPrototype))
+                count -= loadoutPrototype.Slots;
+            else if (prototypeManager.TryIndex<TraitPrototype>(prototype.ID, out var traitPrototype))
+                count -= traitPrototype.ItemGroupSlots;
+            else count--;
+        }
 
         reason = Loc.GetString(
             "character-item-group-requirement",

--- a/Content.Shared/Prototypes/CharacterItemGroupPrototype.cs
+++ b/Content.Shared/Prototypes/CharacterItemGroupPrototype.cs
@@ -1,7 +1,6 @@
 using System.Diagnostics.CodeAnalysis;
 using Content.Shared.Clothing.Loadouts.Prototypes;
 using Content.Shared.Clothing.Loadouts.Systems;
-using Content.Shared.Customization.Systems;
 using Content.Shared.Preferences;
 using Content.Shared.Traits;
 using Robust.Shared.Prototypes;

--- a/Content.Shared/Traits/Prototypes/TraitPrototype.cs
+++ b/Content.Shared/Traits/Prototypes/TraitPrototype.cs
@@ -27,7 +27,20 @@ public sealed partial class TraitPrototype : IPrototype, IComparable
     ///     How many points this will give the character
     /// </summary>
     [DataField]
-    public int Points = 0;
+    public int Points;
+
+    /// <summary>
+    ///     How many trait selections this uses. Defaulted to 1:1, but can be any number.
+    /// </summary>
+    [DataField]
+    public int Slots = 1;
+
+    /// <summary>
+    ///     Traits share their item group implementation with Loadouts, but have a separate use for their normal Slots.
+    ///     Thus, they can optionally be split, otherwise the behavior defaults to their standard slots.
+    /// </summary>
+    [DataField]
+    public int ItemGroupSlots = 1;
 
 
     [DataField]


### PR DESCRIPTION
# Description

https://github.com/Simple-Station/Einstein-Engines/pull/2170

This PR gently reworks the traits and loadouts system to where both
systems have a new Datafield for "Slots", which declares how many
selections the trait/loadout occupies. The actual implementation of
these differs between the two, since Traits has an actual selection
limit, while Loadouts do not(but instead respect CharacterItemGroups).
In both cases, Slots are defaulted to 1, and can be omitted in most
cases.

Where this shines particularly is in Traits, where it serves as a new
second line for trait balancing. Traits such as Accents, which are
completely worthless, otherwise would never be taken at all since they
compete with other traits for Opportunity Cost. Conversely, there's only
so many points we can increase a powerful trait to, (literally, they
cannot cost more than the current trait maximum). So traits can be made
to occupy >1 slot selections.

Slots can be defined for Item Groups as well, which is what this
datafield does on Loadouts, which both of these share. But since Traits
have two different places that their slots are used, I've opted to
create a split slot datafield for Traits. To simplify things, their
ItemGroupSlots defaults to their Slots datafield, but can be
independently changed as desired.

Minor Difference from the Original PR, this doesn't include changes to Accents yet, I'll add em in after this.

# Changelog

:cl:
- There's no player facing changes, just framework for future ones
