### PR TITLE
Task Kitsunebi 2 (Kitsune Markings Update)

### DIFF
--- a/Resources/Prototypes/DeltaV/Entities/Mobs/Customization/Markings/vulpkanin.yml
+++ b/Resources/Prototypes/DeltaV/Entities/Mobs/Customization/Markings/vulpkanin.yml
@@ -5,7 +5,7 @@
   id: VulpEar
   bodyPart: HeadTop
   markingCategory: HeadTop
-  speciesRestriction: [Vulpkanin, Human, SlimePerson, IPC, Oni, Harpy, Arachne, Rodentia]
+  speciesRestriction: [Vulpkanin, Human, SlimePerson, IPC, Oni, Harpy, Arachne, Rodentia, Kitsune] # Floof - M3739 - TaskKitsunebi2 - Give Kitsune access to Vulp Markings
   sprites:
     - sprite: DeltaV/Mobs/Customization/Vulpkanin/ear_markings.rsi
       state: vulp
@@ -16,7 +16,7 @@
   id: VulpEarFade
   bodyPart: HeadTop
   markingCategory: HeadTop
-  speciesRestriction: [Vulpkanin, Human, SlimePerson, IPC, Oni, Harpy, Arachne, Rodentia]
+  speciesRestriction: [Vulpkanin, Human, SlimePerson, IPC, Oni, Harpy, Arachne, Rodentia, Kitsune] # Floof - M3739 - TaskKitsunebi2 - Give Kitsune access to Vulp Markings
   sprites:
     - sprite: DeltaV/Mobs/Customization/Vulpkanin/ear_markings.rsi
       state: vulp
@@ -27,7 +27,7 @@
   id: VulpEarSharp
   bodyPart: HeadTop
   markingCategory: HeadTop
-  speciesRestriction: [Vulpkanin, Human, SlimePerson, IPC, Oni, Harpy, Arachne, Rodentia]
+  speciesRestriction: [Vulpkanin, Human, SlimePerson, IPC, Oni, Harpy, Arachne, Rodentia, Kitsune] # Floof - M3739 - TaskKitsunebi2 - Give Kitsune access to Vulp Markings
   sprites:
     - sprite: DeltaV/Mobs/Customization/Vulpkanin/ear_markings.rsi
       state: vulp
@@ -38,7 +38,7 @@
   id: VulpEarJackal
   bodyPart: HeadTop
   markingCategory: HeadTop
-  speciesRestriction: [Vulpkanin, Human, SlimePerson, IPC, Oni, Harpy, Arachne, Rodentia]
+  speciesRestriction: [Vulpkanin, Human, SlimePerson, IPC, Oni, Harpy, Arachne, Rodentia, Kitsune] # Floof - M3739 - TaskKitsunebi2 - Give Kitsune access to Vulp Markings
   sprites:
     - sprite: DeltaV/Mobs/Customization/Vulpkanin/ear_markings.rsi
       state: jackal
@@ -49,7 +49,7 @@
   id: VulpEarTerrier
   bodyPart: HeadTop
   markingCategory: HeadTop
-  speciesRestriction: [Vulpkanin, Human, SlimePerson, IPC, Oni, Harpy, Arachne, Rodentia]
+  speciesRestriction: [Vulpkanin, Human, SlimePerson, IPC, Oni, Harpy, Arachne, Rodentia, Kitsune] # Floof - M3739 - TaskKitsunebi2 - Give Kitsune access to Vulp Markings
   sprites:
     - sprite: DeltaV/Mobs/Customization/Vulpkanin/ear_markings.rsi
       state: terrier
@@ -60,7 +60,7 @@
   id: VulpEarWolf
   bodyPart: HeadTop
   markingCategory: HeadTop
-  speciesRestriction: [Vulpkanin, Human, SlimePerson, IPC, Oni, Harpy, Arachne, Rodentia]
+  speciesRestriction: [Vulpkanin, Human, SlimePerson, IPC, Oni, Harpy, Arachne, Rodentia, Kitsune] # Floof - M3739 - TaskKitsunebi2 - Give Kitsune access to Vulp Markings
   sprites:
     - sprite: DeltaV/Mobs/Customization/Vulpkanin/ear_markings.rsi
       state: wolf
@@ -93,7 +93,7 @@
   id: VulpEarOtie
   bodyPart: HeadTop
   markingCategory: HeadTop
-  speciesRestriction: [Vulpkanin, Human, SlimePerson, IPC, Oni, Harpy, Arachne, Rodentia]
+  speciesRestriction: [Vulpkanin, Human, SlimePerson, IPC, Oni, Harpy, Arachne, Rodentia, Kitsune] # Floof - M3739 - TaskKitsunebi2 - Give Kitsune access to Vulp Markings
   sprites:
     - sprite: DeltaV/Mobs/Customization/Vulpkanin/ear_markings.rsi
       state: otie
@@ -104,7 +104,7 @@
   id: VulpEarTajaran
   bodyPart: HeadTop
   markingCategory: HeadTop
-  speciesRestriction: [Vulpkanin, Human, SlimePerson, IPC, Oni, Harpy, Arachne, Rodentia]
+  speciesRestriction: [Vulpkanin, Human, SlimePerson, IPC, Oni, Harpy, Arachne, Rodentia, Kitsune] # Floof - M3739 - TaskKitsunebi2 - Give Kitsune access to Vulp Markings
   sprites:
     - sprite: DeltaV/Mobs/Customization/Vulpkanin/ear_markings.rsi
       state: msai
@@ -115,7 +115,7 @@
   id: VulpEarShock
   bodyPart: HeadTop
   markingCategory: HeadTop
-  speciesRestriction: [Vulpkanin, Human, SlimePerson, IPC, Oni, Harpy, Arachne, Rodentia]
+  speciesRestriction: [Vulpkanin, Human, SlimePerson, IPC, Oni, Harpy, Arachne, Rodentia, Kitsune] # Floof - M3739 - TaskKitsunebi2 - Give Kitsune access to Vulp Markings
   sprites:
     - sprite: DeltaV/Mobs/Customization/Vulpkanin/ear_markings.rsi
       state: shock
@@ -124,7 +124,7 @@
   id: VulpEarCoyote
   bodyPart: HeadTop
   markingCategory: HeadTop
-  speciesRestriction: [Vulpkanin, Human, SlimePerson, IPC, Oni, Harpy, Arachne, Rodentia]
+  speciesRestriction: [Vulpkanin, Human, SlimePerson, IPC, Oni, Harpy, Arachne, Rodentia, Kitsune] # Floof - M3739 - TaskKitsunebi2 - Give Kitsune access to Vulp Markings
   sprites:
     - sprite: DeltaV/Mobs/Customization/Vulpkanin/ear_markings.rsi
       state: coyote
@@ -133,7 +133,7 @@
   id: VulpEarDalmatian
   bodyPart: HeadTop
   markingCategory: HeadTop
-  speciesRestriction: [Vulpkanin, Human, SlimePerson, IPC, Oni, Harpy, Arachne, Rodentia]
+  speciesRestriction: [Vulpkanin, Human, SlimePerson, IPC, Oni, Harpy, Arachne, Rodentia, Kitsune] # Floof - M3739 - TaskKitsunebi2 - Give Kitsune access to Vulp Markings
   sprites:
     - sprite: DeltaV/Mobs/Customization/Vulpkanin/ear_markings.rsi
       state: dalmatian
@@ -143,7 +143,7 @@
   id: VulpSnoutAlt
   bodyPart: Snout
   markingCategory: Snout
-  speciesRestriction: [Vulpkanin, SlimePerson, IPC] # FLOOF CHANGE IPCs get furry parts
+  speciesRestriction: [Vulpkanin, SlimePerson, IPC, Kitsune] # Floof - M3739 - TaskKitsunebi2 - Give Kitsune access to Vulp Markings
   sprites:
     - sprite: DeltaV/Mobs/Customization/Vulpkanin/head_markings.rsi
       state: muzzle_alt
@@ -154,7 +154,7 @@
   id: VulpSnout
   bodyPart: Snout
   markingCategory: Snout
-  speciesRestriction: [Vulpkanin, SlimePerson, IPC] # FLOOF CHANGE IPCs get furry parts
+  speciesRestriction: [Vulpkanin, SlimePerson, IPC, Kitsune] # Floof - M3739 - TaskKitsunebi2 - Give Kitsune access to Vulp Markings
   sprites:
     - sprite: DeltaV/Mobs/Customization/Vulpkanin/head_markings.rsi
       state: muzzle
@@ -165,7 +165,7 @@
   id: VulpSnoutSharp
   bodyPart: Snout
   markingCategory: Snout
-  speciesRestriction: [Vulpkanin, SlimePerson, IPC] # FLOOF CHANGE IPCs get furry parts
+  speciesRestriction: [Vulpkanin, SlimePerson, IPC, Kitsune] # Floof - M3739 - TaskKitsunebi2 - Give Kitsune access to Vulp Markings
   sprites:
     - sprite: DeltaV/Mobs/Customization/Vulpkanin/head_markings.rsi
       state: muzzle_sharp
@@ -176,7 +176,7 @@
   id: VulpSnoutFade
   bodyPart: Snout
   markingCategory: Snout
-  speciesRestriction: [Vulpkanin, SlimePerson, IPC] # FLOOF CHANGE IPCs get furry parts
+  speciesRestriction: [Vulpkanin, SlimePerson, IPC, Kitsune] # Floof - M3739 - TaskKitsunebi2 - Give Kitsune access to Vulp Markings
   sprites:
     - sprite: DeltaV/Mobs/Customization/Vulpkanin/head_markings.rsi
       state: muzzle_fade
@@ -187,7 +187,7 @@
   id: VulpSnoutNose
   bodyPart: Snout
   markingCategory: Snout
-  speciesRestriction: [Vulpkanin, SlimePerson, IPC] # FLOOF CHANGE IPCs get furry parts
+  speciesRestriction: [Vulpkanin, SlimePerson, IPC, Kitsune] # Floof - M3739 - TaskKitsunebi2 - Give Kitsune access to Vulp Markings
   sprites:
     - sprite: DeltaV/Mobs/Customization/Vulpkanin/head_markings.rsi
       state: nose
@@ -196,7 +196,7 @@
   id: VulpSnoutMask
   bodyPart: Snout
   markingCategory: Snout
-  speciesRestriction: [Vulpkanin, SlimePerson, IPC] # FLOOF CHANGE IPCs get furry parts
+  speciesRestriction: [Vulpkanin, SlimePerson, IPC, Kitsune] # Floof - M3739 - TaskKitsunebi2 - Give Kitsune access to Vulp Markings
   sprites:
     - sprite: DeltaV/Mobs/Customization/Vulpkanin/head_markings.rsi
       state: mask
@@ -207,7 +207,7 @@
   id: VulpSnoutVulpine
   bodyPart: Snout
   markingCategory: Snout
-  speciesRestriction: [Vulpkanin, SlimePerson, IPC] # FLOOF CHANGE IPCs get furry parts
+  speciesRestriction: [Vulpkanin, SlimePerson, IPC, Kitsune] # Floof - M3739 - TaskKitsunebi2 - Give Kitsune access to Vulp Markings
   sprites:
     - sprite: DeltaV/Mobs/Customization/Vulpkanin/head_markings.rsi
       state: vulpine
@@ -218,7 +218,7 @@
   id: VulpSnoutSwift
   bodyPart: Snout
   markingCategory: Snout
-  speciesRestriction: [Vulpkanin, SlimePerson, IPC] # FLOOF CHANGE IPCs get furry parts
+  speciesRestriction: [Vulpkanin, SlimePerson, IPC, Kitsune] # Floof - M3739 - TaskKitsunebi2 - Give Kitsune access to Vulp Markings
   sprites:
     - sprite: DeltaV/Mobs/Customization/Vulpkanin/head_markings.rsi
       state: vulpine-lines
@@ -227,7 +227,7 @@
   id: VulpSnoutBlaze
   bodyPart: Snout
   markingCategory: Snout
-  speciesRestriction: [Vulpkanin, SlimePerson, IPC] # FLOOF CHANGE IPCs get furry parts
+  speciesRestriction: [Vulpkanin, SlimePerson, IPC, Kitsune] # Floof - M3739 - TaskKitsunebi2 - Give Kitsune access to Vulp Markings
   sprites:
     - sprite: DeltaV/Mobs/Customization/Vulpkanin/head_markings.rsi
       state: blaze
@@ -236,7 +236,7 @@
   id: VulpSnoutPatch
   bodyPart: Snout
   markingCategory: Snout
-  speciesRestriction: [Vulpkanin, SlimePerson, IPC] # FLOOF CHANGE IPCs get furry parts
+  speciesRestriction: [Vulpkanin, SlimePerson, IPC, Kitsune] # Floof - M3739 - TaskKitsunebi2 - Give Kitsune access to Vulp Markings
   sprites:
     - sprite: DeltaV/Mobs/Customization/Vulpkanin/head_markings.rsi
       state: patch
@@ -246,7 +246,7 @@
   id: VulpHeadTiger
   bodyPart: Head
   markingCategory: Head
-  speciesRestriction: [Vulpkanin, SlimePerson, IPC] # FLOOF CHANGE IPCs get furry parts
+  speciesRestriction: [Vulpkanin, SlimePerson, IPC, Kitsune] # Floof - M3739 - TaskKitsunebi2 - Give Kitsune access to Vulp Markings
   sprites:
     - sprite: DeltaV/Mobs/Customization/Vulpkanin/head_markings.rsi
       state: tiger_head
@@ -255,7 +255,7 @@
   id: VulpHeadTigerFace
   bodyPart: Head
   markingCategory: Head
-  speciesRestriction: [Vulpkanin, SlimePerson, IPC] # FLOOF CHANGE IPCs get furry parts
+  speciesRestriction: [Vulpkanin, SlimePerson, IPC, Kitsune] # Floof - M3739 - TaskKitsunebi2 - Give Kitsune access to Vulp Markings
   sprites:
     - sprite: DeltaV/Mobs/Customization/Vulpkanin/head_markings.rsi
       state: tiger_face
@@ -264,7 +264,7 @@
   id: VulpHeadSlash
   bodyPart: Head
   markingCategory: Head
-  speciesRestriction: [Vulpkanin, SlimePerson, IPC] # FLOOF CHANGE IPCs get furry parts
+  speciesRestriction: [Vulpkanin, SlimePerson, IPC, Kitsune] # Floof - M3739 - TaskKitsunebi2 - Give Kitsune access to Vulp Markings
   sprites:
     - sprite: DeltaV/Mobs/Customization/Vulpkanin/head_markings.rsi
       state: slash
@@ -318,7 +318,7 @@
   id: VulpTailAlt
   bodyPart: Tail
   markingCategory: Tail
-  speciesRestriction: [Vulpkanin, Human, SlimePerson, IPC, Oni, Felinid, Rodentia]
+  speciesRestriction: [Vulpkanin, Human, SlimePerson, IPC, Oni, Felinid, Rodentia, Kitsune] # Floof - M3739 - TaskKitsunebi2 - Give Kitsune access to Vulp Markings
   sprites:
     - sprite: DeltaV/Mobs/Customization/Vulpkanin/tail_markings.rsi
       state: vulp_alt
@@ -329,7 +329,7 @@
   id: VulpTailAltTip
   bodyPart: Tail
   markingCategory: Tail
-  speciesRestriction: [Vulpkanin, Human, SlimePerson, IPC, Oni, Felinid, Rodentia]
+  speciesRestriction: [Vulpkanin, Human, SlimePerson, IPC, Oni, Felinid, Rodentia, Kitsune] # Floof - M3739 - TaskKitsunebi2 - Give Kitsune access to Vulp Markings
   sprites:
     - sprite: DeltaV/Mobs/Customization/Vulpkanin/tail_markings.rsi
       state: vulp_alt
@@ -340,7 +340,7 @@
   id: VulpTailLong
   bodyPart: Tail
   markingCategory: Tail
-  speciesRestriction: [Vulpkanin, Human, SlimePerson, IPC, Oni, Felinid, Rodentia]
+  speciesRestriction: [Vulpkanin, Human, SlimePerson, IPC, Oni, Felinid, Rodentia, Kitsune] # Floof - M3739 - TaskKitsunebi2 - Give Kitsune access to Vulp Markings
   sprites:
     - sprite: DeltaV/Mobs/Customization/Vulpkanin/tail_markings.rsi
       state: long
@@ -395,7 +395,7 @@
   id: VulpTailBushy
   bodyPart: Tail
   markingCategory: Tail
-  speciesRestriction: [Vulpkanin, Human, SlimePerson, IPC, Oni, Felinid, Rodentia]
+  speciesRestriction: [Vulpkanin, Human, SlimePerson, IPC, Oni, Felinid, Rodentia, Kitsune] # Floof - M3739 - TaskKitsunebi2 - Give Kitsune access to Vulp Markings
   sprites:
     - sprite: DeltaV/Mobs/Customization/Vulpkanin/tail_markings.rsi
       state: bushfluff
@@ -413,7 +413,7 @@
   id: VulpTailCoyote
   bodyPart: Tail
   markingCategory: Tail
-  speciesRestriction: [Vulpkanin, Human, SlimePerson, IPC, Oni, Felinid, Rodentia]
+  speciesRestriction: [Vulpkanin, Human, SlimePerson, IPC, Oni, Felinid, Rodentia, Kitsune] # Floof - M3739 - TaskKitsunebi2 - Give Kitsune access to Vulp Markings
   sprites:
     - sprite: DeltaV/Mobs/Customization/Vulpkanin/tail_markings.rsi
       state: coyote
@@ -431,7 +431,7 @@
   id: VulpTailCorgi
   bodyPart: Tail
   markingCategory: Tail
-  speciesRestriction: [Vulpkanin, Human, SlimePerson, IPC, Oni, Felinid, Rodentia]
+  speciesRestriction: [Vulpkanin, Human, SlimePerson, IPC, Oni, Felinid, Rodentia, Kitsune] # Floof - M3739 - TaskKitsunebi2 - Give Kitsune access to Vulp Markings
   sprites:
     - sprite: DeltaV/Mobs/Customization/Vulpkanin/tail_markings.rsi
       state: corgi
@@ -449,7 +449,7 @@
   id: VulpTailHusky
   bodyPart: Tail
   markingCategory: Tail
-  speciesRestriction: [Vulpkanin, Human, SlimePerson, IPC, Oni, Felinid, Rodentia]
+  speciesRestriction: [Vulpkanin, Human, SlimePerson, IPC, Oni, Felinid, Rodentia, Kitsune] # Floof - M3739 - TaskKitsunebi2 - Give Kitsune access to Vulp Markings
   sprites:
     - sprite: DeltaV/Mobs/Customization/Vulpkanin/tail_markings.rsi
       state: husky-inner
@@ -460,7 +460,7 @@
   id: VulpTailHuskyAlt
   bodyPart: Tail
   markingCategory: Tail
-  speciesRestriction: [Vulpkanin, Human, SlimePerson, IPC, Oni, Felinid, Rodentia]
+  speciesRestriction: [Vulpkanin, Human, SlimePerson, IPC, Oni, Felinid, Rodentia, Kitsune] # Floof - M3739 - TaskKitsunebi2 - Give Kitsune access to Vulp Markings
   sprites:
     - sprite: DeltaV/Mobs/Customization/Vulpkanin/tail_markings.rsi
       state: husky
@@ -498,7 +498,7 @@
   id: VulpTailOtie
   bodyPart: Tail
   markingCategory: Tail
-  speciesRestriction: [Vulpkanin, Human, SlimePerson, IPC, Oni, Felinid, Rodentia]
+  speciesRestriction: [Vulpkanin, Human, SlimePerson, IPC, Oni, Felinid, Rodentia, Kitsune] # Floof - M3739 - TaskKitsunebi2 - Give Kitsune access to Vulp Markings
   sprites:
     - sprite: DeltaV/Mobs/Customization/Vulpkanin/tail_markings.rsi
       state: otie
@@ -507,7 +507,7 @@
   id: VulpTailFluffy
   bodyPart: Tail
   markingCategory: Tail
-  speciesRestriction: [Vulpkanin, Human, SlimePerson, IPC, Oni, Felinid, Rodentia]
+  speciesRestriction: [Vulpkanin, Human, SlimePerson, IPC, Oni, Felinid, Rodentia, Kitsune] # Floof - M3739 - TaskKitsunebi2 - Give Kitsune access to Vulp Markings
   sprites:
     - sprite: DeltaV/Mobs/Customization/Vulpkanin/tail_markings.rsi
       state: fluffy
@@ -516,7 +516,7 @@
   id: VulpTailDalmatian
   bodyPart: Tail
   markingCategory: Tail
-  speciesRestriction: [Vulpkanin, Human, SlimePerson, IPC, Oni, Felinid, Rodentia]
+  speciesRestriction: [Vulpkanin, Human, SlimePerson, IPC, Oni, Felinid, Rodentia, Kitsune] # Floof - M3739 - TaskKitsunebi2 - Give Kitsune access to Vulp Markings
   sprites:
     - sprite: DeltaV/Mobs/Customization/Vulpkanin/tail_markings.rsi
       state: dalmatian
@@ -535,7 +535,7 @@
   id: VulpBellyCrest
   bodyPart: Chest
   markingCategory: Chest
-  speciesRestriction: [Vulpkanin, SlimePerson, IPC, Human] # FLOOF CHANGE IPCs get furry parts
+  speciesRestriction: [Vulpkanin, SlimePerson, IPC, Human, Kitsune] # Floof - M3739 - TaskKitsunebi2 - Give Kitsune access to Vulp Markings
   sprites:
     - sprite: DeltaV/Mobs/Customization/Vulpkanin/body_markings.rsi
       state: belly_crest
@@ -544,7 +544,7 @@
   id: VulpBellyFull
   bodyPart: Chest
   markingCategory: Chest
-  speciesRestriction: [Vulpkanin, SlimePerson, IPC, Human] # FLOOF CHANGE IPCs get furry parts
+  speciesRestriction: [Vulpkanin, SlimePerson, IPC, Human, Kitsune] # Floof - M3739 - TaskKitsunebi2 - Give Kitsune access to Vulp Markings
   sprites:
     - sprite: DeltaV/Mobs/Customization/Vulpkanin/body_markings.rsi
       state: belly_full
@@ -553,7 +553,7 @@
   id: VulpBellyFox
   bodyPart: Chest
   markingCategory: Chest
-  speciesRestriction: [Vulpkanin, SlimePerson, IPC, Human] # FLOOF CHANGE IPCs get furry parts
+  speciesRestriction: [Vulpkanin, SlimePerson, IPC, Human, Kitsune] # Floof - M3739 - TaskKitsunebi2 - Give Kitsune access to Vulp Markings
   sprites:
     - sprite: DeltaV/Mobs/Customization/Vulpkanin/body_markings.rsi
       state: belly_fox
@@ -564,7 +564,7 @@
 #   id: VulpBodyPointsCrest
 #   markingCategory: Overlay
 #   bodyPart: RFoot
-#   speciesRestriction: [Vulpkanin, SlimePerson, IPC] # FLOOF CHANGE IPCs get furry parts
+#   speciesRestriction: [Vulpkanin, SlimePerson, IPC, Kitsune] # Floof - M3739 - TaskKitsunebi2 - Give Kitsune access to Vulp Markings
 #   sprites:
 #     - sprite: DeltaV/Mobs/Customization/Vulpkanin/body_markings.rsi
 #       state: points_crest
@@ -573,7 +573,7 @@
 #   id: VulpBodyPointsFade
 #   markingCategory: Overlay
 #   bodyPart: RFoot
-#   speciesRestriction: [Vulpkanin, SlimePerson, IPC] # FLOOF CHANGE IPCs get furry parts
+#   speciesRestriction: [Vulpkanin, SlimePerson, IPC, Kitsune] # Floof - M3739 - TaskKitsunebi2 - Give Kitsune access to Vulp Markings
 #   sprites:
 #     - sprite: DeltaV/Mobs/Customization/Vulpkanin/body_markings.rsi
 #       state: points_fade
@@ -582,7 +582,7 @@
 #   id: VulpBodyPointsSharp
 #   markingCategory: Overlay
 #   bodyPart: RFoot
-#   speciesRestriction: [Vulpkanin, SlimePerson, IPC] # FLOOF CHANGE IPCs get furry parts
+#   speciesRestriction: [Vulpkanin, SlimePerson, IPC, Kitsune] # Floof - M3739 - TaskKitsunebi2 - Give Kitsune access to Vulp Markings
 #   sprites:
 #     - sprite: DeltaV/Mobs/Customization/Vulpkanin/body_markings.rsi
 #       state: points_sharp
@@ -592,7 +592,7 @@
   id: VulpPointsFeet
   markingCategory: RightFoot
   bodyPart: RFoot
-  speciesRestriction: [Vulpkanin, SlimePerson, IPC] # FLOOF CHANGE IPCs get furry parts
+  speciesRestriction: [Vulpkanin, SlimePerson, IPC, Kitsune] # Floof - M3739 - TaskKitsunebi2 - Give Kitsune access to Vulp Markings
   sprites:
     - sprite: DeltaV/Mobs/Customization/Vulpkanin/body_markings.rsi
       state: points_feet
@@ -601,7 +601,7 @@
   id: VulpPointsCrestLegs
   markingCategory: LeftLeg
   bodyPart: LLeg
-  speciesRestriction: [Vulpkanin, SlimePerson, IPC] # FLOOF CHANGE IPCs get furry parts
+  speciesRestriction: [Vulpkanin, SlimePerson, IPC, Kitsune] # Floof - M3739 - TaskKitsunebi2 - Give Kitsune access to Vulp Markings
   sprites:
     - sprite: DeltaV/Mobs/Customization/Vulpkanin/body_markings.rsi
       state: points_crest-legs
@@ -610,7 +610,7 @@
   id: VulpPointsFadeLegs
   markingCategory: LeftLeg
   bodyPart: LLeg
-  speciesRestriction: [Vulpkanin, SlimePerson, IPC] # FLOOF CHANGE IPCs get furry parts
+  speciesRestriction: [Vulpkanin, SlimePerson, IPC, Kitsune] # Floof - M3739 - TaskKitsunebi2 - Give Kitsune access to Vulp Markings
   sprites:
     - sprite: DeltaV/Mobs/Customization/Vulpkanin/body_markings.rsi
       state: points_fade-legs
@@ -619,7 +619,7 @@
   id: VulpPointsSharpLegs
   markingCategory: LeftLeg
   bodyPart: LLeg
-  speciesRestriction: [Vulpkanin, SlimePerson, IPC] # FLOOF CHANGE IPCs get furry parts
+  speciesRestriction: [Vulpkanin, SlimePerson, IPC, Kitsune] # Floof - M3739 - TaskKitsunebi2 - Give Kitsune access to Vulp Markings
   sprites:
     - sprite: DeltaV/Mobs/Customization/Vulpkanin/body_markings.rsi
       state: points_sharp-legs
@@ -629,7 +629,7 @@
   id: VulpPointsHands
   markingCategory: RightHand
   bodyPart: RHand
-  speciesRestriction: [Vulpkanin, SlimePerson, IPC] # FLOOF CHANGE IPCs get furry parts
+  speciesRestriction: [Vulpkanin, SlimePerson, IPC, Kitsune] # Floof - M3739 - TaskKitsunebi2 - Give Kitsune access to Vulp Markings
   sprites:
     - sprite: DeltaV/Mobs/Customization/Vulpkanin/body_markings.rsi
       state: points_hands
@@ -638,7 +638,7 @@
   id: VulpPointsCrestArms
   markingCategory: LeftArm
   bodyPart: LArm
-  speciesRestriction: [Vulpkanin, SlimePerson, IPC] # FLOOF CHANGE IPCs get furry parts
+  speciesRestriction: [Vulpkanin, SlimePerson, IPC, Kitsune] # Floof - M3739 - TaskKitsunebi2 - Give Kitsune access to Vulp Markings
   sprites:
     - sprite: DeltaV/Mobs/Customization/Vulpkanin/body_markings.rsi
       state: points_crest-arms
@@ -647,7 +647,7 @@
   id: VulpPointsFadeArms
   markingCategory: LeftArm
   bodyPart: LArm
-  speciesRestriction: [Vulpkanin, SlimePerson, IPC] # FLOOF CHANGE IPCs get furry parts
+  speciesRestriction: [Vulpkanin, SlimePerson, IPC, Kitsune] # Floof - M3739 - TaskKitsunebi2 - Give Kitsune access to Vulp Markings
   sprites:
     - sprite: DeltaV/Mobs/Customization/Vulpkanin/body_markings.rsi
       state: points_fade-arms
@@ -656,7 +656,7 @@
   id: VulpPointsSharpArms
   markingCategory: LeftArm
   bodyPart: LArm
-  speciesRestriction: [Vulpkanin, SlimePerson, IPC] # FLOOF CHANGE IPCs get furry parts
+  speciesRestriction: [Vulpkanin, SlimePerson, IPC, Kitsune] # Floof - M3739 - TaskKitsunebi2 - Give Kitsune access to Vulp Markings
   sprites:
     - sprite: DeltaV/Mobs/Customization/Vulpkanin/body_markings.rsi
       state: points_sharp-arms
@@ -665,7 +665,7 @@
 - type: marking
   id: VulpHairAdhara
   bodyPart: Hair
-  speciesRestriction: [Vulpkanin, SlimePerson, IPC] # FLOOF CHANGE IPCs get furry parts
+  speciesRestriction: [Vulpkanin, SlimePerson, IPC, Kitsune] # Floof - M3739 - TaskKitsunebi2 - Give Kitsune access to Vulp Markings
   markingCategory: Hair
   sprites:
     - sprite: DeltaV/Mobs/Customization/Vulpkanin/hair.rsi
@@ -674,7 +674,7 @@
 - type: marking
   id: VulpHairAnita
   bodyPart: Hair
-  speciesRestriction: [Vulpkanin, SlimePerson, IPC] # FLOOF CHANGE IPCs get furry parts
+  speciesRestriction: [Vulpkanin, SlimePerson, IPC, Kitsune] # Floof - M3739 - TaskKitsunebi2 - Give Kitsune access to Vulp Markings
   markingCategory: Hair
   sprites:
     - sprite: DeltaV/Mobs/Customization/Vulpkanin/hair.rsi
@@ -683,7 +683,7 @@
 - type: marking
   id: VulpHairApollo
   bodyPart: Hair
-  speciesRestriction: [Vulpkanin, SlimePerson, IPC] # FLOOF CHANGE IPCs get furry parts
+  speciesRestriction: [Vulpkanin, SlimePerson, IPC, Kitsune] # Floof - M3739 - TaskKitsunebi2 - Give Kitsune access to Vulp Markings
   markingCategory: Hair
   sprites:
     - sprite: DeltaV/Mobs/Customization/Vulpkanin/hair.rsi
@@ -692,7 +692,7 @@
 - type: marking
   id: VulpHairBelle
   bodyPart: Hair
-  speciesRestriction: [Vulpkanin, SlimePerson, IPC] # FLOOF CHANGE IPCs get furry parts
+  speciesRestriction: [Vulpkanin, SlimePerson, IPC, Kitsune] # Floof - M3739 - TaskKitsunebi2 - Give Kitsune access to Vulp Markings
   markingCategory: Hair
   sprites:
     - sprite: DeltaV/Mobs/Customization/Vulpkanin/hair.rsi
@@ -702,7 +702,7 @@
   id: VulpHairBraided
   bodyPart: Hair
   markingCategory: Hair
-  speciesRestriction: [Vulpkanin, SlimePerson, IPC] # FLOOF CHANGE IPCs get furry parts
+  speciesRestriction: [Vulpkanin, SlimePerson, IPC, Kitsune] # Floof - M3739 - TaskKitsunebi2 - Give Kitsune access to Vulp Markings
   sprites:
     - sprite: DeltaV/Mobs/Customization/Vulpkanin/hair.rsi
       state: braided
@@ -711,7 +711,7 @@
   id: VulpHairBun
   bodyPart: Hair
   markingCategory: Hair
-  speciesRestriction: [Vulpkanin, SlimePerson, IPC] # FLOOF CHANGE IPCs get furry parts
+  speciesRestriction: [Vulpkanin, SlimePerson, IPC, Kitsune] # Floof - M3739 - TaskKitsunebi2 - Give Kitsune access to Vulp Markings
   sprites:
     - sprite: DeltaV/Mobs/Customization/Vulpkanin/hair.rsi
       state: bun
@@ -720,7 +720,7 @@
   id: VulpHairCleanCut
   bodyPart: Hair
   markingCategory: Hair
-  speciesRestriction: [Vulpkanin, SlimePerson, IPC] # FLOOF CHANGE IPCs get furry parts
+  speciesRestriction: [Vulpkanin, SlimePerson, IPC, Kitsune] # Floof - M3739 - TaskKitsunebi2 - Give Kitsune access to Vulp Markings
   sprites:
     - sprite: DeltaV/Mobs/Customization/Vulpkanin/hair.rsi
       state: clean_cut
@@ -729,7 +729,7 @@
   id: VulpHairCurl
   bodyPart: Hair
   markingCategory: Hair
-  speciesRestriction: [Vulpkanin, SlimePerson, IPC] # FLOOF CHANGE IPCs get furry parts
+  speciesRestriction: [Vulpkanin, SlimePerson, IPC, Kitsune] # Floof - M3739 - TaskKitsunebi2 - Give Kitsune access to Vulp Markings
   sprites:
     - sprite: DeltaV/Mobs/Customization/Vulpkanin/hair.rsi
       state: curl
@@ -738,7 +738,7 @@
   id: VulpHairHawk
   bodyPart: Hair
   markingCategory: Hair
-  speciesRestriction: [Vulpkanin, SlimePerson, IPC] # FLOOF CHANGE IPCs get furry parts
+  speciesRestriction: [Vulpkanin, SlimePerson, IPC, Kitsune] # Floof - M3739 - TaskKitsunebi2 - Give Kitsune access to Vulp Markings
   sprites:
     - sprite: DeltaV/Mobs/Customization/Vulpkanin/hair.rsi
       state: hawk
@@ -747,7 +747,7 @@
   id: VulpHairJagged
   bodyPart: Hair
   markingCategory: Hair
-  speciesRestriction: [Vulpkanin, SlimePerson, IPC] # FLOOF CHANGE IPCs get furry parts
+  speciesRestriction: [Vulpkanin, SlimePerson, IPC, Kitsune] # Floof - M3739 - TaskKitsunebi2 - Give Kitsune access to Vulp Markings
   sprites:
     - sprite: DeltaV/Mobs/Customization/Vulpkanin/hair.rsi
       state: jagged
@@ -756,7 +756,7 @@
   id: VulpHairJeremy
   bodyPart: Hair
   markingCategory: Hair
-  speciesRestriction: [Vulpkanin, SlimePerson, IPC] # FLOOF CHANGE IPCs get furry parts
+  speciesRestriction: [Vulpkanin, SlimePerson, IPC, Kitsune] # Floof - M3739 - TaskKitsunebi2 - Give Kitsune access to Vulp Markings
   sprites:
     - sprite: DeltaV/Mobs/Customization/Vulpkanin/hair.rsi
       state: jeremy
@@ -765,7 +765,7 @@
   id: VulpHairKajam
   bodyPart: Hair
   markingCategory: Hair
-  speciesRestriction: [Vulpkanin, SlimePerson, IPC] # FLOOF CHANGE IPCs get furry parts
+  speciesRestriction: [Vulpkanin, SlimePerson, IPC, Kitsune] # Floof - M3739 - TaskKitsunebi2 - Give Kitsune access to Vulp Markings
   sprites:
     - sprite: DeltaV/Mobs/Customization/Vulpkanin/hair.rsi
       state: kajam
@@ -774,7 +774,7 @@
   id: VulpHairKeid
   bodyPart: Hair
   markingCategory: Hair
-  speciesRestriction: [Vulpkanin, SlimePerson, IPC] # FLOOF CHANGE IPCs get furry parts
+  speciesRestriction: [Vulpkanin, SlimePerson, IPC, Kitsune] # Floof - M3739 - TaskKitsunebi2 - Give Kitsune access to Vulp Markings
   sprites:
     - sprite: DeltaV/Mobs/Customization/Vulpkanin/hair.rsi
       state: keid
@@ -783,7 +783,7 @@
   id: VulpHairKleeia
   bodyPart: Hair
   markingCategory: Hair
-  speciesRestriction: [Vulpkanin, SlimePerson, IPC] # FLOOF CHANGE IPCs get furry parts
+  speciesRestriction: [Vulpkanin, SlimePerson, IPC, Kitsune] # Floof - M3739 - TaskKitsunebi2 - Give Kitsune access to Vulp Markings
   sprites:
     - sprite: DeltaV/Mobs/Customization/Vulpkanin/hair.rsi
       state: kleeia
@@ -792,7 +792,7 @@
   id: VulpHairMizar
   bodyPart: Hair
   markingCategory: Hair
-  speciesRestriction: [Vulpkanin, SlimePerson, IPC] # FLOOF CHANGE IPCs get furry parts
+  speciesRestriction: [Vulpkanin, SlimePerson, IPC, Kitsune] # Floof - M3739 - TaskKitsunebi2 - Give Kitsune access to Vulp Markings
   sprites:
     - sprite: DeltaV/Mobs/Customization/Vulpkanin/hair.rsi
       state: mizar
@@ -801,7 +801,7 @@
   id: VulpHairPunkBraided
   bodyPart: Hair
   markingCategory: Hair
-  speciesRestriction: [Vulpkanin, SlimePerson, IPC] # FLOOF CHANGE IPCs get furry parts
+  speciesRestriction: [Vulpkanin, SlimePerson, IPC, Kitsune] # Floof - M3739 - TaskKitsunebi2 - Give Kitsune access to Vulp Markings
   sprites:
     - sprite: DeltaV/Mobs/Customization/Vulpkanin/hair.rsi
       state: punkbraided
@@ -810,7 +810,7 @@
   id: VulpHairRaine
   bodyPart: Hair
   markingCategory: Hair
-  speciesRestriction: [Vulpkanin, SlimePerson, IPC] # FLOOF CHANGE IPCs get furry parts
+  speciesRestriction: [Vulpkanin, SlimePerson, IPC, Kitsune] # Floof - M3739 - TaskKitsunebi2 - Give Kitsune access to Vulp Markings
   sprites:
     - sprite: DeltaV/Mobs/Customization/Vulpkanin/hair.rsi
       state: raine
@@ -819,7 +819,7 @@
   id: VulpHairRough
   bodyPart: Hair
   markingCategory: Hair
-  speciesRestriction: [Vulpkanin, SlimePerson, IPC] # FLOOF CHANGE IPCs get furry parts
+  speciesRestriction: [Vulpkanin, SlimePerson, IPC, Kitsune] # Floof - M3739 - TaskKitsunebi2 - Give Kitsune access to Vulp Markings
   sprites:
     - sprite: DeltaV/Mobs/Customization/Vulpkanin/hair.rsi
       state: rough
@@ -828,7 +828,7 @@
   id: VulpHairShort
   bodyPart: Hair
   markingCategory: Hair
-  speciesRestriction: [Vulpkanin, SlimePerson, IPC] # FLOOF CHANGE IPCs get furry parts
+  speciesRestriction: [Vulpkanin, SlimePerson, IPC, Kitsune] # Floof - M3739 - TaskKitsunebi2 - Give Kitsune access to Vulp Markings
   sprites:
     - sprite: DeltaV/Mobs/Customization/Vulpkanin/hair.rsi
       state: short
@@ -837,7 +837,7 @@
   id: VulpHairShort2
   bodyPart: Hair
   markingCategory: Hair
-  speciesRestriction: [Vulpkanin, SlimePerson, IPC] # FLOOF CHANGE IPCs get furry parts
+  speciesRestriction: [Vulpkanin, SlimePerson, IPC, Kitsune] # Floof - M3739 - TaskKitsunebi2 - Give Kitsune access to Vulp Markings
   sprites:
     - sprite: DeltaV/Mobs/Customization/Vulpkanin/hair.rsi
       state: short2
@@ -846,7 +846,7 @@
   id: VulpHairSpike
   bodyPart: Hair
   markingCategory: Hair
-  speciesRestriction: [Vulpkanin, SlimePerson, IPC] # FLOOF CHANGE IPCs get furry parts
+  speciesRestriction: [Vulpkanin, SlimePerson, IPC, Kitsune] # Floof - M3739 - TaskKitsunebi2 - Give Kitsune access to Vulp Markings
   sprites:
     - sprite: DeltaV/Mobs/Customization/Vulpkanin/hair.rsi
       state: spike
@@ -856,7 +856,7 @@
   id: VulpFacialHairRuff
   bodyPart: FacialHair
   markingCategory: FacialHair
-  speciesRestriction: [Vulpkanin, SlimePerson, IPC] # FLOOF CHANGE IPCs get furry parts
+  speciesRestriction: [Vulpkanin, SlimePerson, IPC, Kitsune] # Floof - M3739 - TaskKitsunebi2 - Give Kitsune access to Vulp Markings
   sprites:
     - sprite: DeltaV/Mobs/Customization/Vulpkanin/facial_hair.rsi
       state: ruff
@@ -865,7 +865,7 @@
   id: VulpFacialHairElder
   bodyPart: FacialHair
   markingCategory: FacialHair
-  speciesRestriction: [Vulpkanin, SlimePerson, IPC] # FLOOF CHANGE IPCs get furry parts
+  speciesRestriction: [Vulpkanin, SlimePerson, IPC, Kitsune] # Floof - M3739 - TaskKitsunebi2 - Give Kitsune access to Vulp Markings
   sprites:
     - sprite: DeltaV/Mobs/Customization/Vulpkanin/facial_hair.rsi
       state: elder
@@ -874,7 +874,7 @@
   id: VulpFacialHairElderChin
   bodyPart: FacialHair
   markingCategory: FacialHair
-  speciesRestriction: [Vulpkanin, SlimePerson, IPC] # FLOOF CHANGE IPCs get furry parts
+  speciesRestriction: [Vulpkanin, SlimePerson, IPC, Kitsune] # Floof - M3739 - TaskKitsunebi2 - Give Kitsune access to Vulp Markings
   sprites:
     - sprite: DeltaV/Mobs/Customization/Vulpkanin/facial_hair.rsi
       state: elder_chin
@@ -883,7 +883,7 @@
   id: VulpFacialHairKita
   bodyPart: FacialHair
   markingCategory: FacialHair
-  speciesRestriction: [Vulpkanin, SlimePerson, IPC] # FLOOF CHANGE IPCs get furry parts
+  speciesRestriction: [Vulpkanin, SlimePerson, IPC, Kitsune] # Floof - M3739 - TaskKitsunebi2 - Give Kitsune access to Vulp Markings
   sprites:
     - sprite: DeltaV/Mobs/Customization/Vulpkanin/facial_hair.rsi
       state: kita

--- a/Resources/Prototypes/DeltaV/Entities/Mobs/Customization/Markings/vulpkanin.yml
+++ b/Resources/Prototypes/DeltaV/Entities/Mobs/Customization/Markings/vulpkanin.yml
@@ -5,7 +5,7 @@
   id: VulpEar
   bodyPart: HeadTop
   markingCategory: HeadTop
-  speciesRestriction: [Vulpkanin, Human, SlimePerson, IPC, Oni, Harpy, Arachne, Rodentia, Kitsune] # Floof - M3739 - #1062 - Give Kitsune access to Vulp Markings
+  speciesRestriction: [Vulpkanin, Human, SlimePerson, IPC, Oni, Harpy, Arachne, Rodentia, Kitsune]
   sprites:
     - sprite: DeltaV/Mobs/Customization/Vulpkanin/ear_markings.rsi
       state: vulp
@@ -16,7 +16,7 @@
   id: VulpEarFade
   bodyPart: HeadTop
   markingCategory: HeadTop
-  speciesRestriction: [Vulpkanin, Human, SlimePerson, IPC, Oni, Harpy, Arachne, Rodentia, Kitsune] # Floof - M3739 - #1062 - Give Kitsune access to Vulp Markings
+  speciesRestriction: [Vulpkanin, Human, SlimePerson, IPC, Oni, Harpy, Arachne, Rodentia, Kitsune]
   sprites:
     - sprite: DeltaV/Mobs/Customization/Vulpkanin/ear_markings.rsi
       state: vulp
@@ -27,7 +27,7 @@
   id: VulpEarSharp
   bodyPart: HeadTop
   markingCategory: HeadTop
-  speciesRestriction: [Vulpkanin, Human, SlimePerson, IPC, Oni, Harpy, Arachne, Rodentia, Kitsune] # Floof - M3739 - #1062 - Give Kitsune access to Vulp Markings
+  speciesRestriction: [Vulpkanin, Human, SlimePerson, IPC, Oni, Harpy, Arachne, Rodentia, Kitsune]
   sprites:
     - sprite: DeltaV/Mobs/Customization/Vulpkanin/ear_markings.rsi
       state: vulp
@@ -38,7 +38,7 @@
   id: VulpEarJackal
   bodyPart: HeadTop
   markingCategory: HeadTop
-  speciesRestriction: [Vulpkanin, Human, SlimePerson, IPC, Oni, Harpy, Arachne, Rodentia, Kitsune] # Floof - M3739 - #1062 - Give Kitsune access to Vulp Markings
+  speciesRestriction: [Vulpkanin, Human, SlimePerson, IPC, Oni, Harpy, Arachne, Rodentia, Kitsune]
   sprites:
     - sprite: DeltaV/Mobs/Customization/Vulpkanin/ear_markings.rsi
       state: jackal
@@ -49,7 +49,7 @@
   id: VulpEarTerrier
   bodyPart: HeadTop
   markingCategory: HeadTop
-  speciesRestriction: [Vulpkanin, Human, SlimePerson, IPC, Oni, Harpy, Arachne, Rodentia, Kitsune] # Floof - M3739 - #1062 - Give Kitsune access to Vulp Markings
+  speciesRestriction: [Vulpkanin, Human, SlimePerson, IPC, Oni, Harpy, Arachne, Rodentia, Kitsune]
   sprites:
     - sprite: DeltaV/Mobs/Customization/Vulpkanin/ear_markings.rsi
       state: terrier
@@ -60,7 +60,7 @@
   id: VulpEarWolf
   bodyPart: HeadTop
   markingCategory: HeadTop
-  speciesRestriction: [Vulpkanin, Human, SlimePerson, IPC, Oni, Harpy, Arachne, Rodentia, Kitsune] # Floof - M3739 - #1062 - Give Kitsune access to Vulp Markings
+  speciesRestriction: [Vulpkanin, Human, SlimePerson, IPC, Oni, Harpy, Arachne, Rodentia, Kitsune]
   sprites:
     - sprite: DeltaV/Mobs/Customization/Vulpkanin/ear_markings.rsi
       state: wolf
@@ -93,7 +93,7 @@
   id: VulpEarOtie
   bodyPart: HeadTop
   markingCategory: HeadTop
-  speciesRestriction: [Vulpkanin, Human, SlimePerson, IPC, Oni, Harpy, Arachne, Rodentia, Kitsune] # Floof - M3739 - #1062 - Give Kitsune access to Vulp Markings
+  speciesRestriction: [Vulpkanin, Human, SlimePerson, IPC, Oni, Harpy, Arachne, Rodentia, Kitsune]
   sprites:
     - sprite: DeltaV/Mobs/Customization/Vulpkanin/ear_markings.rsi
       state: otie
@@ -104,7 +104,7 @@
   id: VulpEarTajaran
   bodyPart: HeadTop
   markingCategory: HeadTop
-  speciesRestriction: [Vulpkanin, Human, SlimePerson, IPC, Oni, Harpy, Arachne, Rodentia, Kitsune] # Floof - M3739 - #1062 - Give Kitsune access to Vulp Markings
+  speciesRestriction: [Vulpkanin, Human, SlimePerson, IPC, Oni, Harpy, Arachne, Rodentia, Kitsune]
   sprites:
     - sprite: DeltaV/Mobs/Customization/Vulpkanin/ear_markings.rsi
       state: msai
@@ -115,7 +115,7 @@
   id: VulpEarShock
   bodyPart: HeadTop
   markingCategory: HeadTop
-  speciesRestriction: [Vulpkanin, Human, SlimePerson, IPC, Oni, Harpy, Arachne, Rodentia, Kitsune] # Floof - M3739 - #1062 - Give Kitsune access to Vulp Markings
+  speciesRestriction: [Vulpkanin, Human, SlimePerson, IPC, Oni, Harpy, Arachne, Rodentia, Kitsune]
   sprites:
     - sprite: DeltaV/Mobs/Customization/Vulpkanin/ear_markings.rsi
       state: shock
@@ -124,7 +124,7 @@
   id: VulpEarCoyote
   bodyPart: HeadTop
   markingCategory: HeadTop
-  speciesRestriction: [Vulpkanin, Human, SlimePerson, IPC, Oni, Harpy, Arachne, Rodentia, Kitsune] # Floof - M3739 - #1062 - Give Kitsune access to Vulp Markings
+  speciesRestriction: [Vulpkanin, Human, SlimePerson, IPC, Oni, Harpy, Arachne, Rodentia, Kitsune]
   sprites:
     - sprite: DeltaV/Mobs/Customization/Vulpkanin/ear_markings.rsi
       state: coyote
@@ -133,7 +133,7 @@
   id: VulpEarDalmatian
   bodyPart: HeadTop
   markingCategory: HeadTop
-  speciesRestriction: [Vulpkanin, Human, SlimePerson, IPC, Oni, Harpy, Arachne, Rodentia, Kitsune] # Floof - M3739 - #1062 - Give Kitsune access to Vulp Markings
+  speciesRestriction: [Vulpkanin, Human, SlimePerson, IPC, Oni, Harpy, Arachne, Rodentia, Kitsune]
   sprites:
     - sprite: DeltaV/Mobs/Customization/Vulpkanin/ear_markings.rsi
       state: dalmatian
@@ -143,7 +143,7 @@
   id: VulpSnoutAlt
   bodyPart: Snout
   markingCategory: Snout
-  speciesRestriction: [Vulpkanin, SlimePerson, IPC, Kitsune] # Floof - M3739 - #1062 - Give Kitsune access to Vulp Markings
+  speciesRestriction: [Vulpkanin, SlimePerson, IPC, Kitsune]
   sprites:
     - sprite: DeltaV/Mobs/Customization/Vulpkanin/head_markings.rsi
       state: muzzle_alt
@@ -154,7 +154,7 @@
   id: VulpSnout
   bodyPart: Snout
   markingCategory: Snout
-  speciesRestriction: [Vulpkanin, SlimePerson, IPC, Kitsune] # Floof - M3739 - #1062 - Give Kitsune access to Vulp Markings
+  speciesRestriction: [Vulpkanin, SlimePerson, IPC, Kitsune]
   sprites:
     - sprite: DeltaV/Mobs/Customization/Vulpkanin/head_markings.rsi
       state: muzzle
@@ -165,7 +165,7 @@
   id: VulpSnoutSharp
   bodyPart: Snout
   markingCategory: Snout
-  speciesRestriction: [Vulpkanin, SlimePerson, IPC, Kitsune] # Floof - M3739 - #1062 - Give Kitsune access to Vulp Markings
+  speciesRestriction: [Vulpkanin, SlimePerson, IPC, Kitsune]
   sprites:
     - sprite: DeltaV/Mobs/Customization/Vulpkanin/head_markings.rsi
       state: muzzle_sharp
@@ -176,7 +176,7 @@
   id: VulpSnoutFade
   bodyPart: Snout
   markingCategory: Snout
-  speciesRestriction: [Vulpkanin, SlimePerson, IPC, Kitsune] # Floof - M3739 - #1062 - Give Kitsune access to Vulp Markings
+  speciesRestriction: [Vulpkanin, SlimePerson, IPC, Kitsune]
   sprites:
     - sprite: DeltaV/Mobs/Customization/Vulpkanin/head_markings.rsi
       state: muzzle_fade
@@ -187,7 +187,7 @@
   id: VulpSnoutNose
   bodyPart: Snout
   markingCategory: Snout
-  speciesRestriction: [Vulpkanin, SlimePerson, IPC, Kitsune] # Floof - M3739 - #1062 - Give Kitsune access to Vulp Markings
+  speciesRestriction: [Vulpkanin, SlimePerson, IPC, Kitsune]
   sprites:
     - sprite: DeltaV/Mobs/Customization/Vulpkanin/head_markings.rsi
       state: nose
@@ -196,7 +196,7 @@
   id: VulpSnoutMask
   bodyPart: Snout
   markingCategory: Snout
-  speciesRestriction: [Vulpkanin, SlimePerson, IPC, Kitsune] # Floof - M3739 - #1062 - Give Kitsune access to Vulp Markings
+  speciesRestriction: [Vulpkanin, SlimePerson, IPC, Kitsune]
   sprites:
     - sprite: DeltaV/Mobs/Customization/Vulpkanin/head_markings.rsi
       state: mask
@@ -207,7 +207,7 @@
   id: VulpSnoutVulpine
   bodyPart: Snout
   markingCategory: Snout
-  speciesRestriction: [Vulpkanin, SlimePerson, IPC, Kitsune] # Floof - M3739 - #1062 - Give Kitsune access to Vulp Markings
+  speciesRestriction: [Vulpkanin, SlimePerson, IPC, Kitsune]
   sprites:
     - sprite: DeltaV/Mobs/Customization/Vulpkanin/head_markings.rsi
       state: vulpine
@@ -218,7 +218,7 @@
   id: VulpSnoutSwift
   bodyPart: Snout
   markingCategory: Snout
-  speciesRestriction: [Vulpkanin, SlimePerson, IPC, Kitsune] # Floof - M3739 - #1062 - Give Kitsune access to Vulp Markings
+  speciesRestriction: [Vulpkanin, SlimePerson, IPC, Kitsune]
   sprites:
     - sprite: DeltaV/Mobs/Customization/Vulpkanin/head_markings.rsi
       state: vulpine-lines
@@ -227,7 +227,7 @@
   id: VulpSnoutBlaze
   bodyPart: Snout
   markingCategory: Snout
-  speciesRestriction: [Vulpkanin, SlimePerson, IPC, Kitsune] # Floof - M3739 - #1062 - Give Kitsune access to Vulp Markings
+  speciesRestriction: [Vulpkanin, SlimePerson, IPC, Kitsune]
   sprites:
     - sprite: DeltaV/Mobs/Customization/Vulpkanin/head_markings.rsi
       state: blaze
@@ -236,7 +236,7 @@
   id: VulpSnoutPatch
   bodyPart: Snout
   markingCategory: Snout
-  speciesRestriction: [Vulpkanin, SlimePerson, IPC, Kitsune] # Floof - M3739 - #1062 - Give Kitsune access to Vulp Markings
+  speciesRestriction: [Vulpkanin, SlimePerson, IPC, Kitsune]
   sprites:
     - sprite: DeltaV/Mobs/Customization/Vulpkanin/head_markings.rsi
       state: patch
@@ -246,7 +246,7 @@
   id: VulpHeadTiger
   bodyPart: Head
   markingCategory: Head
-  speciesRestriction: [Vulpkanin, SlimePerson, IPC, Kitsune] # Floof - M3739 - #1062 - Give Kitsune access to Vulp Markings
+  speciesRestriction: [Vulpkanin, SlimePerson, IPC, Kitsune]
   sprites:
     - sprite: DeltaV/Mobs/Customization/Vulpkanin/head_markings.rsi
       state: tiger_head
@@ -255,7 +255,7 @@
   id: VulpHeadTigerFace
   bodyPart: Head
   markingCategory: Head
-  speciesRestriction: [Vulpkanin, SlimePerson, IPC, Kitsune] # Floof - M3739 - #1062 - Give Kitsune access to Vulp Markings
+  speciesRestriction: [Vulpkanin, SlimePerson, IPC, Kitsune]
   sprites:
     - sprite: DeltaV/Mobs/Customization/Vulpkanin/head_markings.rsi
       state: tiger_face
@@ -264,7 +264,7 @@
   id: VulpHeadSlash
   bodyPart: Head
   markingCategory: Head
-  speciesRestriction: [Vulpkanin, SlimePerson, IPC, Kitsune] # Floof - M3739 - #1062 - Give Kitsune access to Vulp Markings
+  speciesRestriction: [Vulpkanin, SlimePerson, IPC, Kitsune]
   sprites:
     - sprite: DeltaV/Mobs/Customization/Vulpkanin/head_markings.rsi
       state: slash
@@ -318,7 +318,7 @@
   id: VulpTailAlt
   bodyPart: Tail
   markingCategory: Tail
-  speciesRestriction: [Vulpkanin, Human, SlimePerson, IPC, Oni, Felinid, Rodentia, Kitsune] # Floof - M3739 - #1062 - Give Kitsune access to Vulp Markings
+  speciesRestriction: [Vulpkanin, Human, SlimePerson, IPC, Oni, Felinid, Rodentia, Kitsune]
   sprites:
     - sprite: DeltaV/Mobs/Customization/Vulpkanin/tail_markings.rsi
       state: vulp_alt
@@ -329,7 +329,7 @@
   id: VulpTailAltTip
   bodyPart: Tail
   markingCategory: Tail
-  speciesRestriction: [Vulpkanin, Human, SlimePerson, IPC, Oni, Felinid, Rodentia, Kitsune] # Floof - M3739 - #1062 - Give Kitsune access to Vulp Markings
+  speciesRestriction: [Vulpkanin, Human, SlimePerson, IPC, Oni, Felinid, Rodentia, Kitsune]
   sprites:
     - sprite: DeltaV/Mobs/Customization/Vulpkanin/tail_markings.rsi
       state: vulp_alt
@@ -340,7 +340,7 @@
   id: VulpTailLong
   bodyPart: Tail
   markingCategory: Tail
-  speciesRestriction: [Vulpkanin, Human, SlimePerson, IPC, Oni, Felinid, Rodentia, Kitsune] # Floof - M3739 - #1062 - Give Kitsune access to Vulp Markings
+  speciesRestriction: [Vulpkanin, Human, SlimePerson, IPC, Oni, Felinid, Rodentia, Kitsune]
   sprites:
     - sprite: DeltaV/Mobs/Customization/Vulpkanin/tail_markings.rsi
       state: long
@@ -395,7 +395,7 @@
   id: VulpTailBushy
   bodyPart: Tail
   markingCategory: Tail
-  speciesRestriction: [Vulpkanin, Human, SlimePerson, IPC, Oni, Felinid, Rodentia, Kitsune] # Floof - M3739 - #1062 - Give Kitsune access to Vulp Markings
+  speciesRestriction: [Vulpkanin, Human, SlimePerson, IPC, Oni, Felinid, Rodentia, Kitsune]
   sprites:
     - sprite: DeltaV/Mobs/Customization/Vulpkanin/tail_markings.rsi
       state: bushfluff
@@ -413,7 +413,7 @@
   id: VulpTailCoyote
   bodyPart: Tail
   markingCategory: Tail
-  speciesRestriction: [Vulpkanin, Human, SlimePerson, IPC, Oni, Felinid, Rodentia, Kitsune] # Floof - M3739 - #1062 - Give Kitsune access to Vulp Markings
+  speciesRestriction: [Vulpkanin, Human, SlimePerson, IPC, Oni, Felinid, Rodentia, Kitsune]
   sprites:
     - sprite: DeltaV/Mobs/Customization/Vulpkanin/tail_markings.rsi
       state: coyote
@@ -431,7 +431,7 @@
   id: VulpTailCorgi
   bodyPart: Tail
   markingCategory: Tail
-  speciesRestriction: [Vulpkanin, Human, SlimePerson, IPC, Oni, Felinid, Rodentia, Kitsune] # Floof - M3739 - #1062 - Give Kitsune access to Vulp Markings
+  speciesRestriction: [Vulpkanin, Human, SlimePerson, IPC, Oni, Felinid, Rodentia, Kitsune]
   sprites:
     - sprite: DeltaV/Mobs/Customization/Vulpkanin/tail_markings.rsi
       state: corgi
@@ -449,7 +449,7 @@
   id: VulpTailHusky
   bodyPart: Tail
   markingCategory: Tail
-  speciesRestriction: [Vulpkanin, Human, SlimePerson, IPC, Oni, Felinid, Rodentia, Kitsune] # Floof - M3739 - #1062 - Give Kitsune access to Vulp Markings
+  speciesRestriction: [Vulpkanin, Human, SlimePerson, IPC, Oni, Felinid, Rodentia, Kitsune]
   sprites:
     - sprite: DeltaV/Mobs/Customization/Vulpkanin/tail_markings.rsi
       state: husky-inner
@@ -460,7 +460,7 @@
   id: VulpTailHuskyAlt
   bodyPart: Tail
   markingCategory: Tail
-  speciesRestriction: [Vulpkanin, Human, SlimePerson, IPC, Oni, Felinid, Rodentia, Kitsune] # Floof - M3739 - #1062 - Give Kitsune access to Vulp Markings
+  speciesRestriction: [Vulpkanin, Human, SlimePerson, IPC, Oni, Felinid, Rodentia, Kitsune]
   sprites:
     - sprite: DeltaV/Mobs/Customization/Vulpkanin/tail_markings.rsi
       state: husky
@@ -498,7 +498,7 @@
   id: VulpTailOtie
   bodyPart: Tail
   markingCategory: Tail
-  speciesRestriction: [Vulpkanin, Human, SlimePerson, IPC, Oni, Felinid, Rodentia, Kitsune] # Floof - M3739 - #1062 - Give Kitsune access to Vulp Markings
+  speciesRestriction: [Vulpkanin, Human, SlimePerson, IPC, Oni, Felinid, Rodentia, Kitsune]
   sprites:
     - sprite: DeltaV/Mobs/Customization/Vulpkanin/tail_markings.rsi
       state: otie
@@ -507,7 +507,7 @@
   id: VulpTailFluffy
   bodyPart: Tail
   markingCategory: Tail
-  speciesRestriction: [Vulpkanin, Human, SlimePerson, IPC, Oni, Felinid, Rodentia, Kitsune] # Floof - M3739 - #1062 - Give Kitsune access to Vulp Markings
+  speciesRestriction: [Vulpkanin, Human, SlimePerson, IPC, Oni, Felinid, Rodentia, Kitsune]
   sprites:
     - sprite: DeltaV/Mobs/Customization/Vulpkanin/tail_markings.rsi
       state: fluffy
@@ -516,7 +516,7 @@
   id: VulpTailDalmatian
   bodyPart: Tail
   markingCategory: Tail
-  speciesRestriction: [Vulpkanin, Human, SlimePerson, IPC, Oni, Felinid, Rodentia, Kitsune] # Floof - M3739 - #1062 - Give Kitsune access to Vulp Markings
+  speciesRestriction: [Vulpkanin, Human, SlimePerson, IPC, Oni, Felinid, Rodentia, Kitsune]
   sprites:
     - sprite: DeltaV/Mobs/Customization/Vulpkanin/tail_markings.rsi
       state: dalmatian
@@ -535,7 +535,7 @@
   id: VulpBellyCrest
   bodyPart: Chest
   markingCategory: Chest
-  speciesRestriction: [Vulpkanin, SlimePerson, IPC, Human, Kitsune] # Floof - M3739 - #1062 - Give Kitsune access to Vulp Markings
+  speciesRestriction: [Vulpkanin, SlimePerson, IPC, Human, Kitsune]
   sprites:
     - sprite: DeltaV/Mobs/Customization/Vulpkanin/body_markings.rsi
       state: belly_crest
@@ -544,7 +544,7 @@
   id: VulpBellyFull
   bodyPart: Chest
   markingCategory: Chest
-  speciesRestriction: [Vulpkanin, SlimePerson, IPC, Human, Kitsune] # Floof - M3739 - #1062 - Give Kitsune access to Vulp Markings
+  speciesRestriction: [Vulpkanin, SlimePerson, IPC, Human, Kitsune]
   sprites:
     - sprite: DeltaV/Mobs/Customization/Vulpkanin/body_markings.rsi
       state: belly_full
@@ -553,7 +553,7 @@
   id: VulpBellyFox
   bodyPart: Chest
   markingCategory: Chest
-  speciesRestriction: [Vulpkanin, SlimePerson, IPC, Human, Kitsune] # Floof - M3739 - #1062 - Give Kitsune access to Vulp Markings
+  speciesRestriction: [Vulpkanin, SlimePerson, IPC, Human, Kitsune]
   sprites:
     - sprite: DeltaV/Mobs/Customization/Vulpkanin/body_markings.rsi
       state: belly_fox
@@ -564,7 +564,7 @@
 #   id: VulpBodyPointsCrest
 #   markingCategory: Overlay
 #   bodyPart: RFoot
-#   speciesRestriction: [Vulpkanin, SlimePerson, IPC, Kitsune] # Floof - M3739 - #1062 - Give Kitsune access to Vulp Markings
+#   speciesRestriction: [Vulpkanin, SlimePerson, IPC, Kitsune]
 #   sprites:
 #     - sprite: DeltaV/Mobs/Customization/Vulpkanin/body_markings.rsi
 #       state: points_crest
@@ -573,7 +573,7 @@
 #   id: VulpBodyPointsFade
 #   markingCategory: Overlay
 #   bodyPart: RFoot
-#   speciesRestriction: [Vulpkanin, SlimePerson, IPC, Kitsune] # Floof - M3739 - #1062 - Give Kitsune access to Vulp Markings
+#   speciesRestriction: [Vulpkanin, SlimePerson, IPC, Kitsune]
 #   sprites:
 #     - sprite: DeltaV/Mobs/Customization/Vulpkanin/body_markings.rsi
 #       state: points_fade
@@ -582,7 +582,7 @@
 #   id: VulpBodyPointsSharp
 #   markingCategory: Overlay
 #   bodyPart: RFoot
-#   speciesRestriction: [Vulpkanin, SlimePerson, IPC, Kitsune] # Floof - M3739 - #1062 - Give Kitsune access to Vulp Markings
+#   speciesRestriction: [Vulpkanin, SlimePerson, IPC, Kitsune]
 #   sprites:
 #     - sprite: DeltaV/Mobs/Customization/Vulpkanin/body_markings.rsi
 #       state: points_sharp
@@ -592,7 +592,7 @@
   id: VulpPointsFeet
   markingCategory: RightFoot
   bodyPart: RFoot
-  speciesRestriction: [Vulpkanin, SlimePerson, IPC, Kitsune] # Floof - M3739 - #1062 - Give Kitsune access to Vulp Markings
+  speciesRestriction: [Vulpkanin, SlimePerson, IPC, Kitsune]
   sprites:
     - sprite: DeltaV/Mobs/Customization/Vulpkanin/body_markings.rsi
       state: points_feet
@@ -601,7 +601,7 @@
   id: VulpPointsCrestLegs
   markingCategory: LeftLeg
   bodyPart: LLeg
-  speciesRestriction: [Vulpkanin, SlimePerson, IPC, Kitsune] # Floof - M3739 - #1062 - Give Kitsune access to Vulp Markings
+  speciesRestriction: [Vulpkanin, SlimePerson, IPC, Kitsune]
   sprites:
     - sprite: DeltaV/Mobs/Customization/Vulpkanin/body_markings.rsi
       state: points_crest-legs
@@ -610,7 +610,7 @@
   id: VulpPointsFadeLegs
   markingCategory: LeftLeg
   bodyPart: LLeg
-  speciesRestriction: [Vulpkanin, SlimePerson, IPC, Kitsune] # Floof - M3739 - #1062 - Give Kitsune access to Vulp Markings
+  speciesRestriction: [Vulpkanin, SlimePerson, IPC, Kitsune]
   sprites:
     - sprite: DeltaV/Mobs/Customization/Vulpkanin/body_markings.rsi
       state: points_fade-legs
@@ -619,7 +619,7 @@
   id: VulpPointsSharpLegs
   markingCategory: LeftLeg
   bodyPart: LLeg
-  speciesRestriction: [Vulpkanin, SlimePerson, IPC, Kitsune] # Floof - M3739 - #1062 - Give Kitsune access to Vulp Markings
+  speciesRestriction: [Vulpkanin, SlimePerson, IPC, Kitsune]
   sprites:
     - sprite: DeltaV/Mobs/Customization/Vulpkanin/body_markings.rsi
       state: points_sharp-legs
@@ -629,7 +629,7 @@
   id: VulpPointsHands
   markingCategory: RightHand
   bodyPart: RHand
-  speciesRestriction: [Vulpkanin, SlimePerson, IPC, Kitsune] # Floof - M3739 - #1062 - Give Kitsune access to Vulp Markings
+  speciesRestriction: [Vulpkanin, SlimePerson, IPC, Kitsune]
   sprites:
     - sprite: DeltaV/Mobs/Customization/Vulpkanin/body_markings.rsi
       state: points_hands
@@ -638,7 +638,7 @@
   id: VulpPointsCrestArms
   markingCategory: LeftArm
   bodyPart: LArm
-  speciesRestriction: [Vulpkanin, SlimePerson, IPC, Kitsune] # Floof - M3739 - #1062 - Give Kitsune access to Vulp Markings
+  speciesRestriction: [Vulpkanin, SlimePerson, IPC, Kitsune]
   sprites:
     - sprite: DeltaV/Mobs/Customization/Vulpkanin/body_markings.rsi
       state: points_crest-arms
@@ -647,7 +647,7 @@
   id: VulpPointsFadeArms
   markingCategory: LeftArm
   bodyPart: LArm
-  speciesRestriction: [Vulpkanin, SlimePerson, IPC, Kitsune] # Floof - M3739 - #1062 - Give Kitsune access to Vulp Markings
+  speciesRestriction: [Vulpkanin, SlimePerson, IPC, Kitsune]
   sprites:
     - sprite: DeltaV/Mobs/Customization/Vulpkanin/body_markings.rsi
       state: points_fade-arms
@@ -656,7 +656,7 @@
   id: VulpPointsSharpArms
   markingCategory: LeftArm
   bodyPart: LArm
-  speciesRestriction: [Vulpkanin, SlimePerson, IPC, Kitsune] # Floof - M3739 - #1062 - Give Kitsune access to Vulp Markings
+  speciesRestriction: [Vulpkanin, SlimePerson, IPC, Kitsune]
   sprites:
     - sprite: DeltaV/Mobs/Customization/Vulpkanin/body_markings.rsi
       state: points_sharp-arms
@@ -665,7 +665,7 @@
 - type: marking
   id: VulpHairAdhara
   bodyPart: Hair
-  speciesRestriction: [Vulpkanin, SlimePerson, IPC, Kitsune] # Floof - M3739 - #1062 - Give Kitsune access to Vulp Markings
+  speciesRestriction: [Vulpkanin, SlimePerson, IPC, Kitsune]
   markingCategory: Hair
   sprites:
     - sprite: DeltaV/Mobs/Customization/Vulpkanin/hair.rsi
@@ -674,7 +674,7 @@
 - type: marking
   id: VulpHairAnita
   bodyPart: Hair
-  speciesRestriction: [Vulpkanin, SlimePerson, IPC, Kitsune] # Floof - M3739 - #1062 - Give Kitsune access to Vulp Markings
+  speciesRestriction: [Vulpkanin, SlimePerson, IPC, Kitsune]
   markingCategory: Hair
   sprites:
     - sprite: DeltaV/Mobs/Customization/Vulpkanin/hair.rsi
@@ -683,7 +683,7 @@
 - type: marking
   id: VulpHairApollo
   bodyPart: Hair
-  speciesRestriction: [Vulpkanin, SlimePerson, IPC, Kitsune] # Floof - M3739 - #1062 - Give Kitsune access to Vulp Markings
+  speciesRestriction: [Vulpkanin, SlimePerson, IPC, Kitsune]
   markingCategory: Hair
   sprites:
     - sprite: DeltaV/Mobs/Customization/Vulpkanin/hair.rsi
@@ -692,7 +692,7 @@
 - type: marking
   id: VulpHairBelle
   bodyPart: Hair
-  speciesRestriction: [Vulpkanin, SlimePerson, IPC, Kitsune] # Floof - M3739 - #1062 - Give Kitsune access to Vulp Markings
+  speciesRestriction: [Vulpkanin, SlimePerson, IPC, Kitsune]
   markingCategory: Hair
   sprites:
     - sprite: DeltaV/Mobs/Customization/Vulpkanin/hair.rsi
@@ -702,7 +702,7 @@
   id: VulpHairBraided
   bodyPart: Hair
   markingCategory: Hair
-  speciesRestriction: [Vulpkanin, SlimePerson, IPC, Kitsune] # Floof - M3739 - #1062 - Give Kitsune access to Vulp Markings
+  speciesRestriction: [Vulpkanin, SlimePerson, IPC, Kitsune]
   sprites:
     - sprite: DeltaV/Mobs/Customization/Vulpkanin/hair.rsi
       state: braided
@@ -711,7 +711,7 @@
   id: VulpHairBun
   bodyPart: Hair
   markingCategory: Hair
-  speciesRestriction: [Vulpkanin, SlimePerson, IPC, Kitsune] # Floof - M3739 - #1062 - Give Kitsune access to Vulp Markings
+  speciesRestriction: [Vulpkanin, SlimePerson, IPC, Kitsune]
   sprites:
     - sprite: DeltaV/Mobs/Customization/Vulpkanin/hair.rsi
       state: bun
@@ -720,7 +720,7 @@
   id: VulpHairCleanCut
   bodyPart: Hair
   markingCategory: Hair
-  speciesRestriction: [Vulpkanin, SlimePerson, IPC, Kitsune] # Floof - M3739 - #1062 - Give Kitsune access to Vulp Markings
+  speciesRestriction: [Vulpkanin, SlimePerson, IPC, Kitsune]
   sprites:
     - sprite: DeltaV/Mobs/Customization/Vulpkanin/hair.rsi
       state: clean_cut
@@ -729,7 +729,7 @@
   id: VulpHairCurl
   bodyPart: Hair
   markingCategory: Hair
-  speciesRestriction: [Vulpkanin, SlimePerson, IPC, Kitsune] # Floof - M3739 - #1062 - Give Kitsune access to Vulp Markings
+  speciesRestriction: [Vulpkanin, SlimePerson, IPC, Kitsune]
   sprites:
     - sprite: DeltaV/Mobs/Customization/Vulpkanin/hair.rsi
       state: curl
@@ -738,7 +738,7 @@
   id: VulpHairHawk
   bodyPart: Hair
   markingCategory: Hair
-  speciesRestriction: [Vulpkanin, SlimePerson, IPC, Kitsune] # Floof - M3739 - #1062 - Give Kitsune access to Vulp Markings
+  speciesRestriction: [Vulpkanin, SlimePerson, IPC, Kitsune]
   sprites:
     - sprite: DeltaV/Mobs/Customization/Vulpkanin/hair.rsi
       state: hawk
@@ -747,7 +747,7 @@
   id: VulpHairJagged
   bodyPart: Hair
   markingCategory: Hair
-  speciesRestriction: [Vulpkanin, SlimePerson, IPC, Kitsune] # Floof - M3739 - #1062 - Give Kitsune access to Vulp Markings
+  speciesRestriction: [Vulpkanin, SlimePerson, IPC, Kitsune]
   sprites:
     - sprite: DeltaV/Mobs/Customization/Vulpkanin/hair.rsi
       state: jagged
@@ -756,7 +756,7 @@
   id: VulpHairJeremy
   bodyPart: Hair
   markingCategory: Hair
-  speciesRestriction: [Vulpkanin, SlimePerson, IPC, Kitsune] # Floof - M3739 - #1062 - Give Kitsune access to Vulp Markings
+  speciesRestriction: [Vulpkanin, SlimePerson, IPC, Kitsune]
   sprites:
     - sprite: DeltaV/Mobs/Customization/Vulpkanin/hair.rsi
       state: jeremy
@@ -765,7 +765,7 @@
   id: VulpHairKajam
   bodyPart: Hair
   markingCategory: Hair
-  speciesRestriction: [Vulpkanin, SlimePerson, IPC, Kitsune] # Floof - M3739 - #1062 - Give Kitsune access to Vulp Markings
+  speciesRestriction: [Vulpkanin, SlimePerson, IPC, Kitsune]
   sprites:
     - sprite: DeltaV/Mobs/Customization/Vulpkanin/hair.rsi
       state: kajam
@@ -774,7 +774,7 @@
   id: VulpHairKeid
   bodyPart: Hair
   markingCategory: Hair
-  speciesRestriction: [Vulpkanin, SlimePerson, IPC, Kitsune] # Floof - M3739 - #1062 - Give Kitsune access to Vulp Markings
+  speciesRestriction: [Vulpkanin, SlimePerson, IPC, Kitsune]
   sprites:
     - sprite: DeltaV/Mobs/Customization/Vulpkanin/hair.rsi
       state: keid
@@ -783,7 +783,7 @@
   id: VulpHairKleeia
   bodyPart: Hair
   markingCategory: Hair
-  speciesRestriction: [Vulpkanin, SlimePerson, IPC, Kitsune] # Floof - M3739 - #1062 - Give Kitsune access to Vulp Markings
+  speciesRestriction: [Vulpkanin, SlimePerson, IPC, Kitsune]
   sprites:
     - sprite: DeltaV/Mobs/Customization/Vulpkanin/hair.rsi
       state: kleeia
@@ -792,7 +792,7 @@
   id: VulpHairMizar
   bodyPart: Hair
   markingCategory: Hair
-  speciesRestriction: [Vulpkanin, SlimePerson, IPC, Kitsune] # Floof - M3739 - #1062 - Give Kitsune access to Vulp Markings
+  speciesRestriction: [Vulpkanin, SlimePerson, IPC, Kitsune]
   sprites:
     - sprite: DeltaV/Mobs/Customization/Vulpkanin/hair.rsi
       state: mizar
@@ -801,7 +801,7 @@
   id: VulpHairPunkBraided
   bodyPart: Hair
   markingCategory: Hair
-  speciesRestriction: [Vulpkanin, SlimePerson, IPC, Kitsune] # Floof - M3739 - #1062 - Give Kitsune access to Vulp Markings
+  speciesRestriction: [Vulpkanin, SlimePerson, IPC, Kitsune]
   sprites:
     - sprite: DeltaV/Mobs/Customization/Vulpkanin/hair.rsi
       state: punkbraided
@@ -810,7 +810,7 @@
   id: VulpHairRaine
   bodyPart: Hair
   markingCategory: Hair
-  speciesRestriction: [Vulpkanin, SlimePerson, IPC, Kitsune] # Floof - M3739 - #1062 - Give Kitsune access to Vulp Markings
+  speciesRestriction: [Vulpkanin, SlimePerson, IPC, Kitsune]
   sprites:
     - sprite: DeltaV/Mobs/Customization/Vulpkanin/hair.rsi
       state: raine
@@ -819,7 +819,7 @@
   id: VulpHairRough
   bodyPart: Hair
   markingCategory: Hair
-  speciesRestriction: [Vulpkanin, SlimePerson, IPC, Kitsune] # Floof - M3739 - #1062 - Give Kitsune access to Vulp Markings
+  speciesRestriction: [Vulpkanin, SlimePerson, IPC, Kitsune]
   sprites:
     - sprite: DeltaV/Mobs/Customization/Vulpkanin/hair.rsi
       state: rough
@@ -828,7 +828,7 @@
   id: VulpHairShort
   bodyPart: Hair
   markingCategory: Hair
-  speciesRestriction: [Vulpkanin, SlimePerson, IPC, Kitsune] # Floof - M3739 - #1062 - Give Kitsune access to Vulp Markings
+  speciesRestriction: [Vulpkanin, SlimePerson, IPC, Kitsune]
   sprites:
     - sprite: DeltaV/Mobs/Customization/Vulpkanin/hair.rsi
       state: short
@@ -837,7 +837,7 @@
   id: VulpHairShort2
   bodyPart: Hair
   markingCategory: Hair
-  speciesRestriction: [Vulpkanin, SlimePerson, IPC, Kitsune] # Floof - M3739 - #1062 - Give Kitsune access to Vulp Markings
+  speciesRestriction: [Vulpkanin, SlimePerson, IPC, Kitsune]
   sprites:
     - sprite: DeltaV/Mobs/Customization/Vulpkanin/hair.rsi
       state: short2
@@ -846,7 +846,7 @@
   id: VulpHairSpike
   bodyPart: Hair
   markingCategory: Hair
-  speciesRestriction: [Vulpkanin, SlimePerson, IPC, Kitsune] # Floof - M3739 - #1062 - Give Kitsune access to Vulp Markings
+  speciesRestriction: [Vulpkanin, SlimePerson, IPC, Kitsune]
   sprites:
     - sprite: DeltaV/Mobs/Customization/Vulpkanin/hair.rsi
       state: spike
@@ -856,7 +856,7 @@
   id: VulpFacialHairRuff
   bodyPart: FacialHair
   markingCategory: FacialHair
-  speciesRestriction: [Vulpkanin, SlimePerson, IPC, Kitsune] # Floof - M3739 - #1062 - Give Kitsune access to Vulp Markings
+  speciesRestriction: [Vulpkanin, SlimePerson, IPC, Kitsune]
   sprites:
     - sprite: DeltaV/Mobs/Customization/Vulpkanin/facial_hair.rsi
       state: ruff
@@ -865,7 +865,7 @@
   id: VulpFacialHairElder
   bodyPart: FacialHair
   markingCategory: FacialHair
-  speciesRestriction: [Vulpkanin, SlimePerson, IPC, Kitsune] # Floof - M3739 - #1062 - Give Kitsune access to Vulp Markings
+  speciesRestriction: [Vulpkanin, SlimePerson, IPC, Kitsune]
   sprites:
     - sprite: DeltaV/Mobs/Customization/Vulpkanin/facial_hair.rsi
       state: elder
@@ -874,7 +874,7 @@
   id: VulpFacialHairElderChin
   bodyPart: FacialHair
   markingCategory: FacialHair
-  speciesRestriction: [Vulpkanin, SlimePerson, IPC, Kitsune] # Floof - M3739 - #1062 - Give Kitsune access to Vulp Markings
+  speciesRestriction: [Vulpkanin, SlimePerson, IPC, Kitsune]
   sprites:
     - sprite: DeltaV/Mobs/Customization/Vulpkanin/facial_hair.rsi
       state: elder_chin
@@ -883,7 +883,7 @@
   id: VulpFacialHairKita
   bodyPart: FacialHair
   markingCategory: FacialHair
-  speciesRestriction: [Vulpkanin, SlimePerson, IPC, Kitsune] # Floof - M3739 - #1062 - Give Kitsune access to Vulp Markings
+  speciesRestriction: [Vulpkanin, SlimePerson, IPC, Kitsune]
   sprites:
     - sprite: DeltaV/Mobs/Customization/Vulpkanin/facial_hair.rsi
       state: kita

--- a/Resources/Prototypes/DeltaV/Entities/Mobs/Customization/Markings/vulpkanin.yml
+++ b/Resources/Prototypes/DeltaV/Entities/Mobs/Customization/Markings/vulpkanin.yml
@@ -5,7 +5,7 @@
   id: VulpEar
   bodyPart: HeadTop
   markingCategory: HeadTop
-  speciesRestriction: [Vulpkanin, Human, SlimePerson, IPC, Oni, Harpy, Arachne, Rodentia, Kitsune] # Floof - M3739 - TaskKitsunebi2 - Give Kitsune access to Vulp Markings
+  speciesRestriction: [Vulpkanin, Human, SlimePerson, IPC, Oni, Harpy, Arachne, Rodentia, Kitsune] # Floof - M3739 - #1062 - Give Kitsune access to Vulp Markings
   sprites:
     - sprite: DeltaV/Mobs/Customization/Vulpkanin/ear_markings.rsi
       state: vulp
@@ -16,7 +16,7 @@
   id: VulpEarFade
   bodyPart: HeadTop
   markingCategory: HeadTop
-  speciesRestriction: [Vulpkanin, Human, SlimePerson, IPC, Oni, Harpy, Arachne, Rodentia, Kitsune] # Floof - M3739 - TaskKitsunebi2 - Give Kitsune access to Vulp Markings
+  speciesRestriction: [Vulpkanin, Human, SlimePerson, IPC, Oni, Harpy, Arachne, Rodentia, Kitsune] # Floof - M3739 - #1062 - Give Kitsune access to Vulp Markings
   sprites:
     - sprite: DeltaV/Mobs/Customization/Vulpkanin/ear_markings.rsi
       state: vulp
@@ -27,7 +27,7 @@
   id: VulpEarSharp
   bodyPart: HeadTop
   markingCategory: HeadTop
-  speciesRestriction: [Vulpkanin, Human, SlimePerson, IPC, Oni, Harpy, Arachne, Rodentia, Kitsune] # Floof - M3739 - TaskKitsunebi2 - Give Kitsune access to Vulp Markings
+  speciesRestriction: [Vulpkanin, Human, SlimePerson, IPC, Oni, Harpy, Arachne, Rodentia, Kitsune] # Floof - M3739 - #1062 - Give Kitsune access to Vulp Markings
   sprites:
     - sprite: DeltaV/Mobs/Customization/Vulpkanin/ear_markings.rsi
       state: vulp
@@ -38,7 +38,7 @@
   id: VulpEarJackal
   bodyPart: HeadTop
   markingCategory: HeadTop
-  speciesRestriction: [Vulpkanin, Human, SlimePerson, IPC, Oni, Harpy, Arachne, Rodentia, Kitsune] # Floof - M3739 - TaskKitsunebi2 - Give Kitsune access to Vulp Markings
+  speciesRestriction: [Vulpkanin, Human, SlimePerson, IPC, Oni, Harpy, Arachne, Rodentia, Kitsune] # Floof - M3739 - #1062 - Give Kitsune access to Vulp Markings
   sprites:
     - sprite: DeltaV/Mobs/Customization/Vulpkanin/ear_markings.rsi
       state: jackal
@@ -49,7 +49,7 @@
   id: VulpEarTerrier
   bodyPart: HeadTop
   markingCategory: HeadTop
-  speciesRestriction: [Vulpkanin, Human, SlimePerson, IPC, Oni, Harpy, Arachne, Rodentia, Kitsune] # Floof - M3739 - TaskKitsunebi2 - Give Kitsune access to Vulp Markings
+  speciesRestriction: [Vulpkanin, Human, SlimePerson, IPC, Oni, Harpy, Arachne, Rodentia, Kitsune] # Floof - M3739 - #1062 - Give Kitsune access to Vulp Markings
   sprites:
     - sprite: DeltaV/Mobs/Customization/Vulpkanin/ear_markings.rsi
       state: terrier
@@ -60,7 +60,7 @@
   id: VulpEarWolf
   bodyPart: HeadTop
   markingCategory: HeadTop
-  speciesRestriction: [Vulpkanin, Human, SlimePerson, IPC, Oni, Harpy, Arachne, Rodentia, Kitsune] # Floof - M3739 - TaskKitsunebi2 - Give Kitsune access to Vulp Markings
+  speciesRestriction: [Vulpkanin, Human, SlimePerson, IPC, Oni, Harpy, Arachne, Rodentia, Kitsune] # Floof - M3739 - #1062 - Give Kitsune access to Vulp Markings
   sprites:
     - sprite: DeltaV/Mobs/Customization/Vulpkanin/ear_markings.rsi
       state: wolf
@@ -93,7 +93,7 @@
   id: VulpEarOtie
   bodyPart: HeadTop
   markingCategory: HeadTop
-  speciesRestriction: [Vulpkanin, Human, SlimePerson, IPC, Oni, Harpy, Arachne, Rodentia, Kitsune] # Floof - M3739 - TaskKitsunebi2 - Give Kitsune access to Vulp Markings
+  speciesRestriction: [Vulpkanin, Human, SlimePerson, IPC, Oni, Harpy, Arachne, Rodentia, Kitsune] # Floof - M3739 - #1062 - Give Kitsune access to Vulp Markings
   sprites:
     - sprite: DeltaV/Mobs/Customization/Vulpkanin/ear_markings.rsi
       state: otie
@@ -104,7 +104,7 @@
   id: VulpEarTajaran
   bodyPart: HeadTop
   markingCategory: HeadTop
-  speciesRestriction: [Vulpkanin, Human, SlimePerson, IPC, Oni, Harpy, Arachne, Rodentia, Kitsune] # Floof - M3739 - TaskKitsunebi2 - Give Kitsune access to Vulp Markings
+  speciesRestriction: [Vulpkanin, Human, SlimePerson, IPC, Oni, Harpy, Arachne, Rodentia, Kitsune] # Floof - M3739 - #1062 - Give Kitsune access to Vulp Markings
   sprites:
     - sprite: DeltaV/Mobs/Customization/Vulpkanin/ear_markings.rsi
       state: msai
@@ -115,7 +115,7 @@
   id: VulpEarShock
   bodyPart: HeadTop
   markingCategory: HeadTop
-  speciesRestriction: [Vulpkanin, Human, SlimePerson, IPC, Oni, Harpy, Arachne, Rodentia, Kitsune] # Floof - M3739 - TaskKitsunebi2 - Give Kitsune access to Vulp Markings
+  speciesRestriction: [Vulpkanin, Human, SlimePerson, IPC, Oni, Harpy, Arachne, Rodentia, Kitsune] # Floof - M3739 - #1062 - Give Kitsune access to Vulp Markings
   sprites:
     - sprite: DeltaV/Mobs/Customization/Vulpkanin/ear_markings.rsi
       state: shock
@@ -124,7 +124,7 @@
   id: VulpEarCoyote
   bodyPart: HeadTop
   markingCategory: HeadTop
-  speciesRestriction: [Vulpkanin, Human, SlimePerson, IPC, Oni, Harpy, Arachne, Rodentia, Kitsune] # Floof - M3739 - TaskKitsunebi2 - Give Kitsune access to Vulp Markings
+  speciesRestriction: [Vulpkanin, Human, SlimePerson, IPC, Oni, Harpy, Arachne, Rodentia, Kitsune] # Floof - M3739 - #1062 - Give Kitsune access to Vulp Markings
   sprites:
     - sprite: DeltaV/Mobs/Customization/Vulpkanin/ear_markings.rsi
       state: coyote
@@ -133,7 +133,7 @@
   id: VulpEarDalmatian
   bodyPart: HeadTop
   markingCategory: HeadTop
-  speciesRestriction: [Vulpkanin, Human, SlimePerson, IPC, Oni, Harpy, Arachne, Rodentia, Kitsune] # Floof - M3739 - TaskKitsunebi2 - Give Kitsune access to Vulp Markings
+  speciesRestriction: [Vulpkanin, Human, SlimePerson, IPC, Oni, Harpy, Arachne, Rodentia, Kitsune] # Floof - M3739 - #1062 - Give Kitsune access to Vulp Markings
   sprites:
     - sprite: DeltaV/Mobs/Customization/Vulpkanin/ear_markings.rsi
       state: dalmatian
@@ -143,7 +143,7 @@
   id: VulpSnoutAlt
   bodyPart: Snout
   markingCategory: Snout
-  speciesRestriction: [Vulpkanin, SlimePerson, IPC, Kitsune] # Floof - M3739 - TaskKitsunebi2 - Give Kitsune access to Vulp Markings
+  speciesRestriction: [Vulpkanin, SlimePerson, IPC, Kitsune] # Floof - M3739 - #1062 - Give Kitsune access to Vulp Markings
   sprites:
     - sprite: DeltaV/Mobs/Customization/Vulpkanin/head_markings.rsi
       state: muzzle_alt
@@ -154,7 +154,7 @@
   id: VulpSnout
   bodyPart: Snout
   markingCategory: Snout
-  speciesRestriction: [Vulpkanin, SlimePerson, IPC, Kitsune] # Floof - M3739 - TaskKitsunebi2 - Give Kitsune access to Vulp Markings
+  speciesRestriction: [Vulpkanin, SlimePerson, IPC, Kitsune] # Floof - M3739 - #1062 - Give Kitsune access to Vulp Markings
   sprites:
     - sprite: DeltaV/Mobs/Customization/Vulpkanin/head_markings.rsi
       state: muzzle
@@ -165,7 +165,7 @@
   id: VulpSnoutSharp
   bodyPart: Snout
   markingCategory: Snout
-  speciesRestriction: [Vulpkanin, SlimePerson, IPC, Kitsune] # Floof - M3739 - TaskKitsunebi2 - Give Kitsune access to Vulp Markings
+  speciesRestriction: [Vulpkanin, SlimePerson, IPC, Kitsune] # Floof - M3739 - #1062 - Give Kitsune access to Vulp Markings
   sprites:
     - sprite: DeltaV/Mobs/Customization/Vulpkanin/head_markings.rsi
       state: muzzle_sharp
@@ -176,7 +176,7 @@
   id: VulpSnoutFade
   bodyPart: Snout
   markingCategory: Snout
-  speciesRestriction: [Vulpkanin, SlimePerson, IPC, Kitsune] # Floof - M3739 - TaskKitsunebi2 - Give Kitsune access to Vulp Markings
+  speciesRestriction: [Vulpkanin, SlimePerson, IPC, Kitsune] # Floof - M3739 - #1062 - Give Kitsune access to Vulp Markings
   sprites:
     - sprite: DeltaV/Mobs/Customization/Vulpkanin/head_markings.rsi
       state: muzzle_fade
@@ -187,7 +187,7 @@
   id: VulpSnoutNose
   bodyPart: Snout
   markingCategory: Snout
-  speciesRestriction: [Vulpkanin, SlimePerson, IPC, Kitsune] # Floof - M3739 - TaskKitsunebi2 - Give Kitsune access to Vulp Markings
+  speciesRestriction: [Vulpkanin, SlimePerson, IPC, Kitsune] # Floof - M3739 - #1062 - Give Kitsune access to Vulp Markings
   sprites:
     - sprite: DeltaV/Mobs/Customization/Vulpkanin/head_markings.rsi
       state: nose
@@ -196,7 +196,7 @@
   id: VulpSnoutMask
   bodyPart: Snout
   markingCategory: Snout
-  speciesRestriction: [Vulpkanin, SlimePerson, IPC, Kitsune] # Floof - M3739 - TaskKitsunebi2 - Give Kitsune access to Vulp Markings
+  speciesRestriction: [Vulpkanin, SlimePerson, IPC, Kitsune] # Floof - M3739 - #1062 - Give Kitsune access to Vulp Markings
   sprites:
     - sprite: DeltaV/Mobs/Customization/Vulpkanin/head_markings.rsi
       state: mask
@@ -207,7 +207,7 @@
   id: VulpSnoutVulpine
   bodyPart: Snout
   markingCategory: Snout
-  speciesRestriction: [Vulpkanin, SlimePerson, IPC, Kitsune] # Floof - M3739 - TaskKitsunebi2 - Give Kitsune access to Vulp Markings
+  speciesRestriction: [Vulpkanin, SlimePerson, IPC, Kitsune] # Floof - M3739 - #1062 - Give Kitsune access to Vulp Markings
   sprites:
     - sprite: DeltaV/Mobs/Customization/Vulpkanin/head_markings.rsi
       state: vulpine
@@ -218,7 +218,7 @@
   id: VulpSnoutSwift
   bodyPart: Snout
   markingCategory: Snout
-  speciesRestriction: [Vulpkanin, SlimePerson, IPC, Kitsune] # Floof - M3739 - TaskKitsunebi2 - Give Kitsune access to Vulp Markings
+  speciesRestriction: [Vulpkanin, SlimePerson, IPC, Kitsune] # Floof - M3739 - #1062 - Give Kitsune access to Vulp Markings
   sprites:
     - sprite: DeltaV/Mobs/Customization/Vulpkanin/head_markings.rsi
       state: vulpine-lines
@@ -227,7 +227,7 @@
   id: VulpSnoutBlaze
   bodyPart: Snout
   markingCategory: Snout
-  speciesRestriction: [Vulpkanin, SlimePerson, IPC, Kitsune] # Floof - M3739 - TaskKitsunebi2 - Give Kitsune access to Vulp Markings
+  speciesRestriction: [Vulpkanin, SlimePerson, IPC, Kitsune] # Floof - M3739 - #1062 - Give Kitsune access to Vulp Markings
   sprites:
     - sprite: DeltaV/Mobs/Customization/Vulpkanin/head_markings.rsi
       state: blaze
@@ -236,7 +236,7 @@
   id: VulpSnoutPatch
   bodyPart: Snout
   markingCategory: Snout
-  speciesRestriction: [Vulpkanin, SlimePerson, IPC, Kitsune] # Floof - M3739 - TaskKitsunebi2 - Give Kitsune access to Vulp Markings
+  speciesRestriction: [Vulpkanin, SlimePerson, IPC, Kitsune] # Floof - M3739 - #1062 - Give Kitsune access to Vulp Markings
   sprites:
     - sprite: DeltaV/Mobs/Customization/Vulpkanin/head_markings.rsi
       state: patch
@@ -246,7 +246,7 @@
   id: VulpHeadTiger
   bodyPart: Head
   markingCategory: Head
-  speciesRestriction: [Vulpkanin, SlimePerson, IPC, Kitsune] # Floof - M3739 - TaskKitsunebi2 - Give Kitsune access to Vulp Markings
+  speciesRestriction: [Vulpkanin, SlimePerson, IPC, Kitsune] # Floof - M3739 - #1062 - Give Kitsune access to Vulp Markings
   sprites:
     - sprite: DeltaV/Mobs/Customization/Vulpkanin/head_markings.rsi
       state: tiger_head
@@ -255,7 +255,7 @@
   id: VulpHeadTigerFace
   bodyPart: Head
   markingCategory: Head
-  speciesRestriction: [Vulpkanin, SlimePerson, IPC, Kitsune] # Floof - M3739 - TaskKitsunebi2 - Give Kitsune access to Vulp Markings
+  speciesRestriction: [Vulpkanin, SlimePerson, IPC, Kitsune] # Floof - M3739 - #1062 - Give Kitsune access to Vulp Markings
   sprites:
     - sprite: DeltaV/Mobs/Customization/Vulpkanin/head_markings.rsi
       state: tiger_face
@@ -264,7 +264,7 @@
   id: VulpHeadSlash
   bodyPart: Head
   markingCategory: Head
-  speciesRestriction: [Vulpkanin, SlimePerson, IPC, Kitsune] # Floof - M3739 - TaskKitsunebi2 - Give Kitsune access to Vulp Markings
+  speciesRestriction: [Vulpkanin, SlimePerson, IPC, Kitsune] # Floof - M3739 - #1062 - Give Kitsune access to Vulp Markings
   sprites:
     - sprite: DeltaV/Mobs/Customization/Vulpkanin/head_markings.rsi
       state: slash
@@ -318,7 +318,7 @@
   id: VulpTailAlt
   bodyPart: Tail
   markingCategory: Tail
-  speciesRestriction: [Vulpkanin, Human, SlimePerson, IPC, Oni, Felinid, Rodentia, Kitsune] # Floof - M3739 - TaskKitsunebi2 - Give Kitsune access to Vulp Markings
+  speciesRestriction: [Vulpkanin, Human, SlimePerson, IPC, Oni, Felinid, Rodentia, Kitsune] # Floof - M3739 - #1062 - Give Kitsune access to Vulp Markings
   sprites:
     - sprite: DeltaV/Mobs/Customization/Vulpkanin/tail_markings.rsi
       state: vulp_alt
@@ -329,7 +329,7 @@
   id: VulpTailAltTip
   bodyPart: Tail
   markingCategory: Tail
-  speciesRestriction: [Vulpkanin, Human, SlimePerson, IPC, Oni, Felinid, Rodentia, Kitsune] # Floof - M3739 - TaskKitsunebi2 - Give Kitsune access to Vulp Markings
+  speciesRestriction: [Vulpkanin, Human, SlimePerson, IPC, Oni, Felinid, Rodentia, Kitsune] # Floof - M3739 - #1062 - Give Kitsune access to Vulp Markings
   sprites:
     - sprite: DeltaV/Mobs/Customization/Vulpkanin/tail_markings.rsi
       state: vulp_alt
@@ -340,7 +340,7 @@
   id: VulpTailLong
   bodyPart: Tail
   markingCategory: Tail
-  speciesRestriction: [Vulpkanin, Human, SlimePerson, IPC, Oni, Felinid, Rodentia, Kitsune] # Floof - M3739 - TaskKitsunebi2 - Give Kitsune access to Vulp Markings
+  speciesRestriction: [Vulpkanin, Human, SlimePerson, IPC, Oni, Felinid, Rodentia, Kitsune] # Floof - M3739 - #1062 - Give Kitsune access to Vulp Markings
   sprites:
     - sprite: DeltaV/Mobs/Customization/Vulpkanin/tail_markings.rsi
       state: long
@@ -395,7 +395,7 @@
   id: VulpTailBushy
   bodyPart: Tail
   markingCategory: Tail
-  speciesRestriction: [Vulpkanin, Human, SlimePerson, IPC, Oni, Felinid, Rodentia, Kitsune] # Floof - M3739 - TaskKitsunebi2 - Give Kitsune access to Vulp Markings
+  speciesRestriction: [Vulpkanin, Human, SlimePerson, IPC, Oni, Felinid, Rodentia, Kitsune] # Floof - M3739 - #1062 - Give Kitsune access to Vulp Markings
   sprites:
     - sprite: DeltaV/Mobs/Customization/Vulpkanin/tail_markings.rsi
       state: bushfluff
@@ -413,7 +413,7 @@
   id: VulpTailCoyote
   bodyPart: Tail
   markingCategory: Tail
-  speciesRestriction: [Vulpkanin, Human, SlimePerson, IPC, Oni, Felinid, Rodentia, Kitsune] # Floof - M3739 - TaskKitsunebi2 - Give Kitsune access to Vulp Markings
+  speciesRestriction: [Vulpkanin, Human, SlimePerson, IPC, Oni, Felinid, Rodentia, Kitsune] # Floof - M3739 - #1062 - Give Kitsune access to Vulp Markings
   sprites:
     - sprite: DeltaV/Mobs/Customization/Vulpkanin/tail_markings.rsi
       state: coyote
@@ -431,7 +431,7 @@
   id: VulpTailCorgi
   bodyPart: Tail
   markingCategory: Tail
-  speciesRestriction: [Vulpkanin, Human, SlimePerson, IPC, Oni, Felinid, Rodentia, Kitsune] # Floof - M3739 - TaskKitsunebi2 - Give Kitsune access to Vulp Markings
+  speciesRestriction: [Vulpkanin, Human, SlimePerson, IPC, Oni, Felinid, Rodentia, Kitsune] # Floof - M3739 - #1062 - Give Kitsune access to Vulp Markings
   sprites:
     - sprite: DeltaV/Mobs/Customization/Vulpkanin/tail_markings.rsi
       state: corgi
@@ -449,7 +449,7 @@
   id: VulpTailHusky
   bodyPart: Tail
   markingCategory: Tail
-  speciesRestriction: [Vulpkanin, Human, SlimePerson, IPC, Oni, Felinid, Rodentia, Kitsune] # Floof - M3739 - TaskKitsunebi2 - Give Kitsune access to Vulp Markings
+  speciesRestriction: [Vulpkanin, Human, SlimePerson, IPC, Oni, Felinid, Rodentia, Kitsune] # Floof - M3739 - #1062 - Give Kitsune access to Vulp Markings
   sprites:
     - sprite: DeltaV/Mobs/Customization/Vulpkanin/tail_markings.rsi
       state: husky-inner
@@ -460,7 +460,7 @@
   id: VulpTailHuskyAlt
   bodyPart: Tail
   markingCategory: Tail
-  speciesRestriction: [Vulpkanin, Human, SlimePerson, IPC, Oni, Felinid, Rodentia, Kitsune] # Floof - M3739 - TaskKitsunebi2 - Give Kitsune access to Vulp Markings
+  speciesRestriction: [Vulpkanin, Human, SlimePerson, IPC, Oni, Felinid, Rodentia, Kitsune] # Floof - M3739 - #1062 - Give Kitsune access to Vulp Markings
   sprites:
     - sprite: DeltaV/Mobs/Customization/Vulpkanin/tail_markings.rsi
       state: husky
@@ -498,7 +498,7 @@
   id: VulpTailOtie
   bodyPart: Tail
   markingCategory: Tail
-  speciesRestriction: [Vulpkanin, Human, SlimePerson, IPC, Oni, Felinid, Rodentia, Kitsune] # Floof - M3739 - TaskKitsunebi2 - Give Kitsune access to Vulp Markings
+  speciesRestriction: [Vulpkanin, Human, SlimePerson, IPC, Oni, Felinid, Rodentia, Kitsune] # Floof - M3739 - #1062 - Give Kitsune access to Vulp Markings
   sprites:
     - sprite: DeltaV/Mobs/Customization/Vulpkanin/tail_markings.rsi
       state: otie
@@ -507,7 +507,7 @@
   id: VulpTailFluffy
   bodyPart: Tail
   markingCategory: Tail
-  speciesRestriction: [Vulpkanin, Human, SlimePerson, IPC, Oni, Felinid, Rodentia, Kitsune] # Floof - M3739 - TaskKitsunebi2 - Give Kitsune access to Vulp Markings
+  speciesRestriction: [Vulpkanin, Human, SlimePerson, IPC, Oni, Felinid, Rodentia, Kitsune] # Floof - M3739 - #1062 - Give Kitsune access to Vulp Markings
   sprites:
     - sprite: DeltaV/Mobs/Customization/Vulpkanin/tail_markings.rsi
       state: fluffy
@@ -516,7 +516,7 @@
   id: VulpTailDalmatian
   bodyPart: Tail
   markingCategory: Tail
-  speciesRestriction: [Vulpkanin, Human, SlimePerson, IPC, Oni, Felinid, Rodentia, Kitsune] # Floof - M3739 - TaskKitsunebi2 - Give Kitsune access to Vulp Markings
+  speciesRestriction: [Vulpkanin, Human, SlimePerson, IPC, Oni, Felinid, Rodentia, Kitsune] # Floof - M3739 - #1062 - Give Kitsune access to Vulp Markings
   sprites:
     - sprite: DeltaV/Mobs/Customization/Vulpkanin/tail_markings.rsi
       state: dalmatian
@@ -535,7 +535,7 @@
   id: VulpBellyCrest
   bodyPart: Chest
   markingCategory: Chest
-  speciesRestriction: [Vulpkanin, SlimePerson, IPC, Human, Kitsune] # Floof - M3739 - TaskKitsunebi2 - Give Kitsune access to Vulp Markings
+  speciesRestriction: [Vulpkanin, SlimePerson, IPC, Human, Kitsune] # Floof - M3739 - #1062 - Give Kitsune access to Vulp Markings
   sprites:
     - sprite: DeltaV/Mobs/Customization/Vulpkanin/body_markings.rsi
       state: belly_crest
@@ -544,7 +544,7 @@
   id: VulpBellyFull
   bodyPart: Chest
   markingCategory: Chest
-  speciesRestriction: [Vulpkanin, SlimePerson, IPC, Human, Kitsune] # Floof - M3739 - TaskKitsunebi2 - Give Kitsune access to Vulp Markings
+  speciesRestriction: [Vulpkanin, SlimePerson, IPC, Human, Kitsune] # Floof - M3739 - #1062 - Give Kitsune access to Vulp Markings
   sprites:
     - sprite: DeltaV/Mobs/Customization/Vulpkanin/body_markings.rsi
       state: belly_full
@@ -553,7 +553,7 @@
   id: VulpBellyFox
   bodyPart: Chest
   markingCategory: Chest
-  speciesRestriction: [Vulpkanin, SlimePerson, IPC, Human, Kitsune] # Floof - M3739 - TaskKitsunebi2 - Give Kitsune access to Vulp Markings
+  speciesRestriction: [Vulpkanin, SlimePerson, IPC, Human, Kitsune] # Floof - M3739 - #1062 - Give Kitsune access to Vulp Markings
   sprites:
     - sprite: DeltaV/Mobs/Customization/Vulpkanin/body_markings.rsi
       state: belly_fox
@@ -564,7 +564,7 @@
 #   id: VulpBodyPointsCrest
 #   markingCategory: Overlay
 #   bodyPart: RFoot
-#   speciesRestriction: [Vulpkanin, SlimePerson, IPC, Kitsune] # Floof - M3739 - TaskKitsunebi2 - Give Kitsune access to Vulp Markings
+#   speciesRestriction: [Vulpkanin, SlimePerson, IPC, Kitsune] # Floof - M3739 - #1062 - Give Kitsune access to Vulp Markings
 #   sprites:
 #     - sprite: DeltaV/Mobs/Customization/Vulpkanin/body_markings.rsi
 #       state: points_crest
@@ -573,7 +573,7 @@
 #   id: VulpBodyPointsFade
 #   markingCategory: Overlay
 #   bodyPart: RFoot
-#   speciesRestriction: [Vulpkanin, SlimePerson, IPC, Kitsune] # Floof - M3739 - TaskKitsunebi2 - Give Kitsune access to Vulp Markings
+#   speciesRestriction: [Vulpkanin, SlimePerson, IPC, Kitsune] # Floof - M3739 - #1062 - Give Kitsune access to Vulp Markings
 #   sprites:
 #     - sprite: DeltaV/Mobs/Customization/Vulpkanin/body_markings.rsi
 #       state: points_fade
@@ -582,7 +582,7 @@
 #   id: VulpBodyPointsSharp
 #   markingCategory: Overlay
 #   bodyPart: RFoot
-#   speciesRestriction: [Vulpkanin, SlimePerson, IPC, Kitsune] # Floof - M3739 - TaskKitsunebi2 - Give Kitsune access to Vulp Markings
+#   speciesRestriction: [Vulpkanin, SlimePerson, IPC, Kitsune] # Floof - M3739 - #1062 - Give Kitsune access to Vulp Markings
 #   sprites:
 #     - sprite: DeltaV/Mobs/Customization/Vulpkanin/body_markings.rsi
 #       state: points_sharp
@@ -592,7 +592,7 @@
   id: VulpPointsFeet
   markingCategory: RightFoot
   bodyPart: RFoot
-  speciesRestriction: [Vulpkanin, SlimePerson, IPC, Kitsune] # Floof - M3739 - TaskKitsunebi2 - Give Kitsune access to Vulp Markings
+  speciesRestriction: [Vulpkanin, SlimePerson, IPC, Kitsune] # Floof - M3739 - #1062 - Give Kitsune access to Vulp Markings
   sprites:
     - sprite: DeltaV/Mobs/Customization/Vulpkanin/body_markings.rsi
       state: points_feet
@@ -601,7 +601,7 @@
   id: VulpPointsCrestLegs
   markingCategory: LeftLeg
   bodyPart: LLeg
-  speciesRestriction: [Vulpkanin, SlimePerson, IPC, Kitsune] # Floof - M3739 - TaskKitsunebi2 - Give Kitsune access to Vulp Markings
+  speciesRestriction: [Vulpkanin, SlimePerson, IPC, Kitsune] # Floof - M3739 - #1062 - Give Kitsune access to Vulp Markings
   sprites:
     - sprite: DeltaV/Mobs/Customization/Vulpkanin/body_markings.rsi
       state: points_crest-legs
@@ -610,7 +610,7 @@
   id: VulpPointsFadeLegs
   markingCategory: LeftLeg
   bodyPart: LLeg
-  speciesRestriction: [Vulpkanin, SlimePerson, IPC, Kitsune] # Floof - M3739 - TaskKitsunebi2 - Give Kitsune access to Vulp Markings
+  speciesRestriction: [Vulpkanin, SlimePerson, IPC, Kitsune] # Floof - M3739 - #1062 - Give Kitsune access to Vulp Markings
   sprites:
     - sprite: DeltaV/Mobs/Customization/Vulpkanin/body_markings.rsi
       state: points_fade-legs
@@ -619,7 +619,7 @@
   id: VulpPointsSharpLegs
   markingCategory: LeftLeg
   bodyPart: LLeg
-  speciesRestriction: [Vulpkanin, SlimePerson, IPC, Kitsune] # Floof - M3739 - TaskKitsunebi2 - Give Kitsune access to Vulp Markings
+  speciesRestriction: [Vulpkanin, SlimePerson, IPC, Kitsune] # Floof - M3739 - #1062 - Give Kitsune access to Vulp Markings
   sprites:
     - sprite: DeltaV/Mobs/Customization/Vulpkanin/body_markings.rsi
       state: points_sharp-legs
@@ -629,7 +629,7 @@
   id: VulpPointsHands
   markingCategory: RightHand
   bodyPart: RHand
-  speciesRestriction: [Vulpkanin, SlimePerson, IPC, Kitsune] # Floof - M3739 - TaskKitsunebi2 - Give Kitsune access to Vulp Markings
+  speciesRestriction: [Vulpkanin, SlimePerson, IPC, Kitsune] # Floof - M3739 - #1062 - Give Kitsune access to Vulp Markings
   sprites:
     - sprite: DeltaV/Mobs/Customization/Vulpkanin/body_markings.rsi
       state: points_hands
@@ -638,7 +638,7 @@
   id: VulpPointsCrestArms
   markingCategory: LeftArm
   bodyPart: LArm
-  speciesRestriction: [Vulpkanin, SlimePerson, IPC, Kitsune] # Floof - M3739 - TaskKitsunebi2 - Give Kitsune access to Vulp Markings
+  speciesRestriction: [Vulpkanin, SlimePerson, IPC, Kitsune] # Floof - M3739 - #1062 - Give Kitsune access to Vulp Markings
   sprites:
     - sprite: DeltaV/Mobs/Customization/Vulpkanin/body_markings.rsi
       state: points_crest-arms
@@ -647,7 +647,7 @@
   id: VulpPointsFadeArms
   markingCategory: LeftArm
   bodyPart: LArm
-  speciesRestriction: [Vulpkanin, SlimePerson, IPC, Kitsune] # Floof - M3739 - TaskKitsunebi2 - Give Kitsune access to Vulp Markings
+  speciesRestriction: [Vulpkanin, SlimePerson, IPC, Kitsune] # Floof - M3739 - #1062 - Give Kitsune access to Vulp Markings
   sprites:
     - sprite: DeltaV/Mobs/Customization/Vulpkanin/body_markings.rsi
       state: points_fade-arms
@@ -656,7 +656,7 @@
   id: VulpPointsSharpArms
   markingCategory: LeftArm
   bodyPart: LArm
-  speciesRestriction: [Vulpkanin, SlimePerson, IPC, Kitsune] # Floof - M3739 - TaskKitsunebi2 - Give Kitsune access to Vulp Markings
+  speciesRestriction: [Vulpkanin, SlimePerson, IPC, Kitsune] # Floof - M3739 - #1062 - Give Kitsune access to Vulp Markings
   sprites:
     - sprite: DeltaV/Mobs/Customization/Vulpkanin/body_markings.rsi
       state: points_sharp-arms
@@ -665,7 +665,7 @@
 - type: marking
   id: VulpHairAdhara
   bodyPart: Hair
-  speciesRestriction: [Vulpkanin, SlimePerson, IPC, Kitsune] # Floof - M3739 - TaskKitsunebi2 - Give Kitsune access to Vulp Markings
+  speciesRestriction: [Vulpkanin, SlimePerson, IPC, Kitsune] # Floof - M3739 - #1062 - Give Kitsune access to Vulp Markings
   markingCategory: Hair
   sprites:
     - sprite: DeltaV/Mobs/Customization/Vulpkanin/hair.rsi
@@ -674,7 +674,7 @@
 - type: marking
   id: VulpHairAnita
   bodyPart: Hair
-  speciesRestriction: [Vulpkanin, SlimePerson, IPC, Kitsune] # Floof - M3739 - TaskKitsunebi2 - Give Kitsune access to Vulp Markings
+  speciesRestriction: [Vulpkanin, SlimePerson, IPC, Kitsune] # Floof - M3739 - #1062 - Give Kitsune access to Vulp Markings
   markingCategory: Hair
   sprites:
     - sprite: DeltaV/Mobs/Customization/Vulpkanin/hair.rsi
@@ -683,7 +683,7 @@
 - type: marking
   id: VulpHairApollo
   bodyPart: Hair
-  speciesRestriction: [Vulpkanin, SlimePerson, IPC, Kitsune] # Floof - M3739 - TaskKitsunebi2 - Give Kitsune access to Vulp Markings
+  speciesRestriction: [Vulpkanin, SlimePerson, IPC, Kitsune] # Floof - M3739 - #1062 - Give Kitsune access to Vulp Markings
   markingCategory: Hair
   sprites:
     - sprite: DeltaV/Mobs/Customization/Vulpkanin/hair.rsi
@@ -692,7 +692,7 @@
 - type: marking
   id: VulpHairBelle
   bodyPart: Hair
-  speciesRestriction: [Vulpkanin, SlimePerson, IPC, Kitsune] # Floof - M3739 - TaskKitsunebi2 - Give Kitsune access to Vulp Markings
+  speciesRestriction: [Vulpkanin, SlimePerson, IPC, Kitsune] # Floof - M3739 - #1062 - Give Kitsune access to Vulp Markings
   markingCategory: Hair
   sprites:
     - sprite: DeltaV/Mobs/Customization/Vulpkanin/hair.rsi
@@ -702,7 +702,7 @@
   id: VulpHairBraided
   bodyPart: Hair
   markingCategory: Hair
-  speciesRestriction: [Vulpkanin, SlimePerson, IPC, Kitsune] # Floof - M3739 - TaskKitsunebi2 - Give Kitsune access to Vulp Markings
+  speciesRestriction: [Vulpkanin, SlimePerson, IPC, Kitsune] # Floof - M3739 - #1062 - Give Kitsune access to Vulp Markings
   sprites:
     - sprite: DeltaV/Mobs/Customization/Vulpkanin/hair.rsi
       state: braided
@@ -711,7 +711,7 @@
   id: VulpHairBun
   bodyPart: Hair
   markingCategory: Hair
-  speciesRestriction: [Vulpkanin, SlimePerson, IPC, Kitsune] # Floof - M3739 - TaskKitsunebi2 - Give Kitsune access to Vulp Markings
+  speciesRestriction: [Vulpkanin, SlimePerson, IPC, Kitsune] # Floof - M3739 - #1062 - Give Kitsune access to Vulp Markings
   sprites:
     - sprite: DeltaV/Mobs/Customization/Vulpkanin/hair.rsi
       state: bun
@@ -720,7 +720,7 @@
   id: VulpHairCleanCut
   bodyPart: Hair
   markingCategory: Hair
-  speciesRestriction: [Vulpkanin, SlimePerson, IPC, Kitsune] # Floof - M3739 - TaskKitsunebi2 - Give Kitsune access to Vulp Markings
+  speciesRestriction: [Vulpkanin, SlimePerson, IPC, Kitsune] # Floof - M3739 - #1062 - Give Kitsune access to Vulp Markings
   sprites:
     - sprite: DeltaV/Mobs/Customization/Vulpkanin/hair.rsi
       state: clean_cut
@@ -729,7 +729,7 @@
   id: VulpHairCurl
   bodyPart: Hair
   markingCategory: Hair
-  speciesRestriction: [Vulpkanin, SlimePerson, IPC, Kitsune] # Floof - M3739 - TaskKitsunebi2 - Give Kitsune access to Vulp Markings
+  speciesRestriction: [Vulpkanin, SlimePerson, IPC, Kitsune] # Floof - M3739 - #1062 - Give Kitsune access to Vulp Markings
   sprites:
     - sprite: DeltaV/Mobs/Customization/Vulpkanin/hair.rsi
       state: curl
@@ -738,7 +738,7 @@
   id: VulpHairHawk
   bodyPart: Hair
   markingCategory: Hair
-  speciesRestriction: [Vulpkanin, SlimePerson, IPC, Kitsune] # Floof - M3739 - TaskKitsunebi2 - Give Kitsune access to Vulp Markings
+  speciesRestriction: [Vulpkanin, SlimePerson, IPC, Kitsune] # Floof - M3739 - #1062 - Give Kitsune access to Vulp Markings
   sprites:
     - sprite: DeltaV/Mobs/Customization/Vulpkanin/hair.rsi
       state: hawk
@@ -747,7 +747,7 @@
   id: VulpHairJagged
   bodyPart: Hair
   markingCategory: Hair
-  speciesRestriction: [Vulpkanin, SlimePerson, IPC, Kitsune] # Floof - M3739 - TaskKitsunebi2 - Give Kitsune access to Vulp Markings
+  speciesRestriction: [Vulpkanin, SlimePerson, IPC, Kitsune] # Floof - M3739 - #1062 - Give Kitsune access to Vulp Markings
   sprites:
     - sprite: DeltaV/Mobs/Customization/Vulpkanin/hair.rsi
       state: jagged
@@ -756,7 +756,7 @@
   id: VulpHairJeremy
   bodyPart: Hair
   markingCategory: Hair
-  speciesRestriction: [Vulpkanin, SlimePerson, IPC, Kitsune] # Floof - M3739 - TaskKitsunebi2 - Give Kitsune access to Vulp Markings
+  speciesRestriction: [Vulpkanin, SlimePerson, IPC, Kitsune] # Floof - M3739 - #1062 - Give Kitsune access to Vulp Markings
   sprites:
     - sprite: DeltaV/Mobs/Customization/Vulpkanin/hair.rsi
       state: jeremy
@@ -765,7 +765,7 @@
   id: VulpHairKajam
   bodyPart: Hair
   markingCategory: Hair
-  speciesRestriction: [Vulpkanin, SlimePerson, IPC, Kitsune] # Floof - M3739 - TaskKitsunebi2 - Give Kitsune access to Vulp Markings
+  speciesRestriction: [Vulpkanin, SlimePerson, IPC, Kitsune] # Floof - M3739 - #1062 - Give Kitsune access to Vulp Markings
   sprites:
     - sprite: DeltaV/Mobs/Customization/Vulpkanin/hair.rsi
       state: kajam
@@ -774,7 +774,7 @@
   id: VulpHairKeid
   bodyPart: Hair
   markingCategory: Hair
-  speciesRestriction: [Vulpkanin, SlimePerson, IPC, Kitsune] # Floof - M3739 - TaskKitsunebi2 - Give Kitsune access to Vulp Markings
+  speciesRestriction: [Vulpkanin, SlimePerson, IPC, Kitsune] # Floof - M3739 - #1062 - Give Kitsune access to Vulp Markings
   sprites:
     - sprite: DeltaV/Mobs/Customization/Vulpkanin/hair.rsi
       state: keid
@@ -783,7 +783,7 @@
   id: VulpHairKleeia
   bodyPart: Hair
   markingCategory: Hair
-  speciesRestriction: [Vulpkanin, SlimePerson, IPC, Kitsune] # Floof - M3739 - TaskKitsunebi2 - Give Kitsune access to Vulp Markings
+  speciesRestriction: [Vulpkanin, SlimePerson, IPC, Kitsune] # Floof - M3739 - #1062 - Give Kitsune access to Vulp Markings
   sprites:
     - sprite: DeltaV/Mobs/Customization/Vulpkanin/hair.rsi
       state: kleeia
@@ -792,7 +792,7 @@
   id: VulpHairMizar
   bodyPart: Hair
   markingCategory: Hair
-  speciesRestriction: [Vulpkanin, SlimePerson, IPC, Kitsune] # Floof - M3739 - TaskKitsunebi2 - Give Kitsune access to Vulp Markings
+  speciesRestriction: [Vulpkanin, SlimePerson, IPC, Kitsune] # Floof - M3739 - #1062 - Give Kitsune access to Vulp Markings
   sprites:
     - sprite: DeltaV/Mobs/Customization/Vulpkanin/hair.rsi
       state: mizar
@@ -801,7 +801,7 @@
   id: VulpHairPunkBraided
   bodyPart: Hair
   markingCategory: Hair
-  speciesRestriction: [Vulpkanin, SlimePerson, IPC, Kitsune] # Floof - M3739 - TaskKitsunebi2 - Give Kitsune access to Vulp Markings
+  speciesRestriction: [Vulpkanin, SlimePerson, IPC, Kitsune] # Floof - M3739 - #1062 - Give Kitsune access to Vulp Markings
   sprites:
     - sprite: DeltaV/Mobs/Customization/Vulpkanin/hair.rsi
       state: punkbraided
@@ -810,7 +810,7 @@
   id: VulpHairRaine
   bodyPart: Hair
   markingCategory: Hair
-  speciesRestriction: [Vulpkanin, SlimePerson, IPC, Kitsune] # Floof - M3739 - TaskKitsunebi2 - Give Kitsune access to Vulp Markings
+  speciesRestriction: [Vulpkanin, SlimePerson, IPC, Kitsune] # Floof - M3739 - #1062 - Give Kitsune access to Vulp Markings
   sprites:
     - sprite: DeltaV/Mobs/Customization/Vulpkanin/hair.rsi
       state: raine
@@ -819,7 +819,7 @@
   id: VulpHairRough
   bodyPart: Hair
   markingCategory: Hair
-  speciesRestriction: [Vulpkanin, SlimePerson, IPC, Kitsune] # Floof - M3739 - TaskKitsunebi2 - Give Kitsune access to Vulp Markings
+  speciesRestriction: [Vulpkanin, SlimePerson, IPC, Kitsune] # Floof - M3739 - #1062 - Give Kitsune access to Vulp Markings
   sprites:
     - sprite: DeltaV/Mobs/Customization/Vulpkanin/hair.rsi
       state: rough
@@ -828,7 +828,7 @@
   id: VulpHairShort
   bodyPart: Hair
   markingCategory: Hair
-  speciesRestriction: [Vulpkanin, SlimePerson, IPC, Kitsune] # Floof - M3739 - TaskKitsunebi2 - Give Kitsune access to Vulp Markings
+  speciesRestriction: [Vulpkanin, SlimePerson, IPC, Kitsune] # Floof - M3739 - #1062 - Give Kitsune access to Vulp Markings
   sprites:
     - sprite: DeltaV/Mobs/Customization/Vulpkanin/hair.rsi
       state: short
@@ -837,7 +837,7 @@
   id: VulpHairShort2
   bodyPart: Hair
   markingCategory: Hair
-  speciesRestriction: [Vulpkanin, SlimePerson, IPC, Kitsune] # Floof - M3739 - TaskKitsunebi2 - Give Kitsune access to Vulp Markings
+  speciesRestriction: [Vulpkanin, SlimePerson, IPC, Kitsune] # Floof - M3739 - #1062 - Give Kitsune access to Vulp Markings
   sprites:
     - sprite: DeltaV/Mobs/Customization/Vulpkanin/hair.rsi
       state: short2
@@ -846,7 +846,7 @@
   id: VulpHairSpike
   bodyPart: Hair
   markingCategory: Hair
-  speciesRestriction: [Vulpkanin, SlimePerson, IPC, Kitsune] # Floof - M3739 - TaskKitsunebi2 - Give Kitsune access to Vulp Markings
+  speciesRestriction: [Vulpkanin, SlimePerson, IPC, Kitsune] # Floof - M3739 - #1062 - Give Kitsune access to Vulp Markings
   sprites:
     - sprite: DeltaV/Mobs/Customization/Vulpkanin/hair.rsi
       state: spike
@@ -856,7 +856,7 @@
   id: VulpFacialHairRuff
   bodyPart: FacialHair
   markingCategory: FacialHair
-  speciesRestriction: [Vulpkanin, SlimePerson, IPC, Kitsune] # Floof - M3739 - TaskKitsunebi2 - Give Kitsune access to Vulp Markings
+  speciesRestriction: [Vulpkanin, SlimePerson, IPC, Kitsune] # Floof - M3739 - #1062 - Give Kitsune access to Vulp Markings
   sprites:
     - sprite: DeltaV/Mobs/Customization/Vulpkanin/facial_hair.rsi
       state: ruff
@@ -865,7 +865,7 @@
   id: VulpFacialHairElder
   bodyPart: FacialHair
   markingCategory: FacialHair
-  speciesRestriction: [Vulpkanin, SlimePerson, IPC, Kitsune] # Floof - M3739 - TaskKitsunebi2 - Give Kitsune access to Vulp Markings
+  speciesRestriction: [Vulpkanin, SlimePerson, IPC, Kitsune] # Floof - M3739 - #1062 - Give Kitsune access to Vulp Markings
   sprites:
     - sprite: DeltaV/Mobs/Customization/Vulpkanin/facial_hair.rsi
       state: elder
@@ -874,7 +874,7 @@
   id: VulpFacialHairElderChin
   bodyPart: FacialHair
   markingCategory: FacialHair
-  speciesRestriction: [Vulpkanin, SlimePerson, IPC, Kitsune] # Floof - M3739 - TaskKitsunebi2 - Give Kitsune access to Vulp Markings
+  speciesRestriction: [Vulpkanin, SlimePerson, IPC, Kitsune] # Floof - M3739 - #1062 - Give Kitsune access to Vulp Markings
   sprites:
     - sprite: DeltaV/Mobs/Customization/Vulpkanin/facial_hair.rsi
       state: elder_chin
@@ -883,7 +883,7 @@
   id: VulpFacialHairKita
   bodyPart: FacialHair
   markingCategory: FacialHair
-  speciesRestriction: [Vulpkanin, SlimePerson, IPC, Kitsune] # Floof - M3739 - TaskKitsunebi2 - Give Kitsune access to Vulp Markings
+  speciesRestriction: [Vulpkanin, SlimePerson, IPC, Kitsune] # Floof - M3739 - #1062 - Give Kitsune access to Vulp Markings
   sprites:
     - sprite: DeltaV/Mobs/Customization/Vulpkanin/facial_hair.rsi
       state: kita

--- a/Resources/Prototypes/DeltaV/Species/kitsune.yml
+++ b/Resources/Prototypes/DeltaV/Species/kitsune.yml
@@ -6,24 +6,23 @@
   sprites: MobHumanSprites
   markingLimits: MobKitsuneMarkingLimits
   dollPrototype: MobKitsuneDummy
-# Floof - M3739 - #937 | Begin Changes
+# Floof - M3739 - #1062 | Begin Changes
   skinColoration: Hues 
-  minHeight: 0.65 # Floof - M3739 - #937 | Values copied over from Rodentia and Felinids, Kitsune are small.
+  minHeight: 0.65 | Values copied over from Rodentia and Felinids, Kitsune are small.
 #  defaultHeight: 0.8 
   maxHeight: 1.1 
   minWidth: 0.6 
 #  defaultWidth: 0.8 
   maxWidth: 1.15  
   customName: true 
-# Floof - M3739 - #937 | End Changes
 - type: markingPoints
   id: MobKitsuneMarkingLimits
   points:
-    Underwear: # Floof - M3739 - #937
-      points: 2 # Floof - M3739 - #937
+    Underwear:
+      points: 2
       required: false
-    Undershirt: # Floof - M3739 - #937
-      points: 2 # Floof - M3739 - #937
+    Undershirt:
+      points: 2
       required: false
     Hair:
       points: 1
@@ -31,9 +30,9 @@
     FacialHair:
       points: 1
       required: false
-    Head: # Floof - M3739 - #937
-      points: 6 # Floof - M3739 - #937
-      required: false # Floof - M3739 - #937
+    Head:
+      points: 6
+      required: false
     Snout:
       points: 1
       required: false
@@ -42,10 +41,10 @@
       required: true
       defaultMarkings: [ KitsuneTailDefault ]
     Wings:
-      points: 1 # Floof - M3739 - #1062
+      points: 1
       required: false
     HeadTop:
-      points: 6 # Floof - M3739 - #1062
+      points: 6
       required: true
       defaultMarkings: [ KitsuneEarsDefault ]
 #    UndergarmentTop: # Floof - M3739 - #937 - Commented out for posterity. Superseded by Underwear and Undershirt.
@@ -55,32 +54,33 @@
 #      points: 1
 #      required: false
     Chest:
-      points: 6 # Floof - M3739 - #1062
+      points: 6
       required: false
-    RightLeg: # Floof - M3739 - #937
-      points: 6 # Floof - M3739 - #1062
+    RightLeg:
+      points: 6
       required: false
-    RightFoot: # Floof - M3739 - #937
-      points: 6 # Floof - M3739 - #1062
+    RightFoot:
+      points: 6
       required: false
-    LeftLeg: # Floof - M3739 - #937
-      points: 6 # Floof - M3739 - #1062
+    LeftLeg:
+      points: 6
       required: false
-    LeftFoot: # Floof - M3739 - #937
-      points: 6 # Floof - M3739 - #1062
+    LeftFoot:
+      points: 6
       required: false
-    RightArm: # Floof - M3739 - #937
-      points: 6 # Floof - M3739 - #1062
+    RightArm:
+      points: 6
       required: false
-    RightHand: # Floof - M3739 - #937
-      points: 6 # Floof - M3739 - #1062
+    RightHand:
+      points: 6
       required: false
-    LeftArm: # Floof - M3739 - #937
-      points: 6 # Floof - M3739 - #1062
+    LeftArm:
+      points: 6
       required: false
-    LeftHand: # Floof - M3739 - #937
-      points: 6 # Floof - M3739 - #1062
+    LeftHand:
+      points: 6
       required: false
-    HeadSide: # Floof - M3739 - #937
-      points: 6 # Floof - M3739 - #1062
-      required: false # Floof - M3739 - #937
+    HeadSide:
+      points: 6
+      required: false
+# Floof - M3739 - #1062 | End Changes

--- a/Resources/Prototypes/DeltaV/Species/kitsune.yml
+++ b/Resources/Prototypes/DeltaV/Species/kitsune.yml
@@ -32,7 +32,7 @@
       points: 1
       required: false
     Head: # Floof - M3739 - #937
-      points: 3 # Floof - M3739 - #937
+      points: 6 # Floof - M3739 - #937
       required: false # Floof - M3739 - #937
     Snout:
       points: 1
@@ -41,8 +41,11 @@
       points: 1
       required: true
       defaultMarkings: [ KitsuneTailDefault ]
+    Wings:
+      points: 1 # Floof - M3739 - TaskKitsunebi2
+      required: false
     HeadTop:
-      points: 1
+      points: 6 # Floof - M3739 - TaskKitsunebi2
       required: true
       defaultMarkings: [ KitsuneEarsDefault ]
 #    UndergarmentTop: # Floof - M3739 - #937 - Commented out for posterity. Superseded by Underwear and Undershirt.
@@ -52,32 +55,32 @@
 #      points: 1
 #      required: false
     Chest:
-      points: 3 # Floof - M3739 - #937
+      points: 6 # Floof - M3739 - TaskKitsunebi2
       required: false
     RightLeg: # Floof - M3739 - #937
-      points: 2
+      points: 6 # Floof - M3739 - TaskKitsunebi2
       required: false
     RightFoot: # Floof - M3739 - #937
-      points: 2
+      points: 6 # Floof - M3739 - TaskKitsunebi2
       required: false
     LeftLeg: # Floof - M3739 - #937
-      points: 2
+      points: 6 # Floof - M3739 - TaskKitsunebi2
       required: false
     LeftFoot: # Floof - M3739 - #937
-      points: 2
+      points: 6 # Floof - M3739 - TaskKitsunebi2
       required: false
     RightArm: # Floof - M3739 - #937
-      points: 2
+      points: 6 # Floof - M3739 - TaskKitsunebi2
       required: false
     RightHand: # Floof - M3739 - #937
-      points: 3
+      points: 6 # Floof - M3739 - TaskKitsunebi2
       required: false
     LeftArm: # Floof - M3739 - #937
-      points: 2
+      points: 6 # Floof - M3739 - TaskKitsunebi2
       required: false
     LeftHand: # Floof - M3739 - #937
-      points: 3
+      points: 6 # Floof - M3739 - TaskKitsunebi2
       required: false
     HeadSide: # Floof - M3739 - #937
-      points: 2 # Floof - M3739 - #937
+      points: 6 # Floof - M3739 - TaskKitsunebi2
       required: false # Floof - M3739 - #937

--- a/Resources/Prototypes/DeltaV/Species/kitsune.yml
+++ b/Resources/Prototypes/DeltaV/Species/kitsune.yml
@@ -8,7 +8,7 @@
   dollPrototype: MobKitsuneDummy
 # Floof - M3739 - #1062 | Begin Changes
   skinColoration: Hues 
-  minHeight: 0.65 | Values copied over from Rodentia and Felinids, Kitsune are small.
+  minHeight: 0.65
 #  defaultHeight: 0.8 
   maxHeight: 1.1 
   minWidth: 0.6 

--- a/Resources/Prototypes/DeltaV/Species/kitsune.yml
+++ b/Resources/Prototypes/DeltaV/Species/kitsune.yml
@@ -42,10 +42,10 @@
       required: true
       defaultMarkings: [ KitsuneTailDefault ]
     Wings:
-      points: 1 # Floof - M3739 - TaskKitsunebi2
+      points: 1 # Floof - M3739 - #1062
       required: false
     HeadTop:
-      points: 6 # Floof - M3739 - TaskKitsunebi2
+      points: 6 # Floof - M3739 - #1062
       required: true
       defaultMarkings: [ KitsuneEarsDefault ]
 #    UndergarmentTop: # Floof - M3739 - #937 - Commented out for posterity. Superseded by Underwear and Undershirt.
@@ -55,32 +55,32 @@
 #      points: 1
 #      required: false
     Chest:
-      points: 6 # Floof - M3739 - TaskKitsunebi2
+      points: 6 # Floof - M3739 - #1062
       required: false
     RightLeg: # Floof - M3739 - #937
-      points: 6 # Floof - M3739 - TaskKitsunebi2
+      points: 6 # Floof - M3739 - #1062
       required: false
     RightFoot: # Floof - M3739 - #937
-      points: 6 # Floof - M3739 - TaskKitsunebi2
+      points: 6 # Floof - M3739 - #1062
       required: false
     LeftLeg: # Floof - M3739 - #937
-      points: 6 # Floof - M3739 - TaskKitsunebi2
+      points: 6 # Floof - M3739 - #1062
       required: false
     LeftFoot: # Floof - M3739 - #937
-      points: 6 # Floof - M3739 - TaskKitsunebi2
+      points: 6 # Floof - M3739 - #1062
       required: false
     RightArm: # Floof - M3739 - #937
-      points: 6 # Floof - M3739 - TaskKitsunebi2
+      points: 6 # Floof - M3739 - #1062
       required: false
     RightHand: # Floof - M3739 - #937
-      points: 6 # Floof - M3739 - TaskKitsunebi2
+      points: 6 # Floof - M3739 - #1062
       required: false
     LeftArm: # Floof - M3739 - #937
-      points: 6 # Floof - M3739 - TaskKitsunebi2
+      points: 6 # Floof - M3739 - #1062
       required: false
     LeftHand: # Floof - M3739 - #937
-      points: 6 # Floof - M3739 - TaskKitsunebi2
+      points: 6 # Floof - M3739 - #1062
       required: false
     HeadSide: # Floof - M3739 - #937
-      points: 6 # Floof - M3739 - TaskKitsunebi2
+      points: 6 # Floof - M3739 - #1062
       required: false # Floof - M3739 - #937

--- a/Resources/Prototypes/Entities/Mobs/Customization/Markings/kemonomimi_ears.yml
+++ b/Resources/Prototypes/Entities/Mobs/Customization/Markings/kemonomimi_ears.yml
@@ -2,7 +2,7 @@
   id: BullishHorns
   bodyPart: HeadTop
   markingCategory: HeadTop
-  speciesRestriction: [Human, SlimePerson, Arachne, Oni, IPC]
+  speciesRestriction: [Human, SlimePerson, Arachne, Oni, IPC, Kitsune] # Floof - M3739 - TaskKitsunebi2 - Give Kitsune access to Kemonomimi markings
   coloring:
     default:
       type:
@@ -18,7 +18,7 @@
   id: BunnyEars
   bodyPart: HeadTop
   markingCategory: HeadTop
-  speciesRestriction: [Human, SlimePerson, Arachne, Oni, IPC]
+  speciesRestriction: [Human, SlimePerson, Arachne, Oni, IPC, Kitsune] # Floof - M3739 - TaskKitsunebi2 - Give Kitsune access to Kemonomimi markings
   coloring:
     default:
       type:
@@ -41,7 +41,7 @@
   id: BunnyEarsAlt
   bodyPart: HeadTop
   markingCategory: HeadTop
-  speciesRestriction: [Human, SlimePerson, Arachne, Oni, IPC]
+  speciesRestriction: [Human, SlimePerson, Arachne, Oni, IPC, Kitsune] # Floof - M3739 - TaskKitsunebi2 - Give Kitsune access to Kemonomimi markings
   coloring:
     default:
       type:
@@ -57,7 +57,7 @@
   id: FoxEars
   bodyPart: HeadTop
   markingCategory: HeadTop
-  speciesRestriction: [Human, SlimePerson, Arachne, Oni, IPC]
+  speciesRestriction: [Human, SlimePerson, Arachne, Oni, IPC, Kitsune] # Floof - M3739 - TaskKitsunebi2 - Give Kitsune access to Kemonomimi markings
   coloring:
     default:
       type:
@@ -73,7 +73,7 @@
   id: GoatHorns
   bodyPart: HeadTop
   markingCategory: HeadTop
-  speciesRestriction: [Human, SlimePerson, Arachne, Oni, IPC]
+  speciesRestriction: [Human, SlimePerson, Arachne, Oni, IPC, Kitsune] # Floof - M3739 - TaskKitsunebi2 - Give Kitsune access to Kemonomimi markings
   coloring:
     default:
       type:

--- a/Resources/Prototypes/Entities/Mobs/Customization/Markings/kemonomimi_ears.yml
+++ b/Resources/Prototypes/Entities/Mobs/Customization/Markings/kemonomimi_ears.yml
@@ -2,7 +2,7 @@
   id: BullishHorns
   bodyPart: HeadTop
   markingCategory: HeadTop
-  speciesRestriction: [Human, SlimePerson, Arachne, Oni, IPC, Kitsune] # Floof - M3739 - TaskKitsunebi2 - Give Kitsune access to Kemonomimi markings
+  speciesRestriction: [Human, SlimePerson, Arachne, Oni, IPC, Kitsune] # Floof - M3739 - #1062 - Give Kitsune access to Kemonomimi markings
   coloring:
     default:
       type:
@@ -18,7 +18,7 @@
   id: BunnyEars
   bodyPart: HeadTop
   markingCategory: HeadTop
-  speciesRestriction: [Human, SlimePerson, Arachne, Oni, IPC, Kitsune] # Floof - M3739 - TaskKitsunebi2 - Give Kitsune access to Kemonomimi markings
+  speciesRestriction: [Human, SlimePerson, Arachne, Oni, IPC, Kitsune] # Floof - M3739 - #1062 - Give Kitsune access to Kemonomimi markings
   coloring:
     default:
       type:
@@ -41,7 +41,7 @@
   id: BunnyEarsAlt
   bodyPart: HeadTop
   markingCategory: HeadTop
-  speciesRestriction: [Human, SlimePerson, Arachne, Oni, IPC, Kitsune] # Floof - M3739 - TaskKitsunebi2 - Give Kitsune access to Kemonomimi markings
+  speciesRestriction: [Human, SlimePerson, Arachne, Oni, IPC, Kitsune] # Floof - M3739 - #1062 - Give Kitsune access to Kemonomimi markings
   coloring:
     default:
       type:
@@ -57,7 +57,7 @@
   id: FoxEars
   bodyPart: HeadTop
   markingCategory: HeadTop
-  speciesRestriction: [Human, SlimePerson, Arachne, Oni, IPC, Kitsune] # Floof - M3739 - TaskKitsunebi2 - Give Kitsune access to Kemonomimi markings
+  speciesRestriction: [Human, SlimePerson, Arachne, Oni, IPC, Kitsune] # Floof - M3739 - #1062 - Give Kitsune access to Kemonomimi markings
   coloring:
     default:
       type:
@@ -73,7 +73,7 @@
   id: GoatHorns
   bodyPart: HeadTop
   markingCategory: HeadTop
-  speciesRestriction: [Human, SlimePerson, Arachne, Oni, IPC, Kitsune] # Floof - M3739 - TaskKitsunebi2 - Give Kitsune access to Kemonomimi markings
+  speciesRestriction: [Human, SlimePerson, Arachne, Oni, IPC, Kitsune] # Floof - M3739 - #1062 - Give Kitsune access to Kemonomimi markings
   coloring:
     default:
       type:

--- a/Resources/Prototypes/Entities/Mobs/Customization/Markings/kemonomimi_tails.yml
+++ b/Resources/Prototypes/Entities/Mobs/Customization/Markings/kemonomimi_tails.yml
@@ -2,7 +2,7 @@
   id: BunnyTail
   bodyPart: Tail
   markingCategory: Tail
-  speciesRestriction: [Human, SlimePerson, Vulpkanin, Oni]
+  speciesRestriction: [Human, SlimePerson, Vulpkanin, Oni, Kitsune] # Floof - M3739 - TaskKitsunebi2 - Give Kitsune access to Kemonomimi markings
   coloring:
     default:
       type:
@@ -20,7 +20,7 @@
   id: BunnyTailAlt
   bodyPart: Tail
   markingCategory: Tail
-  speciesRestriction: [Human, SlimePerson, Vulpkanin, Oni]
+  speciesRestriction: [Human, SlimePerson, Vulpkanin, Oni, Kitsune] # Floof - M3739 - TaskKitsunebi2 - Give Kitsune access to Kemonomimi markings
   coloring:
     default:
       type:
@@ -38,7 +38,7 @@
   id: DobleFur
   bodyPart: Tail
   markingCategory: Tail
-  speciesRestriction: [Human, SlimePerson, Vulpkanin, Oni]
+  speciesRestriction: [Human, SlimePerson, Vulpkanin, Oni, Kitsune] # Floof - M3739 - TaskKitsunebi2 - Give Kitsune access to Kemonomimi markings
   coloring:
     default:
       type:
@@ -58,7 +58,7 @@
   id: FluffyTail
   bodyPart: Tail
   markingCategory: Tail
-  speciesRestriction: [Human, SlimePerson, Vulpkanin, Oni]
+  speciesRestriction: [Human, SlimePerson, Vulpkanin, Oni, Kitsune] # Floof - M3739 - TaskKitsunebi2 - Give Kitsune access to Kemonomimi markings
   coloring:
     default:
       type:
@@ -76,7 +76,7 @@
   id: FoxNineTails
   bodyPart: Tail
   markingCategory: Tail
-  speciesRestriction: [Human, SlimePerson, Vulpkanin, Oni]
+  speciesRestriction: [Human, SlimePerson, Vulpkanin, Oni, Kitsune] # Floof - M3739 - TaskKitsunebi2 - Give Kitsune access to Kemonomimi markings
   coloring:
     default:
       type:
@@ -96,7 +96,7 @@
   id: FoxThreeTails
   bodyPart: Tail
   markingCategory: Tail
-  speciesRestriction: [Human, SlimePerson, Vulpkanin, Oni]
+  speciesRestriction: [Human, SlimePerson, Vulpkanin, Oni, Kitsune] # Floof - M3739 - TaskKitsunebi2 - Give Kitsune access to Kemonomimi markings
   coloring:
     default:
       type:
@@ -116,7 +116,7 @@
   id: HorseTailCulty
   bodyPart: Tail
   markingCategory: Tail
-  speciesRestriction: [Human, SlimePerson, Vulpkanin, Oni]
+  speciesRestriction: [Human, SlimePerson, Vulpkanin, Oni, Kitsune] # Floof - M3739 - TaskKitsunebi2 - Give Kitsune access to Kemonomimi markings
   coloring:
     default:
       type:
@@ -134,7 +134,7 @@
   id: HorseTailLong
   bodyPart: Tail
   markingCategory: Tail
-  speciesRestriction: [Human, SlimePerson, Vulpkanin, Oni]
+  speciesRestriction: [Human, SlimePerson, Vulpkanin, Oni, Kitsune] # Floof - M3739 - TaskKitsunebi2 - Give Kitsune access to Kemonomimi markings
   coloring:
     default:
       type:
@@ -152,7 +152,7 @@
   id: SharkTail
   bodyPart: Tail
   markingCategory: Tail
-  speciesRestriction: [Human, SlimePerson, Vulpkanin, Reptilian, Oni]
+  speciesRestriction: [Human, SlimePerson, Vulpkanin, Reptilian, Oni, Kitsune] # Floof - M3739 - TaskKitsunebi2 - Give Kitsune access to Kemonomimi markings
   coloring:
     default:
       type:
@@ -170,7 +170,7 @@
   id: TasselTail
   bodyPart: Tail
   markingCategory: Tail
-  speciesRestriction: [Human, SlimePerson, Vulpkanin, Oni]
+  speciesRestriction: [Human, SlimePerson, Vulpkanin, Oni, Kitsune] # Floof - M3739 - TaskKitsunebi2 - Give Kitsune access to Kemonomimi markings
   coloring:
     default:
       type:

--- a/Resources/Prototypes/Entities/Mobs/Customization/Markings/kemonomimi_tails.yml
+++ b/Resources/Prototypes/Entities/Mobs/Customization/Markings/kemonomimi_tails.yml
@@ -2,7 +2,7 @@
   id: BunnyTail
   bodyPart: Tail
   markingCategory: Tail
-  speciesRestriction: [Human, SlimePerson, Vulpkanin, Oni, Kitsune] # Floof - M3739 - TaskKitsunebi2 - Give Kitsune access to Kemonomimi markings
+  speciesRestriction: [Human, SlimePerson, Vulpkanin, Oni, Kitsune] # Floof - M3739 - #1062 - Give Kitsune access to Kemonomimi markings
   coloring:
     default:
       type:
@@ -20,7 +20,7 @@
   id: BunnyTailAlt
   bodyPart: Tail
   markingCategory: Tail
-  speciesRestriction: [Human, SlimePerson, Vulpkanin, Oni, Kitsune] # Floof - M3739 - TaskKitsunebi2 - Give Kitsune access to Kemonomimi markings
+  speciesRestriction: [Human, SlimePerson, Vulpkanin, Oni, Kitsune] # Floof - M3739 - #1062 - Give Kitsune access to Kemonomimi markings
   coloring:
     default:
       type:
@@ -38,7 +38,7 @@
   id: DobleFur
   bodyPart: Tail
   markingCategory: Tail
-  speciesRestriction: [Human, SlimePerson, Vulpkanin, Oni, Kitsune] # Floof - M3739 - TaskKitsunebi2 - Give Kitsune access to Kemonomimi markings
+  speciesRestriction: [Human, SlimePerson, Vulpkanin, Oni, Kitsune] # Floof - M3739 - #1062 - Give Kitsune access to Kemonomimi markings
   coloring:
     default:
       type:
@@ -58,7 +58,7 @@
   id: FluffyTail
   bodyPart: Tail
   markingCategory: Tail
-  speciesRestriction: [Human, SlimePerson, Vulpkanin, Oni, Kitsune] # Floof - M3739 - TaskKitsunebi2 - Give Kitsune access to Kemonomimi markings
+  speciesRestriction: [Human, SlimePerson, Vulpkanin, Oni, Kitsune] # Floof - M3739 - #1062 - Give Kitsune access to Kemonomimi markings
   coloring:
     default:
       type:
@@ -76,7 +76,7 @@
   id: FoxNineTails
   bodyPart: Tail
   markingCategory: Tail
-  speciesRestriction: [Human, SlimePerson, Vulpkanin, Oni, Kitsune] # Floof - M3739 - TaskKitsunebi2 - Give Kitsune access to Kemonomimi markings
+  speciesRestriction: [Human, SlimePerson, Vulpkanin, Oni, Kitsune] # Floof - M3739 - #1062 - Give Kitsune access to Kemonomimi markings
   coloring:
     default:
       type:
@@ -96,7 +96,7 @@
   id: FoxThreeTails
   bodyPart: Tail
   markingCategory: Tail
-  speciesRestriction: [Human, SlimePerson, Vulpkanin, Oni, Kitsune] # Floof - M3739 - TaskKitsunebi2 - Give Kitsune access to Kemonomimi markings
+  speciesRestriction: [Human, SlimePerson, Vulpkanin, Oni, Kitsune] # Floof - M3739 - #1062 - Give Kitsune access to Kemonomimi markings
   coloring:
     default:
       type:
@@ -116,7 +116,7 @@
   id: HorseTailCulty
   bodyPart: Tail
   markingCategory: Tail
-  speciesRestriction: [Human, SlimePerson, Vulpkanin, Oni, Kitsune] # Floof - M3739 - TaskKitsunebi2 - Give Kitsune access to Kemonomimi markings
+  speciesRestriction: [Human, SlimePerson, Vulpkanin, Oni, Kitsune] # Floof - M3739 - #1062 - Give Kitsune access to Kemonomimi markings
   coloring:
     default:
       type:
@@ -134,7 +134,7 @@
   id: HorseTailLong
   bodyPart: Tail
   markingCategory: Tail
-  speciesRestriction: [Human, SlimePerson, Vulpkanin, Oni, Kitsune] # Floof - M3739 - TaskKitsunebi2 - Give Kitsune access to Kemonomimi markings
+  speciesRestriction: [Human, SlimePerson, Vulpkanin, Oni, Kitsune] # Floof - M3739 - #1062 - Give Kitsune access to Kemonomimi markings
   coloring:
     default:
       type:
@@ -152,7 +152,7 @@
   id: SharkTail
   bodyPart: Tail
   markingCategory: Tail
-  speciesRestriction: [Human, SlimePerson, Vulpkanin, Reptilian, Oni, Kitsune] # Floof - M3739 - TaskKitsunebi2 - Give Kitsune access to Kemonomimi markings
+  speciesRestriction: [Human, SlimePerson, Vulpkanin, Reptilian, Oni, Kitsune] # Floof - M3739 - #1062 - Give Kitsune access to Kemonomimi markings
   coloring:
     default:
       type:
@@ -170,7 +170,7 @@
   id: TasselTail
   bodyPart: Tail
   markingCategory: Tail
-  speciesRestriction: [Human, SlimePerson, Vulpkanin, Oni, Kitsune] # Floof - M3739 - TaskKitsunebi2 - Give Kitsune access to Kemonomimi markings
+  speciesRestriction: [Human, SlimePerson, Vulpkanin, Oni, Kitsune] # Floof - M3739 - #1062 - Give Kitsune access to Kemonomimi markings
   coloring:
     default:
       type:

--- a/Resources/Prototypes/_Floof/Entities/Mobs/Customization/Markings/anthro.yml
+++ b/Resources/Prototypes/_Floof/Entities/Mobs/Customization/Markings/anthro.yml
@@ -14,7 +14,7 @@
 #  id: SnoutCanidAlt
 #  bodyPart: Snout
 #  markingCategory: Snout
-#  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni]
+#  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni, Kitsune]
 #  sprites:
 #  - sprite: _Floof/Mobs/Customization/skyratsnouts.rsi
 #    state: snout_canid_alt
@@ -100,7 +100,7 @@
 #  id: SnoutFHusky
 #  bodyPart: Snout
 #  markingCategory: Snout
-#  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni]
+#  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni, Kitsune]
 #  sprites:
 #  - sprite: _Floof/Mobs/Customization/skyratsnouts.rsi
 #    state: snout_fhusky_primary
@@ -122,7 +122,7 @@
 #  id: SnoutFWolf
 #  bodyPart: Snout
 #  markingCategory: Snout
-#  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni]
+#  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni, Kitsune]
 #  sprites:
 #  - sprite: _Floof/Mobs/Customization/skyratsnouts.rsi
 #    state: snout_fwolf_primary
@@ -144,7 +144,7 @@
 #  id: SnoutFWolfAlt
 #  bodyPart: Snout
 #  markingCategory: Snout
-#  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni]
+#  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni, Kitsune]
 #  sprites:
 #  - sprite: _Floof/Mobs/Customization/skyratsnouts.rsi
 #    state: snout_fwolfalt_primary
@@ -184,7 +184,7 @@
 #  id: SnoutFSCanidAlt
 #  bodyPart: Snout
 #  markingCategory: Snout
-#  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni]
+#  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni, Kitsune]
 #  sprites:
 #  - sprite: _Floof/Mobs/Customization/skyratsnouts.rsi
 #    state: snout_fscanidalt_primary
@@ -195,7 +195,7 @@
 #  id: SnoutFSCanidAlt2
 #  bodyPart: Snout
 #  markingCategory: Snout
-#  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni]
+#  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni, Kitsune]
 #  sprites:
 #  - sprite: _Floof/Mobs/Customization/skyratsnouts.rsi
 #    state: snout_fscanidalt2_primary
@@ -204,7 +204,7 @@
 #  id: SnoutFSCanidAlt3
 #  bodyPart: Snout
 #  markingCategory: Snout
-#  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni]
+#  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni, Kitsune]
 #  sprites:
 #  - sprite: _Floof/Mobs/Customization/skyratsnouts.rsi
 #    state: snout_fscanidalt3_primary
@@ -228,7 +228,7 @@
   id: SnoutRound
   bodyPart: Snout
   markingCategory: Snout
-  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni]
+  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni, Kitsune]
   sprites:
   - sprite: _Floof/Mobs/Customization/skyratsnouts.rsi
     state: snout_round
@@ -237,7 +237,7 @@
   id: SnoutSharp
   bodyPart: Snout
   markingCategory: Snout
-  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni]
+  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni, Kitsune]
   sprites:
   - sprite: _Floof/Mobs/Customization/skyratsnouts.rsi
     state: snout_sharp
@@ -246,7 +246,7 @@
   id: SnoutRoundLight
   bodyPart: Snout
   markingCategory: Snout
-  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni]
+  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni, Kitsune]
   sprites:
   - sprite: _Floof/Mobs/Customization/skyratsnouts.rsi
     state: snout_roundlight
@@ -255,7 +255,7 @@
   id: SnoutSharpLight
   bodyPart: Snout
   markingCategory: Snout
-  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni]
+  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni, Kitsune]
   sprites:
   - sprite: _Floof/Mobs/Customization/skyratsnouts.rsi
     state: snout_sharplight
@@ -266,7 +266,7 @@
 #  id: SnoutFBird
 #  bodyPart: Snout
 #  markingCategory: Snout
-#  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni]
+#  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni, Kitsune]
 #  sprites:
 #  - sprite: _Floof/Mobs/Customization/skyratsnouts.rsi
 #    state: snout_fbird_primary
@@ -279,7 +279,7 @@
   id: SnoutBird
   bodyPart: Snout
   markingCategory: Snout
-  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni]
+  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni, Kitsune]
   sprites:
   - sprite: _Floof/Mobs/Customization/skyratsnouts.rsi
     state: snout_bird_primary
@@ -292,7 +292,7 @@
 #  id: SnoutFBigBeak
 #  bodyPart: Snout
 #  markingCategory: Snout
-#  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni]
+#  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni, Kitsune]
 #  sprites:
 #  - sprite: _Floof/Mobs/Customization/skyratsnouts.rsi
 #    state: snout_fbigbeak_primary
@@ -301,7 +301,7 @@
   id: SnoutBigBeak
   bodyPart: Snout
   markingCategory: Snout
-  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni]
+  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni, Kitsune]
   sprites:
   - sprite: _Floof/Mobs/Customization/skyratsnouts.rsi
     state: snout_bigbeak_primary
@@ -310,7 +310,7 @@
 #  id: SnoutFCorvidBeak
 #  bodyPart: Snout
 #  markingCategory: Snout
-#  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni]
+#  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni, Kitsune]
 #  sprites:
 #  - sprite: _Floof/Mobs/Customization/skyratsnouts.rsi
 #    state: snout_fcorvidbeak_primary
@@ -319,7 +319,7 @@
 #  id: SnoutFToucan
 #  bodyPart: Snout
 #  markingCategory: Snout
-#  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni]
+#  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni, Kitsune]
 #  sprites:
 #  - sprite: _Floof/Mobs/Customization/skyratsnouts.rsi
 #    state: snout_ftoucan_primary
@@ -330,7 +330,7 @@
   id: SnoutToucan
   bodyPart: Snout
   markingCategory: Snout
-  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni]
+  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni, Kitsune]
   sprites:
   - sprite: _Floof/Mobs/Customization/skyratsnouts.rsi
     state: snout_toucan_primary
@@ -341,7 +341,7 @@
   id: SnoutBirdSmall
   bodyPart: Snout
   markingCategory: Snout
-  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni]
+  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni, Kitsune]
   sprites:
   - sprite: _Floof/Mobs/Customization/skyratsnouts.rsi
     state: snout_birdsmall_primary
@@ -354,7 +354,7 @@
   id: SnoutBigBeakShort
   bodyPart: Snout
   markingCategory: Snout
-  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni]
+  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni, Kitsune]
   sprites:
   - sprite: _Floof/Mobs/Customization/skyratsnouts.rsi
     state: snout_bigbeakshort_primary
@@ -363,7 +363,7 @@
   id: SnoutSlimBeak
   bodyPart: Snout
   markingCategory: Snout
-  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni]
+  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni, Kitsune]
   sprites:
   - sprite: _Floof/Mobs/Customization/skyratsnouts.rsi
     state: snout_slimbeak_primary
@@ -372,7 +372,7 @@
   id: SnoutSlimBeakAlt
   bodyPart: Snout
   markingCategory: Snout
-  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni]
+  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni, Kitsune]
   sprites:
   - sprite: _Floof/Mobs/Customization/skyratsnouts.rsi
     state: snout_slimbeakalt_primary
@@ -381,7 +381,7 @@
   id: SnoutSlimBeakShort
   bodyPart: Snout
   markingCategory: Snout
-  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni]
+  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni, Kitsune]
   sprites:
   - sprite: _Floof/Mobs/Customization/skyratsnouts.rsi
     state: snout_slimbeakshort_primary
@@ -390,7 +390,7 @@
   id: SnoutHookBeak
   bodyPart: Snout
   markingCategory: Snout
-  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni]
+  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni, Kitsune]
   sprites:
   - sprite: _Floof/Mobs/Customization/skyratsnouts.rsi
     state: snout_hookbeak_primary
@@ -399,7 +399,7 @@
   id: SnoutHookBeakBig
   bodyPart: Snout
   markingCategory: Snout
-  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni]
+  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni, Kitsune]
   sprites:
   - sprite: _Floof/Mobs/Customization/skyratsnouts.rsi
     state: snout_hookbeakbig_primary
@@ -410,7 +410,7 @@
 #  id: SnoutFWah
 #  bodyPart: Snout
 #  markingCategory: Snout
-#  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni]
+#  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni, Kitsune]
 #  sprites:
 #  - sprite: _Floof/Mobs/Customization/skyratsnouts.rsi
 #    state:  snout_fwah_primary
@@ -423,7 +423,7 @@
   id: SnoutWah
   bodyPart: Snout
   markingCategory: Snout
-  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni]
+  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni, Kitsune]
   sprites:
   - sprite: _Floof/Mobs/Customization/skyratsnouts.rsi
     state:  snout_wah_primary
@@ -436,7 +436,7 @@
 #  id: SnoutFWahAlt
 #  bodyPart: Snout
 #  markingCategory: Snout
-#  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni]
+#  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni, Kitsune]
 #  sprites:
 #  - sprite: _Floof/Mobs/Customization/skyratsnouts.rsi
 #    state:  snout_fwahalt_primary
@@ -447,7 +447,7 @@
   id: SnoutWahAlt
   bodyPart: Snout
   markingCategory: Snout
-  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni]
+  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni, Kitsune]
   sprites:
   - sprite: _Floof/Mobs/Customization/skyratsnouts.rsi
     state:  snout_wahalt_primary
@@ -458,7 +458,7 @@
 #  id: SnoutFOtie
 #  bodyPart: Snout
 #  markingCategory: Snout
-#  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni]
+#  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni, Kitsune]
 #  sprites:
 #  - sprite: _Floof/Mobs/Customization/skyratsnouts.rsi
 #    state:  snout_fotie_primary
@@ -469,7 +469,7 @@
   id: SnoutOtie
   bodyPart: Snout
   markingCategory: Snout
-  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni]
+  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni, Kitsune]
   sprites:
   - sprite: _Floof/Mobs/Customization/skyratsnouts.rsi
     state:  snout_otie_primary
@@ -480,7 +480,7 @@
 #  id: SnoutFOtieSmile
 #  bodyPart: Snout
 #  markingCategory: Snout
-#  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni]
+#  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni, Kitsune]
 #  sprites:
 #  - sprite: _Floof/Mobs/Customization/skyratsnouts.rsi
 #    state:  snout_fotiesmile_primary
@@ -491,7 +491,7 @@
   id: SnoutOtieSmile
   bodyPart: Snout
   markingCategory: Snout
-  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni]
+  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni, Kitsune]
   sprites:
   - sprite: _Floof/Mobs/Customization/skyratsnouts.rsi
     state:  snout_otiesmile_primary
@@ -502,7 +502,7 @@
 #  id: SnoutFPede
 #  bodyPart: Snout
 #  markingCategory: Snout
-#  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni]
+#  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni, Kitsune]
 #  sprites:
 #  - sprite: _Floof/Mobs/Customization/skyratsnouts.rsi
 #    state:  snout_fpede_primary
@@ -513,7 +513,7 @@
   id: SnoutPede
   bodyPart: Snout
   markingCategory: Snout
-  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni]
+  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni, Kitsune]
   sprites:
   - sprite: _Floof/Mobs/Customization/skyratsnouts.rsi
     state:  snout_pede_primary
@@ -524,7 +524,7 @@
 #  id: SnoutFRodent
 #  bodyPart: Snout
 #  markingCategory: Snout
-#  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni]
+#  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni, Kitsune]
 #  sprites:
 #  - sprite: _Floof/Mobs/Customization/skyratsnouts.rsi
 #    state:  snout_frodent_primary
@@ -533,7 +533,7 @@
   id: SnoutRodent
   bodyPart: Snout
   markingCategory: Snout
-  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni]
+  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni, Kitsune]
   sprites:
   - sprite: _Floof/Mobs/Customization/skyratsnouts.rsi
     state:  snout_rodent_primary
@@ -542,7 +542,7 @@
 #  id: SnoutFSergal
 #  bodyPart: Snout
 #  markingCategory: Snout
-#  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni]
+#  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni, Kitsune]
 #  sprites:
 #  - sprite: _Floof/Mobs/Customization/skyratsnouts.rsi
 #    state:  snout_fsergal_primary
@@ -553,7 +553,7 @@
 #  id: SnoutFRhino
 #  bodyPart: Snout
 #  markingCategory: Snout
-#  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni]
+#  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni, Kitsune]
 #  sprites:
 #  - sprite: _Floof/Mobs/Customization/skyratsnouts.rsi
 #    state:  snout_frhino_primary
@@ -564,7 +564,7 @@
   id: SnoutRhino
   bodyPart: Snout
   markingCategory: Snout
-  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni]
+  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni, Kitsune]
   sprites:
   - sprite: _Floof/Mobs/Customization/skyratsnouts.rsi
     state:  snout_rhino_primary
@@ -577,7 +577,7 @@
 #  id: SnoutFBovine
 #  bodyPart: Snout
 #  markingCategory: Snout
-#  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni]
+#  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni, Kitsune]
 #  sprites:
 #  - sprite: _Floof/Mobs/Customization/skyratsnouts.rsi
 #    state:  snout_fbovine_primary
@@ -590,7 +590,7 @@
   id: SnoutBovine
   bodyPart: Snout
   markingCategory: Snout
-  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni]
+  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni, Kitsune]
   sprites:
   - sprite: _Floof/Mobs/Customization/skyratsnouts.rsi
     state:  snout_bovine_primary
@@ -603,7 +603,7 @@
 #  id: SnoutFElephant
 #  bodyPart: Snout
 #  markingCategory: Snout
-#  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni]
+#  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni, Kitsune]
 #  sprites:
 #  - sprite: _Floof/Mobs/Customization/skyratsnouts.rsi
 #    state:  snout_felephant_primary
@@ -614,7 +614,7 @@
   id: SnoutElephant
   bodyPart: Snout
   markingCategory: Snout
-  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni]
+  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni, Kitsune]
   sprites:
   - sprite: _Floof/Mobs/Customization/skyratsnouts.rsi
     state:  snout_elephant_primary
@@ -625,7 +625,7 @@
 #  id: SnoutFRound
 #  bodyPart: Snout
 #  markingCategory: Snout
-#  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni]
+#  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni, Kitsune]
 #  sprites:
 #  - sprite: _Floof/Mobs/Customization/skyratsnouts.rsi
 #    state:  snout_fround
@@ -634,7 +634,7 @@
 #  id: SnoutFSharpLight
 #  bodyPart: Snout
 #  markingCategory: Snout
-#  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni]
+#  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni, Kitsune]
 #  sprites:
 #  - sprite: _Floof/Mobs/Customization/skyratsnouts.rsi
 #    state:  snout_fsharplight
@@ -643,7 +643,7 @@
 #  id: SnoutFRoundLight
 #  bodyPart: Snout
 #  markingCategory: Snout
-#  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni]
+#  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni, Kitsune]
 #  sprites:
 #  - sprite: _Floof/Mobs/Customization/skyratsnouts.rsi
 #    state:  snout_froundlight
@@ -652,7 +652,7 @@
 #  id: SnoutFShark
 #  bodyPart: Snout
 #  markingCategory: Snout
-#  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni]
+#  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni, Kitsune]
 #  sprites:
 #  - sprite: _Floof/Mobs/Customization/skyratsnouts.rsi
 #    state:  snout_fshark_primary
@@ -661,7 +661,7 @@
   id: SnoutShark
   bodyPart: Snout
   markingCategory: Snout
-  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni]
+  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni, Kitsune]
   sprites:
   - sprite: _Floof/Mobs/Customization/skyratsnouts.rsi
     state:  snout_shark_primary
@@ -670,7 +670,7 @@
   id: SnoutHShark
   bodyPart: Snout
   markingCategory: Snout
-  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni]
+  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni, Kitsune]
   sprites:
   - sprite: _Floof/Mobs/Customization/skyratsnouts.rsi
     state:  snout_hshark_primary
@@ -681,7 +681,7 @@
   id: SnoutHSharkEyes
   bodyPart: Snout
   markingCategory: Snout
-  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni]
+  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni, Kitsune]
   sprites:
   - sprite: _Floof/Mobs/Customization/skyratsnouts.rsi
     state:  snout_hshark_eyes_primary
@@ -692,7 +692,7 @@
 #  id: SnoutFBug
 #  bodyPart: Snout
 #  markingCategory: Snout
-#  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni]
+#  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni, Kitsune]
 #  colorLinks:
 #    snout_fbug_FRONT_primary: snout_fbug_primary
 #  sprites:
@@ -707,7 +707,7 @@
   id: SnoutBug
   bodyPart: Snout
   markingCategory: Snout
-  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni]
+  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni, Kitsune]
   sprites:
   - sprite: _Floof/Mobs/Customization/skyratsnouts.rsi
     state:  snout_bug_primary
@@ -718,7 +718,7 @@
   id: SnoutBugNoEyes
   bodyPart: Snout
   markingCategory: Snout
-  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni]
+  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni, Kitsune]
   sprites:
   - sprite: _Floof/Mobs/Customization/skyratsnouts.rsi
     state:  snout_bug_no_eyes
@@ -727,7 +727,7 @@
   id: SnoutSergal
   bodyPart: Snout
   markingCategory: Snout
-  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni]
+  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni, Kitsune]
   sprites:
   - sprite: _Floof/Mobs/Customization/skyratsnouts.rsi
     state:  snout_sergal_primary
@@ -738,7 +738,7 @@
   id: SnoutHHorse
   bodyPart: Snout
   markingCategory: Snout
-  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni]
+  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni, Kitsune]
   sprites:
   - sprite: _Floof/Mobs/Customization/skyratsnouts.rsi
     state:  snout_hhorse_primary
@@ -749,7 +749,7 @@
   id: SnoutHZebra
   bodyPart: Snout
   markingCategory: Snout
-  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni]
+  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni, Kitsune]
   sprites:
   - sprite: _Floof/Mobs/Customization/skyratsnouts.rsi
     state:  snout_hzebra_primary
@@ -760,7 +760,7 @@
   id: SnoutHAnubus
   bodyPart: Snout
   markingCategory: Snout
-  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni]
+  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni, Kitsune]
   sprites:
   - sprite: _Floof/Mobs/Customization/skyratsnouts.rsi
     state:  snout_hanubus_primary
@@ -771,7 +771,7 @@
   id: SnoutHPanda
   bodyPart: Snout
   markingCategory: Snout
-  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni]
+  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni, Kitsune]
   sprites:
   - sprite: _Floof/Mobs/Customization/skyratsnouts.rsi
     state:  snout_hpanda_primary
@@ -793,7 +793,7 @@
   id: SnoutHSpots
   bodyPart: Snout
   markingCategory: Snout
-  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni]
+  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni, Kitsune]
   sprites:
   - sprite: _Floof/Mobs/Customization/skyratsnouts.rsi
     state: snout_hspots_primary
@@ -804,7 +804,7 @@
 #  id: SnoutFSkulldog
 #  bodyPart: Snout
 #  markingCategory: Snout
-#  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni]
+#  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni, Kitsune]
 #  sprites:
 #  - sprite: _Floof/Mobs/Customization/skyratsnouts.rsi
 #    state: snout_fskulldog_primary
@@ -830,7 +830,7 @@
   id: SnoutSharkBlubber
   bodyPart: Snout
   markingCategory: Snout
-  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni]
+  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni, Kitsune]
   sprites:
   - sprite: _Floof/Mobs/Customization/skyratsnouts.rsi
     state: snout_sharkblubber_primary
@@ -841,7 +841,7 @@
   id: SnoutRat
   bodyPart: Snout
   markingCategory: Snout
-  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni]
+  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni, Kitsune]
   sprites:
   - sprite: _Floof/Mobs/Customization/skyratsnouts.rsi
     state: snout_rat_primary
@@ -852,7 +852,7 @@
   id: SnoutNTajaran
   bodyPart: Snout
   markingCategory: Snout
-  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni]
+  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni, Kitsune]
   sprites:
   - sprite: _Floof/Mobs/Customization/skyratsnouts.rsi
     state: snout_ntajaran
@@ -872,7 +872,7 @@
   id: SnoutLeporid
   bodyPart: Snout
   markingCategory: Snout
-  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni]
+  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni, Kitsune]
   sprites:
   - sprite: _Floof/Mobs/Customization/skyratsnouts.rsi
     state: snout_leporid_primary

--- a/Resources/Prototypes/_Floof/Entities/Mobs/Customization/Markings/anthro_ears.yml
+++ b/Resources/Prototypes/_Floof/Entities/Mobs/Customization/Markings/anthro_ears.yml
@@ -15,7 +15,7 @@
   id: EarsAntennaFuzzball
   bodyPart: HeadTop
   markingCategory: HeadTop
-  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid]
+  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Kitsune]
   colorLinks:
     m_ears_antenna_fuzzball_ADJ_secondary: m_ears_antenna_fuzzball_FRONT_secondary
     m_ears_antenna_fuzzball_ADJ_tertiary: m_ears_antenna_fuzzball_FRONT_tertiary
@@ -33,7 +33,7 @@
   id: EarsAntennaFuzzballv2
   bodyPart: HeadTop
   markingCategory: HeadTop
-  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid]
+  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Kitsune]
   colorLinks:
     m_ears_antenna_fuzzballv2_ADJ_primary: m_ears_antenna_fuzzballv2_FRONT_primary
     m_ears_antenna_fuzzballv2_ADJ_tertiary: m_ears_antenna_fuzzballv2_FRONT_tertiary
@@ -51,7 +51,7 @@
   id: EarsAntennaSimple1
   bodyPart: HeadTop
   markingCategory: HeadTop
-  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid]
+  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Kitsune]
   colorLinks:
     m_ears_antenna_simple1_ADJ_primary: m_ears_antenna_simple1_FRONT_primary
   sprites:
@@ -64,7 +64,7 @@
   id: EarsAntennaSimple1v2
   bodyPart: HeadTop
   markingCategory: HeadTop
-  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid]
+  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Kitsune]
   colorLinks:
     m_ears_antenna_simple1v2_ADJ_primary: m_ears_antenna_simple1v2_FRONT_primary
   sprites:
@@ -77,7 +77,7 @@
   id: EarsAntennaSimple2
   bodyPart: HeadTop
   markingCategory: HeadTop
-  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid]
+  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Kitsune]
   colorLinks:
     m_ears_antenna_simple2_ADJ_primary: m_ears_antenna_simple2_FRONT_primary
   sprites:
@@ -90,7 +90,7 @@
   id: EarsAntennaSimple2v2
   bodyPart: HeadTop
   markingCategory: HeadTop
-  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid]
+  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Kitsune]
   colorLinks:
     m_ears_antenna_simple2v2_ADJ_primary: m_ears_antenna_simple2v2_FRONT_primary
   sprites:
@@ -103,7 +103,7 @@
   id: EarsAxolotl
   bodyPart: HeadTop
   markingCategory: HeadTop
-  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid]
+  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Kitsune]
   colorLinks:
     m_ears_axolotl_ADJ: m_ears_axolotl_FRONT
   sprites:
@@ -116,7 +116,7 @@
   id: EarsBat
   bodyPart: HeadTop
   markingCategory: HeadTop
-  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid]
+  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Kitsune]
   sprites:
   - sprite: _Floof/Mobs/Customization/skyratears.rsi
     state: m_ears_bat_ADJ_primary
@@ -127,7 +127,7 @@
   id: EarsBear
   bodyPart: HeadTop
   markingCategory: HeadTop
-  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid]
+  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Kitsune]
   colorLinks:
     m_ears_bear_ADJ: m_ears_bear_FRONT
   sprites:
@@ -142,7 +142,7 @@
 #  id: EarsBigWolf
 #  bodyPart: HeadTop
 #  markingCategory: HeadTop
-#  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid]
+#  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Kitsune]
 #  colorLinks:
 #    m_ears_bigwolf_ADJ_primary: m_ears_bigwolf_FRONT_primary
 #    m_ears_bigwolfinner_ADJ: m_ears_bigwolfinner_FRONT
@@ -164,7 +164,7 @@
 #  id: EarsBigWolfDark
 #  bodyPart: HeadTop
 #  markingCategory: HeadTop
-#  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid]
+#  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Kitsune]
 #  colorLinks:
 #    m_ears_bigwolfdark_ADJ_primary: m_ears_bigwolfdark_FRONT_primary
 #    m_ears_bigwolfinnerdark_ADJ: m_ears_bigwolfinnerdark_FRONT
@@ -186,7 +186,7 @@
   id: EarsBunny
   bodyPart: HeadTop
   markingCategory: HeadTop
-  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid]
+  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Kitsune]
   colorLinks:
     m_ears_bunny_ADJ_primary: m_ears_bunny_FRONT_primary
   sprites:
@@ -201,7 +201,7 @@
   id: EarsBunnyAlt
   bodyPart: HeadTop
   markingCategory: HeadTop
-  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid]
+  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Kitsune]
   colorLinks:
     m_ears_bunnyalt_ADJ_primary: m_ears_bunnyalt_FRONT_primary
     m_ears_bunnyalt_ADJ_secondary: m_ears_bunnyalt_FRONT_secondary
@@ -219,7 +219,7 @@
   id: EarsCatBig
   bodyPart: HeadTop
   markingCategory: HeadTop
-  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid]
+  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Kitsune]
   colorLinks:
     m_ears_catbig_ADJ_primary: m_ears_catbig_FRONT_primary
     m_ears_catbig_ADJ_secondary: m_ears_catbig_FRONT_secondary
@@ -237,7 +237,7 @@
   id: EarsCatNormal
   bodyPart: HeadTop
   markingCategory: HeadTop
-  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid]
+  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Kitsune]
   colorLinks:
     m_ears_catnormal_ADJ_primary: m_ears_catnormal_FRONT_primary
     m_ears_catnormal_ADJ_secondary: m_ears_catnormal_FRONT_secondary
@@ -255,7 +255,7 @@
   id: EarsCobraEars
   bodyPart: HeadTop
   markingCategory: HeadTop
-  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid]
+  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Kitsune]
   sprites:
   - sprite: _Floof/Mobs/Customization/skyratears.rsi
     state: m_ears_cobraears_ADJ_primary
@@ -266,7 +266,7 @@
   id: EarsCobraHood
   bodyPart: HeadTop
   markingCategory: HeadTop
-  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid]
+  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Kitsune]
   sprites:
   - sprite: _Floof/Mobs/Customization/skyratears.rsi
     state: m_ears_cobrahood_ADJ_primary
@@ -277,7 +277,7 @@
   id: EarsCow
   bodyPart: HeadTop
   markingCategory: HeadTop
-  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid]
+  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Kitsune]
   colorLinks:
     m_ears_cow_ADJ: m_ears_cow_FRONT
   sprites:
@@ -290,7 +290,7 @@
   id: EarsDeer
   bodyPart: HeadTop
   markingCategory: HeadTop
-  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid]
+  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Kitsune]
   colorLinks:
     m_ears_cow_ADJ: m_ears_cow_FRONT
   sprites:
@@ -303,7 +303,7 @@
   id: EarsDeer2
   bodyPart: HeadTop
   markingCategory: HeadTop
-  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid]
+  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Kitsune]
   colorLinks:
     m_ears_cow_ADJ: m_ears_cow_FRONT
   sprites:
@@ -316,7 +316,7 @@
   id: EarsDeerEar
   bodyPart: HeadTop
   markingCategory: HeadTop
-  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid]
+  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Kitsune]
   colorLinks:
     m_ears_deerear_ADJ_primary: m_ears_deerear_FRONT_primary
     m_ears_deerear_ADJ_secondary: m_ears_deerear_FRONT_secondary
@@ -370,7 +370,7 @@
   id: EarsElephant
   bodyPart: HeadTop
   markingCategory: HeadTop
-  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid]
+  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Kitsune]
   colorLinks:
     m_ears_elephant_ADJ: m_ears_elephant_FRONT
   sprites:
@@ -383,7 +383,7 @@
   id: EarsElf
   bodyPart: HeadTop
   markingCategory: HeadTop
-  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid]
+  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Kitsune]
   colorLinks:
     m_ears_elf_ADJ: m_ears_elf_FRONT
   sprites:
@@ -396,7 +396,7 @@
   id: EarsElfBroad
   bodyPart: HeadTop
   markingCategory: HeadTop
-  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid]
+  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Kitsune]
   colorLinks:
     m_ears_elfbroad_ADJ: m_ears_elfbroad_FRONT
   sprites:
@@ -409,7 +409,7 @@
   id: EarsElfLonger
   bodyPart: HeadTop
   markingCategory: HeadTop
-  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid]
+  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Kitsune]
   colorLinks:
     m_ears_elflonger_ADJ: m_ears_elflonger_FRONT
   sprites:
@@ -422,7 +422,7 @@
   id: EarsElfWide
   bodyPart: HeadTop
   markingCategory: HeadTop
-  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid]
+  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Kitsune]
   colorLinks:
     m_ears_elfwide_ADJ: m_ears_elfwide_FRONT
   sprites:
@@ -466,7 +466,7 @@
   id: EarsFish
   bodyPart: HeadTop
   markingCategory: HeadTop
-  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid]
+  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Kitsune]
   colorLinks:
     m_ears_fish_ADJ: m_ears_fish_FRONT
   sprites:
@@ -512,7 +512,7 @@
   id: EarsHammerhead
   bodyPart: HeadTop
   markingCategory: HeadTop
-  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid]
+  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Kitsune]
   sprites:
   - sprite: _Floof/Mobs/Customization/skyratears.rsi
     state: m_ears_hammerhead_FRONT_primary
@@ -523,7 +523,7 @@
   id: EarsHawk
   bodyPart: HeadTop
   markingCategory: HeadTop
-  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid]
+  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Kitsune]
   colorLinks:
     m_ears_hawk_ADJ_primary: m_ears_hawk_FRONT_primary
   sprites:
@@ -536,7 +536,7 @@
   id: EarsHorn1
   bodyPart: HeadTop
   markingCategory: HeadTop
-  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid]
+  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Kitsune]
   sprites:
   - sprite: _Floof/Mobs/Customization/skyratears.rsi
     state: m_ears_horn1_FRONT
@@ -545,7 +545,7 @@
   id: EarsJellyfish
   bodyPart: HeadTop
   markingCategory: HeadTop
-  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid]
+  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Kitsune]
   colorLinks:
     m_ears_jellyfish_ADJ: m_ears_jellyfish_FRONT
   sprites:
@@ -558,7 +558,7 @@
   id: EarsKangaroo
   bodyPart: HeadTop
   markingCategory: HeadTop
-  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid]
+  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Kitsune]
   colorLinks:
     m_ears_kangaroo_ADJ_primary: m_ears_kangaroo_FRONT_primary
     m_ears_kangaroo_ADJ_secondary: m_ears_kangaroo_FRONT_secondary
@@ -576,7 +576,7 @@
   id: EarsLab
   bodyPart: HeadTop
   markingCategory: HeadTop
-  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid]
+  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Kitsune]
   sprites:
   - sprite: _Floof/Mobs/Customization/skyratears.rsi
     state: m_ears_lab_FRONT
@@ -605,7 +605,7 @@
   id: EarsMiqote
   bodyPart: HeadTop
   markingCategory: HeadTop
-  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid]
+  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Kitsune]
   colorLinks:
     m_ears_miqote_ADJ_primary: m_ears_miqote_FRONT_primary
     m_ears_miqote_ADJ_secondary: m_ears_miqote_FRONT_secondary
@@ -623,7 +623,7 @@
   id: EarsMouse
   bodyPart: HeadTop
   markingCategory: HeadTop
-  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid]
+  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Kitsune]
   colorLinks:
     m_ears_mouse_ADJ_primary: m_ears_mouse_FRONT_primary
     m_ears_mouse_ADJ_secondary: m_ears_mouse_FRONT_secondary
@@ -643,7 +643,7 @@
   id: EarsMouse2
   bodyPart: HeadTop
   markingCategory: HeadTop
-  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid]
+  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Kitsune]
   colorLinks:
     m_ears_mouse_two_ADJ_primary: m_ears_mouse_two_FRONT_primary
     m_ears_mouse_two_ADJ_secondary: m_ears_mouse_two_FRONT_secondary
@@ -663,7 +663,7 @@
   id: EarsMurid
   bodyPart: HeadTop
   markingCategory: HeadTop
-  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid]
+  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Kitsune]
   colorLinks:
     m_ears_murid_ADJ_primary: m_ears_murid_FRONT_primary
     m_ears_murid_ADJ_secondary: m_ears_murid_FRONT_secondary
@@ -681,7 +681,7 @@
   id: EarsOtie
   bodyPart: HeadTop
   markingCategory: HeadTop
-  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid]
+  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Kitsune]
   colorLinks:
     m_ears_otie_ADJ_primary: m_ears_otie_FRONT_primary
     m_ears_otie_ADJ_secondary: m_ears_otie_FRONT_secondary
@@ -699,7 +699,7 @@
   id: EarsPede
   bodyPart: HeadTop
   markingCategory: HeadTop
-  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid]
+  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Kitsune]
   colorLinks:
     m_ears_pede_ADJ_primary: m_ears_pede_FRONT_primary
     m_ears_pede_ADJ_secondary: m_ears_pede_FRONT_secondary
@@ -735,7 +735,7 @@
   id: EarsPossum
   bodyPart: HeadTop
   markingCategory: HeadTop
-  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid]
+  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Kitsune]
   colorLinks:
     m_ears_possum_ADJ_primary: m_ears_possum_FRONT_primary
     m_ears_possum_ADJ_secondary: m_ears_possum_FRONT_secondary
@@ -753,7 +753,7 @@
 #  id: EarsProtogen
 #  bodyPart: HeadTop
 #  markingCategory: HeadTop
-#  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid]
+#  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Kitsune]
 #  colorLinks:
 #    m_ears_protogen_ADJ_primary: m_ears_protogen_FRONT_primary
 #    m_ears_protogen_ADJ_secondary: m_ears_protogen_FRONT_secondary
@@ -771,7 +771,7 @@
   id: EarsRabbit
   bodyPart: HeadTop
   markingCategory: HeadTop
-  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid]
+  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Kitsune]
   colorLinks:
     m_ears_rabbit_ADJ_primary: m_ears_rabbit_FRONT_primary
     m_ears_rabbit_ADJ_secondary: m_ears_rabbit_FRONT_secondary
@@ -789,7 +789,7 @@
   id: EarsRabbitAlt
   bodyPart: HeadTop
   markingCategory: HeadTop
-  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid]
+  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Kitsune]
   colorLinks:
     m_ears_rabbitalt_ADJ_primary: m_ears_rabbitalt_FRONT_primary
     m_ears_rabbitalt_ADJ_secondary: m_ears_rabbitalt_FRONT_secondary
@@ -807,7 +807,7 @@
   id: EarsRabbitLop
   bodyPart: HeadTop
   markingCategory: HeadTop
-  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid]
+  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Kitsune]
   colorLinks:
     m_ears_rabbitlop_ADJ_primary: m_ears_rabbitlop_FRONT_primary
     m_ears_rabbitlop_ADJ_secondary: m_ears_rabbitlop_FRONT_secondary
@@ -825,7 +825,7 @@
   id: EarsRaccoon
   bodyPart: HeadTop
   markingCategory: HeadTop
-  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid]
+  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Kitsune]
   colorLinks:
     m_ears_raccoon_ADJ_primary: m_ears_raccoon_FRONT_primary
     m_ears_raccoon_ADJ_secondary: m_ears_raccoon_FRONT_secondary
@@ -861,7 +861,7 @@
   id: EarsSergal
   bodyPart: HeadTop
   markingCategory: HeadTop
-  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid]
+  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Kitsune]
   colorLinks:
     m_ears_sergal_ADJ_primary: m_ears_sergal_FRONT_primary
   sprites:
@@ -876,7 +876,7 @@
   id: EarsSkunk
   bodyPart: HeadTop
   markingCategory: HeadTop
-  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid]
+  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Kitsune]
   colorLinks:
     m_ears_skunk_ADJ_primary: m_ears_skunk_FRONT_primary
     m_ears_skunk_ADJ_secondary: m_ears_skunk_FRONT_secondary
@@ -894,7 +894,7 @@
   id: EarsSquirrel
   bodyPart: HeadTop
   markingCategory: HeadTop
-  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid]
+  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Kitsune]
   colorLinks:
     m_ears_squirrel_ADJ_primary: m_ears_squirrel_FRONT_primary
     m_ears_squirrel_ADJ_secondary: m_ears_squirrel_FRONT_secondary
@@ -915,7 +915,7 @@
   id: EarsWolf
   bodyPart: HeadTop
   markingCategory: HeadTop
-  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid]
+  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Kitsune]
   colorLinks:
     m_ears_wolf_ADJ_primary: m_ears_wolf_FRONT_primary
     m_ears_wolf_ADJ_tertiary: m_ears_wolf_FRONT_tertiary
@@ -933,7 +933,7 @@
   id: EarsGuilmonHorns
   bodyPart: HeadTop
   markingCategory: HeadTop
-  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid]
+  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Kitsune]
   sprites:
   - sprite: _Floof/Mobs/Customization/skyratears.rsi
     state: m_horns_guilmon

--- a/Resources/Prototypes/_Floof/Entities/Mobs/Customization/Markings/anthro_tails.yml
+++ b/Resources/Prototypes/_Floof/Entities/Mobs/Customization/Markings/anthro_tails.yml
@@ -39,7 +39,7 @@
   id: TailAvian1
   bodyPart: Tail
   markingCategory: Tail
-  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni]
+  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni, Kitsune]
   layering:
     m_tail_avian1_BEHIND_primary: TailBehind
     m_tail_avian1_BEHIND_secondary: TailBehind
@@ -63,7 +63,7 @@
   id: TailAvian2
   bodyPart: Tail
   markingCategory: Tail
-  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni]
+  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni, Kitsune]
   layering:
     m_tail_avian2_BEHIND_primary: TailBehind
     m_tail_avian2_BEHIND_secondary: TailBehind
@@ -86,7 +86,7 @@
   id: TailBatl
   bodyPart: Tail
   markingCategory: Tail
-  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni]
+  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni, Kitsune]
   layering:
     m_tail_batl_BEHIND_primary: TailBehind
     m_tail_batl_BEHIND_secondary: TailBehind
@@ -109,7 +109,7 @@
   id: TailBats
   bodyPart: Tail
   markingCategory: Tail
-  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni]
+  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni, Kitsune]
   layering:
     m_tail_bats_BEHIND_primary: TailBehind
     m_tail_bats_BEHIND_secondary: TailBehind
@@ -140,7 +140,7 @@
   colorLinks:
     m_tail_bee_BEHIND_primary: m_tail_bee_FRONT_primary
     m_tail_bee_BEHIND_secondary: m_tail_bee_FRONT_secondary
-  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni]
+  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni, Kitsune]
   sprites:
   - sprite: _Floof/Mobs/Customization/skyrattails.rsi
     state: m_tail_bee_FRONT_primary
@@ -156,7 +156,7 @@
   id: TailCable
   bodyPart: Tail
   markingCategory: Tail
-  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni]
+  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni, Kitsune]
   layering:
     m_tail_cable_BEHIND_primary: TailBehind
     m_tail_cable_BEHIND_secondary: TailBehind
@@ -175,7 +175,7 @@
   id: TailCat
   bodyPart: Tail
   markingCategory: Tail
-  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni]
+  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni, Kitsune]
   layering:
     m_tail_cat_BEHIND: TailBehind
     m_tail_cat_FRONT: Tail #should go over backpack!
@@ -191,7 +191,7 @@
   id: TailCatBig
   bodyPart: Tail
   markingCategory: Tail
-  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni]
+  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni, Kitsune]
   layering:
     m_tail_catbig_BEHIND: TailBehind
     m_tail_catbig_FRONT: TailOversuit
@@ -207,7 +207,7 @@
   id: TailCow
   bodyPart: Tail
   markingCategory: Tail
-  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni]
+  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni, Kitsune]
   layering:
     m_tail_cow_BEHIND_primary: TailBehind
     m_tail_cow_FRONT_primary: TailOversuit
@@ -223,7 +223,7 @@
   id: TailCrow
   bodyPart: Tail
   markingCategory: Tail
-  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni]
+  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni, Kitsune]
   layering:
     m_tail_crow_BEHIND_primary: TailBehind
     m_tail_crow_FRONT_primary: TailOversuit
@@ -240,7 +240,7 @@
 #  id: TailDatashark
 #  bodyPart: Tail
 #  markingCategory: Tail
-#  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni]
+#  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni, Kitsune]
 #  sprites:
 #  - sprite: _Floof/Mobs/Customization/skyrattails.rsi
 #    state: m_tail_datashark_FRONT_primary
@@ -256,7 +256,7 @@
   id: TailDeer
   bodyPart: Tail
   markingCategory: Tail
-  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni]
+  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni, Kitsune]
   layering:
     m_tail_deer_BEHIND_primary: TailBehind
     m_tail_deer_BEHIND_secondary: TailBehind
@@ -279,7 +279,7 @@
   id: TailDeerTwo
   bodyPart: Tail
   markingCategory: Tail
-  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni]
+  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni, Kitsune]
   layering:
     m_tail_deer_two_BEHIND: TailBehind
     m_tail_deer_two_FRONT: TailOversuit
@@ -319,7 +319,7 @@
   id: TailDTiger
   bodyPart: Tail
   markingCategory: Tail
-  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni]
+  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni, Kitsune]
   layering:
     m_tail_dtiger_BEHIND: TailBehind
     m_tail_dtiger_FRONT: TailOversuit
@@ -415,7 +415,7 @@
   id: TailGuilmon
   bodyPart: Tail
   markingCategory: Tail
-  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni]
+  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni, Kitsune]
   layering:
     m_tail_guilmon_BEHIND_primary: TailBehind
     m_tail_guilmon_FRONT_primary: TailOversuit
@@ -431,7 +431,7 @@
   id: TailHawk
   bodyPart: Tail
   markingCategory: Tail
-  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni]
+  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni, Kitsune]
   layering:
     m_tail_hawk_BEHIND_primary: TailBehind
     m_tail_hawk_BEHIND_secondary: TailBehind
@@ -454,7 +454,7 @@
   id: TailHorse
   bodyPart: Tail
   markingCategory: Tail
-  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni]
+  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni, Kitsune]
   layering:
     m_tail_horse_BEHIND: TailBehind
     m_tail_horse_FRONT: TailOversuit
@@ -470,7 +470,7 @@
   id: TailHusk
   bodyPart: Tail
   markingCategory: Tail
-  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni]
+  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni, Kitsune]
   layering:
     m_tail_husk_BEHIND_primary: TailBehind
     m_tail_husk_FRONT_primary: TailOversuit
@@ -486,7 +486,7 @@
   id: TailHusky
   bodyPart: Tail
   markingCategory: Tail
-  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni]
+  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni, Kitsune]
   layering:
     m_tail_husky_BEHIND_primary: TailBehind
     m_tail_husky_BEHIND_secondary: TailBehind
@@ -509,7 +509,7 @@
   id: TailInsect
   bodyPart: Tail
   markingCategory: Tail
-  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni]
+  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni, Kitsune]
   layering:
     m_tail_insect_BEHIND_primary: TailBehind
     m_tail_insect_FRONT_primary: TailOversuit
@@ -525,7 +525,7 @@
   id: TailKangaroo
   bodyPart: Tail
   markingCategory: Tail
-  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni]
+  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni, Kitsune]
   layering:
     m_tail_kangaroo_BEHIND_primary: TailBehind
     m_tail_kangaroo_FRONT_primary: TailOversuit
@@ -564,7 +564,7 @@
   id: TailLab
   bodyPart: Tail
   markingCategory: Tail
-  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni]
+  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni, Kitsune]
   layering:
     m_tail_lab_BEHIND_primary: TailBehind
     m_tail_lab_FRONT_primary: Tail
@@ -580,7 +580,7 @@
   id: TailLeopard
   bodyPart: Tail
   markingCategory: Tail
-  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni]
+  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni, Kitsune]
   layering:
     m_tail_leopard_BEHIND_primary: TailBehind
     m_tail_leopard_BEHIND_secondary: TailBehind
@@ -603,7 +603,7 @@
   id: TailLTiger
   bodyPart: Tail
   markingCategory: Tail
-  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni]
+  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni, Kitsune]
   layering:
     m_tail_ltiger_BEHIND: TailBehind
     m_tail_ltiger_FRONT: Tail
@@ -636,7 +636,7 @@
 #  id: TailMFox
 #  bodyPart: Tail
 #  markingCategory: Tail
-#  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni]
+#  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni, Kitsune]
 #  sprites:
 #  - sprite: _Floof/Mobs/Customization/skyrattails.rsi
 #    state: m_tail_fox_FRONT_primary
@@ -647,7 +647,7 @@
   id: TailMurid
   bodyPart: Tail
   markingCategory: Tail
-  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni]
+  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni, Kitsune]
   layering:
     m_tail_murid_BEHIND_primary: TailBehind
     m_tail_murid_FRONT_primary: TailOversuit
@@ -663,7 +663,7 @@
   id: TailMuridTwo
   bodyPart: Tail
   markingCategory: Tail
-  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni]
+  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni, Kitsune]
   layering:
     m_tail_murid_two_BEHIND_primary: TailBehind
     m_tail_murid_two_FRONT_primary: TailOversuit
@@ -679,7 +679,7 @@
   id: TailOrca
   bodyPart: Tail
   markingCategory: Tail
-  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni]
+  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni, Kitsune]
   layering:
     m_tail_orca_BEHIND_primary: TailBehind
     m_tail_orca_FRONT_primary: TailOversuit
@@ -695,7 +695,7 @@
   id: TailOtie
   bodyPart: Tail
   markingCategory: Tail
-  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni]
+  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni, Kitsune]
   layering:
     m_tail_otie_BEHIND_primary: TailBehind
     m_tail_otie_FRONT_primary: TailOversuit
@@ -711,7 +711,7 @@
   id: TailPede
   bodyPart: Tail
   markingCategory: Tail
-  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni]
+  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni, Kitsune]
   layering:
     m_tail_leopard_BEHIND_primary: TailBehind
     m_tail_leopard_BEHIND_secondary: TailBehind
@@ -741,7 +741,7 @@
   id: TailPlugTail
   bodyPart: Tail
   markingCategory: Tail
-  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni]
+  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni, Kitsune]
   layering:
     m_tail_plugtail_BEHIND_primary: TailBehind
     m_tail_plugtail_BEHIND_secondary: TailBehind
@@ -771,7 +771,7 @@
   id: TailQueenBee
   bodyPart: Tail
   markingCategory: Tail
-  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni]
+  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni, Kitsune]
   layering:
     m_tail_queenbee_BEHIND_primary: TailBehind
     m_tail_queenbee_BEHIND_secondary: TailBehind
@@ -794,7 +794,7 @@
   id: TailQueenInsect
   bodyPart: Tail
   markingCategory: Tail
-  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni]
+  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni, Kitsune]
   layering:
     m_tail_queeninsect_BEHIND_primary: TailBehind
     m_tail_queeninsect_BEHIND_secondary: TailBehind
@@ -813,7 +813,7 @@
   id: TailRabbit
   bodyPart: Tail
   markingCategory: Tail
-  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni]
+  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni, Kitsune]
   layering:
     m_tail_rabbit_BEHIND_primary: TailBehind
     m_tail_rabbit_FRONT_primary: Tail
@@ -829,7 +829,7 @@
   id: TailRabbitAlt
   bodyPart: Tail
   markingCategory: Tail
-  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni]
+  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni, Kitsune]
   layering:
     m_tail_rabbit_alt_FRONT_primary: Tail
     m_tail_rabbit_alt_FRONT_secondary: Tail
@@ -843,7 +843,7 @@
   id: TailRaccoon
   bodyPart: Tail
   markingCategory: Tail
-  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni]
+  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni, Kitsune]
   layering:
     m_tail_raccoon_BEHIND_primary: TailBehind
     m_tail_raccoon_BEHIND_secondary: TailBehind
@@ -866,7 +866,7 @@
   id: TailRaptor
   bodyPart: Tail
   markingCategory: Tail
-  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni]
+  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni, Kitsune]
   layering:
     m_tail_raptor_BEHIND_primary: TailBehind
     m_tail_raptor_BEHIND_secondary: TailBehind
@@ -896,7 +896,7 @@
   id: TailReptileSlim
   bodyPart: Tail
   markingCategory: Tail
-  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni]
+  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni, Kitsune]
   layering:
     m_tail_reptileslim_BEHIND: TailBehind
     m_tail_reptileslim_FRONT: Tail
@@ -935,7 +935,7 @@
   id: TailSegmentedTail
   bodyPart: Tail
   markingCategory: Tail
-  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni]
+  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni, Kitsune]
   layering:
     m_tail_segmentedtail_BEHIND_primary: TailBehind
     m_tail_segmentedtail_BEHIND_secondary: TailBehind
@@ -965,7 +965,7 @@
   id: TailSergal
   bodyPart: Tail
   markingCategory: Tail
-  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni]
+  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni, Kitsune]
   layering:
     m_tail_sergal_BEHIND_primary: TailBehind
     m_tail_sergal_BEHIND_secondary: TailBehind
@@ -1011,7 +1011,7 @@
   id: TailShark
   bodyPart: Tail
   markingCategory: Tail
-  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni]
+  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni, Kitsune]
   layering:
     m_tail_shark_BEHIND_primary: TailBehind
     m_tail_shark_FRONT_primary: TailOversuit
@@ -1027,7 +1027,7 @@
   id: TailSharkNoFin
   bodyPart: Tail
   markingCategory: Tail
-  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni]
+  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni, Kitsune]
   layering:
     m_tail_sharknofin_BEHIND_primary: TailBehind
     m_tail_sharknofin_FRONT_primary: TailOversuit
@@ -1043,7 +1043,7 @@
   id: TailShepherd
   bodyPart: Tail
   markingCategory: Tail
-  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni]
+  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni, Kitsune]
   layering:
     m_tail_shepherd_BEHIND_secondary: TailBehind
     m_tail_shepherd_BEHIND_tertiary: TailBehind
@@ -1066,7 +1066,7 @@
   id: TailSkunk
   bodyPart: Tail
   markingCategory: Tail
-  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni]
+  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni, Kitsune]
   layering:
     m_tail_skunk_BEHIND_primary: TailBehind
     m_tail_skunk_BEHIND_secondary: TailBehind
@@ -1096,7 +1096,7 @@
   id: TailSmooth
   bodyPart: Tail
   markingCategory: Tail
-  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni]
+  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni, Kitsune]
   layering:
     m_tail_smooth_BEHIND: TailBehind
     m_tail_smooth_FRONT: TailOversuit
@@ -1112,7 +1112,7 @@
   id: TailSnakeDual
   bodyPart: Tail
   markingCategory: Tail
-  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni]
+  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni, Kitsune]
   layering:
     m_tail_snakedual_BEHIND_primary: TailBehind
     m_tail_snakedual_BEHIND_secondary: TailBehind
@@ -1135,7 +1135,7 @@
   id: TailSnakeStripe
   bodyPart: Tail
   markingCategory: Tail
-  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni]
+  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni, Kitsune]
   layering:
     m_tail_snakestripe_BEHIND_primary: TailBehind
     m_tail_snakestripe_BEHIND_secondary: TailBehind
@@ -1158,7 +1158,7 @@
   id: TailSnakeStripeAlt
   bodyPart: Tail
   markingCategory: Tail
-  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni]
+  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni, Kitsune]
   layering:
     m_tail_snakestripealt_BEHIND_primary: TailBehind
     m_tail_snakestripealt_BEHIND_secondary: TailBehind
@@ -1181,7 +1181,7 @@
   id: TailSnakeTail
   bodyPart: Tail
   markingCategory: Tail
-  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni]
+  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni, Kitsune]
   layering:
     m_tail_snaketail_BEHIND: TailBehind
     m_tail_snaketail_FRONT: Tail
@@ -1197,7 +1197,7 @@
   id: TailSnakeUnder
   bodyPart: Tail
   markingCategory: Tail
-  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni]
+  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni, Kitsune]
   layering:
     m_tail_snakeunder_BEHIND_primary: TailBehind
     m_tail_snakeunder_BEHIND_secondary: TailBehind
@@ -1220,7 +1220,7 @@
   id: TailSpade
   bodyPart: Tail
   markingCategory: Tail
-  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni]
+  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni, Kitsune]
   layering:
     m_tail_spade_BEHIND_primary: TailBehind
     m_tail_spade_FRONT_primary: TailOversuit
@@ -1236,7 +1236,7 @@
   id: TailSpikes
   bodyPart: Tail
   markingCategory: Tail
-  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni]
+  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni, Kitsune]
   layering:
     m_tail_spikes_BEHIND: TailBehind
     m_tail_spikes_FRONT: TailOversuit
@@ -1252,7 +1252,7 @@
   id: TailSquirrel
   bodyPart: Tail
   markingCategory: Tail
-  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni]
+  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni, Kitsune]
   layering:
     m_tail_squirrel_BEHIND: TailBehind
     m_tail_squirrel_FRONT: Tail
@@ -1268,7 +1268,7 @@
   id: TailStraightTail
   bodyPart: Tail
   markingCategory: Tail
-  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni]
+  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni, Kitsune]
   layering:
     m_tail_straighttail_BEHIND_primary: TailBehind
     m_tail_straighttail_FRONT_primary: Tail
@@ -1284,7 +1284,7 @@
   id: TailStripe
   bodyPart: Tail
   markingCategory: Tail
-  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni]
+  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni, Kitsune]
   layering:
     m_tail_stripe_BEHIND_primary: TailBehind
     m_tail_stripe_BEHIND_secondary: TailBehind
@@ -1308,7 +1308,7 @@
 #  id: TailMawWag
 #  bodyPart: Tail
 #  markingCategory: Tail
-#  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni]
+#  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni, Kitsune]
 #  layering:
 #    m_tail_tailmawwag_BEHIND_primary: TailBehind
 #    m_tail_tailmawwag_FRONT_primary: Tail
@@ -1324,7 +1324,7 @@
   id: TailThreeCat
   bodyPart: Tail
   markingCategory: Tail
-  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni]
+  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni, Kitsune]
   layering:
     m_tail_threecat_BEHIND_primary: TailBehind
     m_tail_threecat_FRONT_primary: Tail
@@ -1340,7 +1340,7 @@
   id: TailTiger
   bodyPart: Tail
   markingCategory: Tail
-  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni]
+  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni, Kitsune]
   layering:
     m_tail_tiger_BEHIND_primary: TailBehind
     m_tail_tiger_BEHIND_secondary: TailBehind
@@ -1370,7 +1370,7 @@
   id: TailTiger2
   bodyPart: Tail
   markingCategory: Tail
-  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni]
+  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni, Kitsune]
   layering:
     m_tail_tiger2_BEHIND_primary: TailBehind
     m_tail_tiger2_BEHIND_secondary: TailBehind
@@ -1400,7 +1400,7 @@
   id: TailTwoCat
   bodyPart: Tail
   markingCategory: Tail
-  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni]
+  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni, Kitsune]
   layering:
     m_tail_twocat_BEHIND_primary: TailBehind
     m_tail_twocat_FRONT_primary: Tail
@@ -1416,7 +1416,7 @@
   id: TailWah
   bodyPart: Tail
   markingCategory: Tail
-  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni]
+  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni, Kitsune]
   layering:
     m_tail_wah_BEHIND_primary: TailBehind
     m_tail_wah_BEHIND_secondary: TailBehind
@@ -1439,7 +1439,7 @@
   id: TailWolf
   bodyPart: Tail
   markingCategory: Tail
-  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni]
+  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni, Kitsune]
   layering:
     m_tail_wolf_BEHIND: TailBehind
     m_tail_wolf_FRONT: Tail
@@ -1455,7 +1455,7 @@
   id: TailZorgoia
   bodyPart: Tail
   markingCategory: Tail
-  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni]
+  speciesRestriction: [Vulpkanin, Rodentia, SlimePerson, Human, Harpy, IPC, Arachne, Felinid, Oni, Kitsune]
   layering:
     m_tail_zorgoia_BEHIND_primary: TailBehind
     m_tail_zorgoia_BEHIND_secondary: TailBehind

--- a/Resources/Prototypes/_Floof/Entities/Mobs/Customization/Markings/species_adaptors.yml
+++ b/Resources/Prototypes/_Floof/Entities/Mobs/Customization/Markings/species_adaptors.yml
@@ -9,7 +9,7 @@
   id: SpeciesAdaptorVulpkaninHeadMale
   bodyPart: Head
   markingCategory: Head
-  speciesRestriction: [Vulpkanin, SlimePerson, Human, Rodentia, Feroxi, Oni, IPC, Reptilian]
+  speciesRestriction: [Vulpkanin, SlimePerson, Human, Rodentia, Feroxi, Oni, IPC, Reptilian, Kitsune]
   sprites:
   - sprite: DeltaV/Mobs/Species/Vulpkanin/parts.rsi
     state: head_m
@@ -18,7 +18,7 @@
   id: SpeciesAdaptorVulpkaninHeadFemale
   bodyPart: Head
   markingCategory: Head
-  speciesRestriction: [Vulpkanin, SlimePerson, Human, Rodentia, Feroxi, Oni, IPC, Reptilian]
+  speciesRestriction: [Vulpkanin, SlimePerson, Human, Rodentia, Feroxi, Oni, IPC, Reptilian, Kitsune]
   sprites:
   - sprite: DeltaV/Mobs/Species/Vulpkanin/parts.rsi
     state: head_f
@@ -27,7 +27,7 @@
   id: SpeciesAdaptorVulpkaninTorsoMale
   bodyPart: Chest
   markingCategory: Chest
-  speciesRestriction: [Vulpkanin, SlimePerson, Human, Rodentia, Feroxi, Oni, IPC, Reptilian]
+  speciesRestriction: [Vulpkanin, SlimePerson, Human, Rodentia, Feroxi, Oni, IPC, Reptilian, Kitsune]
   sprites:
   - sprite: DeltaV/Mobs/Species/Vulpkanin/parts.rsi
     state: torso_m
@@ -36,7 +36,7 @@
   id: SpeciesAdaptorVulpkaninTorsoFemale
   bodyPart: Chest
   markingCategory: Chest
-  speciesRestriction: [Vulpkanin, SlimePerson, Human, Rodentia, Feroxi, Oni, IPC, Reptilian]
+  speciesRestriction: [Vulpkanin, SlimePerson, Human, Rodentia, Feroxi, Oni, IPC, Reptilian, Kitsune]
   sprites:
   - sprite: DeltaV/Mobs/Species/Vulpkanin/parts.rsi
     state: torso_f
@@ -45,7 +45,7 @@
   id: SpeciesAdaptorVulpkaninLArm
   bodyPart: LArm
   markingCategory: LeftArm
-  speciesRestriction: [Vulpkanin, SlimePerson, Human, Rodentia, Feroxi, Oni, IPC, Reptilian]
+  speciesRestriction: [Vulpkanin, SlimePerson, Human, Rodentia, Feroxi, Oni, IPC, Reptilian, Kitsune]
   sprites:
   - sprite: DeltaV/Mobs/Species/Vulpkanin/parts.rsi
     state: l_arm
@@ -54,7 +54,7 @@
   id: SpeciesAdaptorVulpkaninLHand
   bodyPart: LHand
   markingCategory: LeftHand
-  speciesRestriction: [Vulpkanin, SlimePerson, Human, Rodentia, Feroxi, Oni, IPC, Reptilian]
+  speciesRestriction: [Vulpkanin, SlimePerson, Human, Rodentia, Feroxi, Oni, IPC, Reptilian, Kitsune]
   sprites:
   - sprite: DeltaV/Mobs/Species/Vulpkanin/parts.rsi
     state: l_hand
@@ -63,7 +63,7 @@
   id: SpeciesAdaptorVulpkaninRArm
   bodyPart: RArm
   markingCategory: RightArm
-  speciesRestriction: [Vulpkanin, SlimePerson, Human, Rodentia, Feroxi, Oni, IPC, Reptilian]
+  speciesRestriction: [Vulpkanin, SlimePerson, Human, Rodentia, Feroxi, Oni, IPC, Reptilian, Kitsune]
   sprites:
     - sprite: DeltaV/Mobs/Species/Vulpkanin/parts.rsi
       state: r_arm
@@ -72,7 +72,7 @@
   id: SpeciesAdaptorVulpkaninRHand
   bodyPart: RHand
   markingCategory: RightHand
-  speciesRestriction: [Vulpkanin, SlimePerson, Human, Rodentia, Feroxi, Oni, IPC, Reptilian]
+  speciesRestriction: [Vulpkanin, SlimePerson, Human, Rodentia, Feroxi, Oni, IPC, Reptilian, Kitsune]
   sprites:
     - sprite: DeltaV/Mobs/Species/Vulpkanin/parts.rsi
       state: r_hand
@@ -81,7 +81,7 @@
   id: SpeciesAdaptorVulpkaninLLeg
   bodyPart: LLeg
   markingCategory: LeftLeg
-  speciesRestriction: [Vulpkanin, SlimePerson, Human, Rodentia, Feroxi, Oni, IPC, Reptilian]
+  speciesRestriction: [Vulpkanin, SlimePerson, Human, Rodentia, Feroxi, Oni, IPC, Reptilian, Kitsune]
   sprites:
     - sprite: DeltaV/Mobs/Species/Vulpkanin/parts.rsi
       state: l_leg
@@ -90,7 +90,7 @@
   id: SpeciesAdaptorVulpkaninLFoot
   bodyPart: LFoot
   markingCategory: LeftFoot
-  speciesRestriction: [Vulpkanin, SlimePerson, Human, Rodentia, Feroxi, Oni, IPC, Reptilian]
+  speciesRestriction: [Vulpkanin, SlimePerson, Human, Rodentia, Feroxi, Oni, IPC, Reptilian, Kitsune]
   sprites:
     - sprite: DeltaV/Mobs/Species/Vulpkanin/parts.rsi
       state: l_foot
@@ -99,7 +99,7 @@
   id: SpeciesAdaptorVulpkaninRLeg
   bodyPart: RLeg
   markingCategory: RightLeg
-  speciesRestriction: [Vulpkanin, SlimePerson, Human, Rodentia, Feroxi, Oni, IPC, Reptilian]
+  speciesRestriction: [Vulpkanin, SlimePerson, Human, Rodentia, Feroxi, Oni, IPC, Reptilian, Kitsune]
   sprites:
     - sprite: DeltaV/Mobs/Species/Vulpkanin/parts.rsi
       state: r_leg
@@ -108,7 +108,7 @@
   id: SpeciesAdaptorVulpkaninRFoot
   bodyPart: RFoot
   markingCategory: RightFoot
-  speciesRestriction: [Vulpkanin, SlimePerson, Human, Rodentia, Feroxi, Oni, IPC, Reptilian]
+  speciesRestriction: [Vulpkanin, SlimePerson, Human, Rodentia, Feroxi, Oni, IPC, Reptilian, Kitsune]
   sprites:
     - sprite: DeltaV/Mobs/Species/Vulpkanin/parts.rsi
       state: r_foot
@@ -118,7 +118,7 @@
   id: SpeciesAdaptorRodentiaHeadMale
   bodyPart: Head
   markingCategory: Head
-  speciesRestriction: [Vulpkanin, SlimePerson, Human, Rodentia, Feroxi, Oni, IPC, Reptilian]
+  speciesRestriction: [Vulpkanin, SlimePerson, Human, Rodentia, Feroxi, Oni, IPC, Reptilian, Kitsune]
   sprites:
   - sprite: DeltaV/Mobs/Species/Rodentia/parts.rsi
     state: head_m
@@ -127,7 +127,7 @@
   id: SpeciesAdaptorRodentiaHeadFemale
   bodyPart: Head
   markingCategory: Head
-  speciesRestriction: [Vulpkanin, SlimePerson, Human, Rodentia, Feroxi, Oni, IPC, Reptilian]
+  speciesRestriction: [Vulpkanin, SlimePerson, Human, Rodentia, Feroxi, Oni, IPC, Reptilian, Kitsune]
   sprites:
   - sprite: DeltaV/Mobs/Species/Rodentia/parts.rsi
     state: head_f
@@ -136,7 +136,7 @@
   id: SpeciesAdaptorRodentiaTorsoMale
   bodyPart: Chest
   markingCategory: Chest
-  speciesRestriction: [Vulpkanin, SlimePerson, Human, Rodentia, Feroxi, Oni, IPC, Reptilian]
+  speciesRestriction: [Vulpkanin, SlimePerson, Human, Rodentia, Feroxi, Oni, IPC, Reptilian, Kitsune]
   sprites:
   - sprite: DeltaV/Mobs/Species/Rodentia/parts.rsi
     state: torso_m
@@ -145,7 +145,7 @@
   id: SpeciesAdaptorRodentiaTorsoFemale
   bodyPart: Chest
   markingCategory: Chest
-  speciesRestriction: [Vulpkanin, SlimePerson, Human, Rodentia, Feroxi, Oni, IPC, Reptilian]
+  speciesRestriction: [Vulpkanin, SlimePerson, Human, Rodentia, Feroxi, Oni, IPC, Reptilian, Kitsune]
   sprites:
   - sprite: DeltaV/Mobs/Species/Rodentia/parts.rsi
     state: torso_f
@@ -154,7 +154,7 @@
   id: SpeciesAdaptorRodentiaLArm
   bodyPart: LArm
   markingCategory: LeftArm
-  speciesRestriction: [Vulpkanin, SlimePerson, Human, Rodentia, Feroxi, Oni, IPC, Reptilian]
+  speciesRestriction: [Vulpkanin, SlimePerson, Human, Rodentia, Feroxi, Oni, IPC, Reptilian, Kitsune]
   sprites:
   - sprite: DeltaV/Mobs/Species/Rodentia/parts.rsi
     state: l_arm
@@ -163,7 +163,7 @@
   id: SpeciesAdaptorRodentiaLHand
   bodyPart: LHand
   markingCategory: LeftHand
-  speciesRestriction: [Vulpkanin, SlimePerson, Human, Rodentia, Feroxi, Oni, IPC, Reptilian]
+  speciesRestriction: [Vulpkanin, SlimePerson, Human, Rodentia, Feroxi, Oni, IPC, Reptilian, Kitsune]
   sprites:
   - sprite: DeltaV/Mobs/Species/Rodentia/parts.rsi
     state: l_hand
@@ -172,7 +172,7 @@
   id: SpeciesAdaptorRodentiaRArm
   bodyPart: RArm
   markingCategory: RightArm
-  speciesRestriction: [Vulpkanin, SlimePerson, Human, Rodentia, Feroxi, Oni, IPC, Reptilian]
+  speciesRestriction: [Vulpkanin, SlimePerson, Human, Rodentia, Feroxi, Oni, IPC, Reptilian, Kitsune]
   sprites:
     - sprite: DeltaV/Mobs/Species/Rodentia/parts.rsi
       state: r_arm
@@ -181,7 +181,7 @@
   id: SpeciesAdaptorRodentiaRHand
   bodyPart: RHand
   markingCategory: RightHand
-  speciesRestriction: [Vulpkanin, SlimePerson, Human, Rodentia, Feroxi, Oni, IPC, Reptilian]
+  speciesRestriction: [Vulpkanin, SlimePerson, Human, Rodentia, Feroxi, Oni, IPC, Reptilian, Kitsune]
   sprites:
     - sprite: DeltaV/Mobs/Species/Rodentia/parts.rsi
       state: r_hand
@@ -190,7 +190,7 @@
   id: SpeciesAdaptorRodentiaLLeg
   bodyPart: LLeg
   markingCategory: LeftLeg
-  speciesRestriction: [Vulpkanin, SlimePerson, Human, Rodentia, Feroxi, Oni, IPC, Reptilian]
+  speciesRestriction: [Vulpkanin, SlimePerson, Human, Rodentia, Feroxi, Oni, IPC, Reptilian, Kitsune]
   sprites:
     - sprite: DeltaV/Mobs/Species/Rodentia/parts.rsi
       state: l_leg
@@ -199,7 +199,7 @@
   id: SpeciesAdaptorRodentiaLFoot
   bodyPart: LFoot
   markingCategory: LeftFoot
-  speciesRestriction: [Vulpkanin, SlimePerson, Human, Rodentia, Feroxi, Oni, IPC, Reptilian]
+  speciesRestriction: [Vulpkanin, SlimePerson, Human, Rodentia, Feroxi, Oni, IPC, Reptilian, Kitsune]
   sprites:
     - sprite: DeltaV/Mobs/Species/Rodentia/parts.rsi
       state: l_foot
@@ -208,7 +208,7 @@
   id: SpeciesAdaptorRodentiaRLeg
   bodyPart: RLeg
   markingCategory: RightLeg
-  speciesRestriction: [Vulpkanin, SlimePerson, Human, Rodentia, Feroxi, Oni, IPC, Reptilian]
+  speciesRestriction: [Vulpkanin, SlimePerson, Human, Rodentia, Feroxi, Oni, IPC, Reptilian, Kitsune]
   sprites:
     - sprite: DeltaV/Mobs/Species/Rodentia/parts.rsi
       state: r_leg
@@ -217,7 +217,7 @@
   id: SpeciesAdaptorRodentiaRFoot
   bodyPart: RFoot
   markingCategory: RightFoot
-  speciesRestriction: [Vulpkanin, SlimePerson, Human, Rodentia, Feroxi, Oni, IPC, Reptilian]
+  speciesRestriction: [Vulpkanin, SlimePerson, Human, Rodentia, Feroxi, Oni, IPC, Reptilian, Kitsune]
   sprites:
     - sprite: DeltaV/Mobs/Species/Rodentia/parts.rsi
       state: r_foot
@@ -227,7 +227,7 @@
   id: SpeciesAdaptorHumanHeadMale
   bodyPart: Head
   markingCategory: Head
-  speciesRestriction: [Vulpkanin, SlimePerson, Human, Rodentia, Feroxi, Oni, IPC, Reptilian]
+  speciesRestriction: [Vulpkanin, SlimePerson, Human, Rodentia, Feroxi, Oni, IPC, Reptilian, Kitsune]
   sprites:
   - sprite: Mobs/Species/Human/parts.rsi
     state: head_m
@@ -236,7 +236,7 @@
   id: SpeciesAdaptorHumanHeadFemale
   bodyPart: Head
   markingCategory: Head
-  speciesRestriction: [Vulpkanin, SlimePerson, Human, Rodentia, Feroxi, Oni, IPC, Reptilian]
+  speciesRestriction: [Vulpkanin, SlimePerson, Human, Rodentia, Feroxi, Oni, IPC, Reptilian, Kitsune]
   sprites:
   - sprite: Mobs/Species/Human/parts.rsi
     state: head_f
@@ -245,7 +245,7 @@
   id: SpeciesAdaptorHumanTorsoMale
   bodyPart: Chest
   markingCategory: Chest
-  speciesRestriction: [Vulpkanin, SlimePerson, Human, Rodentia, Feroxi, Oni, IPC, Reptilian]
+  speciesRestriction: [Vulpkanin, SlimePerson, Human, Rodentia, Feroxi, Oni, IPC, Reptilian, Kitsune]
   sprites:
   - sprite: Mobs/Species/Human/parts.rsi
     state: torso_m
@@ -254,7 +254,7 @@
   id: SpeciesAdaptorHumanTorsoFemale
   bodyPart: Chest
   markingCategory: Chest
-  speciesRestriction: [Vulpkanin, SlimePerson, Human, Rodentia, Feroxi, Oni, IPC, Reptilian]
+  speciesRestriction: [Vulpkanin, SlimePerson, Human, Rodentia, Feroxi, Oni, IPC, Reptilian, Kitsune]
   sprites:
   - sprite: Mobs/Species/Human/parts.rsi
     state: torso_f
@@ -263,7 +263,7 @@
   id: SpeciesAdaptorHumanLArm
   bodyPart: LArm
   markingCategory: LeftArm
-  speciesRestriction: [Vulpkanin, SlimePerson, Human, Rodentia, Feroxi, Oni, IPC, Reptilian]
+  speciesRestriction: [Vulpkanin, SlimePerson, Human, Rodentia, Feroxi, Oni, IPC, Reptilian, Kitsune]
   sprites:
   - sprite: Mobs/Species/Human/parts.rsi
     state: l_arm
@@ -272,7 +272,7 @@
   id: SpeciesAdaptorHumanLHand
   bodyPart: LHand
   markingCategory: LeftHand
-  speciesRestriction: [Vulpkanin, SlimePerson, Human, Rodentia, Feroxi, Oni, IPC, Reptilian]
+  speciesRestriction: [Vulpkanin, SlimePerson, Human, Rodentia, Feroxi, Oni, IPC, Reptilian, Kitsune]
   sprites:
   - sprite: Mobs/Species/Human/parts.rsi
     state: l_hand
@@ -281,7 +281,7 @@
   id: SpeciesAdaptorHumanRArm
   bodyPart: RArm
   markingCategory: RightArm
-  speciesRestriction: [Vulpkanin, SlimePerson, Human, Rodentia, Feroxi, Oni, IPC, Reptilian]
+  speciesRestriction: [Vulpkanin, SlimePerson, Human, Rodentia, Feroxi, Oni, IPC, Reptilian, Kitsune]
   sprites:
     - sprite: Mobs/Species/Human/parts.rsi
       state: r_arm
@@ -290,7 +290,7 @@
   id: SpeciesAdaptorHumanRHand
   bodyPart: RHand
   markingCategory: RightHand
-  speciesRestriction: [Vulpkanin, SlimePerson, Human, Rodentia, Feroxi, Oni, IPC, Reptilian]
+  speciesRestriction: [Vulpkanin, SlimePerson, Human, Rodentia, Feroxi, Oni, IPC, Reptilian, Kitsune]
   sprites:
     - sprite: Mobs/Species/Human/parts.rsi
       state: r_hand
@@ -299,7 +299,7 @@
   id: SpeciesAdaptorHumanLLeg
   bodyPart: LLeg
   markingCategory: LeftLeg
-  speciesRestriction: [Vulpkanin, SlimePerson, Human, Rodentia, Feroxi, Oni, IPC, Reptilian]
+  speciesRestriction: [Vulpkanin, SlimePerson, Human, Rodentia, Feroxi, Oni, IPC, Reptilian, Kitsune]
   sprites:
     - sprite: Mobs/Species/Human/parts.rsi
       state: l_leg
@@ -308,7 +308,7 @@
   id: SpeciesAdaptorHumanLFoot
   bodyPart: LFoot
   markingCategory: LeftFoot
-  speciesRestriction: [Vulpkanin, SlimePerson, Human, Rodentia, Feroxi, Oni, IPC, Reptilian]
+  speciesRestriction: [Vulpkanin, SlimePerson, Human, Rodentia, Feroxi, Oni, IPC, Reptilian, Kitsune]
   sprites:
     - sprite: Mobs/Species/Human/parts.rsi
       state: l_foot
@@ -317,7 +317,7 @@
   id: SpeciesAdaptorHumanRLeg
   bodyPart: RLeg
   markingCategory: RightLeg
-  speciesRestriction: [Vulpkanin, SlimePerson, Human, Rodentia, Feroxi, Oni, IPC, Reptilian]
+  speciesRestriction: [Vulpkanin, SlimePerson, Human, Rodentia, Feroxi, Oni, IPC, Reptilian, Kitsune]
   sprites:
     - sprite: Mobs/Species/Human/parts.rsi
       state: r_leg
@@ -326,7 +326,7 @@
   id: SpeciesAdaptorHumanRFoot
   bodyPart: RFoot
   markingCategory: RightFoot
-  speciesRestriction: [Vulpkanin, SlimePerson, Human, Rodentia, Feroxi, Oni, IPC, Reptilian]
+  speciesRestriction: [Vulpkanin, SlimePerson, Human, Rodentia, Feroxi, Oni, IPC, Reptilian, Kitsune]
   sprites:
     - sprite: Mobs/Species/Human/parts.rsi
       state: r_foot
@@ -336,7 +336,7 @@
   id: SpeciesAdaptorFeroxiHeadMale
   bodyPart: Head
   markingCategory: Head
-  speciesRestriction: [Vulpkanin, SlimePerson, Human, Rodentia, Feroxi, Oni, IPC, Reptilian]
+  speciesRestriction: [Vulpkanin, SlimePerson, Human, Rodentia, Feroxi, Oni, IPC, Reptilian, Kitsune]
   sprites:
   - sprite: DeltaV/Mobs/Species/Feroxi/parts.rsi
     state: head_m
@@ -345,7 +345,7 @@
   id: SpeciesAdaptorFeroxiHeadFemale
   bodyPart: Head
   markingCategory: Head
-  speciesRestriction: [Vulpkanin, SlimePerson, Human, Rodentia, Feroxi, Oni, IPC, Reptilian]
+  speciesRestriction: [Vulpkanin, SlimePerson, Human, Rodentia, Feroxi, Oni, IPC, Reptilian, Kitsune]
   sprites:
   - sprite: DeltaV/Mobs/Species/Feroxi/parts.rsi
     state: head_f
@@ -354,7 +354,7 @@
   id: SpeciesAdaptorFeroxiTorsoMale
   bodyPart: Chest
   markingCategory: Chest
-  speciesRestriction: [Vulpkanin, SlimePerson, Human, Rodentia, Feroxi, Oni, IPC, Reptilian]
+  speciesRestriction: [Vulpkanin, SlimePerson, Human, Rodentia, Feroxi, Oni, IPC, Reptilian, Kitsune]
   sprites:
   - sprite: DeltaV/Mobs/Species/Feroxi/parts.rsi
     state: torso_m
@@ -363,7 +363,7 @@
   id: SpeciesAdaptorFeroxiTorsoFemale
   bodyPart: Chest
   markingCategory: Chest
-  speciesRestriction: [Vulpkanin, SlimePerson, Human, Rodentia, Feroxi, Oni, IPC, Reptilian]
+  speciesRestriction: [Vulpkanin, SlimePerson, Human, Rodentia, Feroxi, Oni, IPC, Reptilian, Kitsune]
   sprites:
   - sprite: DeltaV/Mobs/Species/Feroxi/parts.rsi
     state: torso_f
@@ -372,7 +372,7 @@
   id: SpeciesAdaptorFeroxiLArm
   bodyPart: LArm
   markingCategory: LeftArm
-  speciesRestriction: [Vulpkanin, SlimePerson, Human, Rodentia, Feroxi, Oni, IPC, Reptilian]
+  speciesRestriction: [Vulpkanin, SlimePerson, Human, Rodentia, Feroxi, Oni, IPC, Reptilian, Kitsune]
   sprites:
   - sprite: DeltaV/Mobs/Species/Feroxi/parts.rsi
     state: l_arm
@@ -381,7 +381,7 @@
   id: SpeciesAdaptorFeroxiLHand
   bodyPart: LHand
   markingCategory: LeftHand
-  speciesRestriction: [Vulpkanin, SlimePerson, Human, Rodentia, Feroxi, Oni, IPC, Reptilian]
+  speciesRestriction: [Vulpkanin, SlimePerson, Human, Rodentia, Feroxi, Oni, IPC, Reptilian, Kitsune]
   sprites:
   - sprite: DeltaV/Mobs/Species/Feroxi/parts.rsi
     state: l_hand
@@ -390,7 +390,7 @@
   id: SpeciesAdaptorFeroxiRArm
   bodyPart: RArm
   markingCategory: RightArm
-  speciesRestriction: [Vulpkanin, SlimePerson, Human, Rodentia, Feroxi, Oni, IPC, Reptilian]
+  speciesRestriction: [Vulpkanin, SlimePerson, Human, Rodentia, Feroxi, Oni, IPC, Reptilian, Kitsune]
   sprites:
   - sprite: DeltaV/Mobs/Species/Feroxi/parts.rsi
     state: r_arm
@@ -399,7 +399,7 @@
   id: SpeciesAdaptorFeroxiRHand
   bodyPart: RHand
   markingCategory: RightHand
-  speciesRestriction: [Vulpkanin, SlimePerson, Human, Rodentia, Feroxi, Oni, IPC, Reptilian]
+  speciesRestriction: [Vulpkanin, SlimePerson, Human, Rodentia, Feroxi, Oni, IPC, Reptilian, Kitsune]
   sprites:
   - sprite: DeltaV/Mobs/Species/Feroxi/parts.rsi
     state: r_hand
@@ -408,7 +408,7 @@
   id: SpeciesAdaptorFeroxiLLeg
   bodyPart: LLeg
   markingCategory: LeftLeg
-  speciesRestriction: [Vulpkanin, SlimePerson, Human, Rodentia, Feroxi, Oni, IPC, Reptilian]
+  speciesRestriction: [Vulpkanin, SlimePerson, Human, Rodentia, Feroxi, Oni, IPC, Reptilian, Kitsune]
   sprites:
   - sprite: DeltaV/Mobs/Species/Feroxi/parts.rsi
     state: l_leg
@@ -417,7 +417,7 @@
   id: SpeciesAdaptorFeroxiLFoot
   bodyPart: LFoot
   markingCategory: LeftFoot
-  speciesRestriction: [Vulpkanin, SlimePerson, Human, Rodentia, Feroxi, Oni, IPC, Reptilian]
+  speciesRestriction: [Vulpkanin, SlimePerson, Human, Rodentia, Feroxi, Oni, IPC, Reptilian, Kitsune]
   sprites:
   - sprite: DeltaV/Mobs/Species/Feroxi/parts.rsi
     state: l_foot
@@ -426,7 +426,7 @@
   id: SpeciesAdaptorFeroxiRLeg
   bodyPart: RLeg
   markingCategory: RightLeg
-  speciesRestriction: [Vulpkanin, SlimePerson, Human, Rodentia, Feroxi, Oni, IPC, Reptilian]
+  speciesRestriction: [Vulpkanin, SlimePerson, Human, Rodentia, Feroxi, Oni, IPC, Reptilian, Kitsune]
   sprites:
   - sprite: DeltaV/Mobs/Species/Feroxi/parts.rsi
     state: r_leg
@@ -435,7 +435,7 @@
   id: SpeciesAdaptorFeroxiRFoot
   bodyPart: RFoot
   markingCategory: RightFoot
-  speciesRestriction: [Vulpkanin, SlimePerson, Human, Rodentia, Feroxi, Oni, IPC, Reptilian]
+  speciesRestriction: [Vulpkanin, SlimePerson, Human, Rodentia, Feroxi, Oni, IPC, Reptilian, Kitsune]
   sprites:
   - sprite: DeltaV/Mobs/Species/Feroxi/parts.rsi
     state: r_foot
@@ -445,7 +445,7 @@
   id: SpeciesAdaptorReptilianHeadMale
   bodyPart: Head
   markingCategory: Head
-  speciesRestriction: [Vulpkanin, SlimePerson, Human, Rodentia, Feroxi, Oni, IPC, Reptilian]
+  speciesRestriction: [Vulpkanin, SlimePerson, Human, Rodentia, Feroxi, Oni, IPC, Reptilian, Kitsune]
   sprites:
   - sprite: Mobs/Species/Reptilian/parts.rsi
     state: head_m
@@ -454,7 +454,7 @@
   id: SpeciesAdaptorReptilianHeadFemale
   bodyPart: Head
   markingCategory: Head
-  speciesRestriction: [Vulpkanin, SlimePerson, Human, Rodentia, Feroxi, Oni, IPC, Reptilian]
+  speciesRestriction: [Vulpkanin, SlimePerson, Human, Rodentia, Feroxi, Oni, IPC, Reptilian, Kitsune]
   sprites:
   - sprite: Mobs/Species/Reptilian/parts.rsi
     state: head_f
@@ -463,7 +463,7 @@
   id: SpeciesAdaptorReptilianTorsoMale
   bodyPart: Chest
   markingCategory: Chest
-  speciesRestriction: [Vulpkanin, SlimePerson, Human, Rodentia, Feroxi, Oni, IPC, Reptilian]
+  speciesRestriction: [Vulpkanin, SlimePerson, Human, Rodentia, Feroxi, Oni, IPC, Reptilian, Kitsune]
   sprites:
   - sprite: Mobs/Species/Reptilian/parts.rsi
     state: torso_m
@@ -472,7 +472,7 @@
   id: SpeciesAdaptorReptilianTorsoFemale
   bodyPart: Chest
   markingCategory: Chest
-  speciesRestriction: [Vulpkanin, SlimePerson, Human, Rodentia, Feroxi, Oni, IPC, Reptilian]
+  speciesRestriction: [Vulpkanin, SlimePerson, Human, Rodentia, Feroxi, Oni, IPC, Reptilian, Kitsune]
   sprites:
   - sprite: Mobs/Species/Reptilian/parts.rsi
     state: torso_f
@@ -481,7 +481,7 @@
   id: SpeciesAdaptorReptilianLArm
   bodyPart: LArm
   markingCategory: LeftArm
-  speciesRestriction: [Vulpkanin, SlimePerson, Human, Rodentia, Feroxi, Oni, IPC, Reptilian]
+  speciesRestriction: [Vulpkanin, SlimePerson, Human, Rodentia, Feroxi, Oni, IPC, Reptilian, Kitsune]
   sprites:
   - sprite: Mobs/Species/Reptilian/parts.rsi
     state: l_arm
@@ -490,7 +490,7 @@
   id: SpeciesAdaptorReptilianLHand
   bodyPart: LHand
   markingCategory: LeftHand
-  speciesRestriction: [Vulpkanin, SlimePerson, Human, Rodentia, Feroxi, Oni, IPC, Reptilian]
+  speciesRestriction: [Vulpkanin, SlimePerson, Human, Rodentia, Feroxi, Oni, IPC, Reptilian, Kitsune]
   sprites:
   - sprite: Mobs/Species/Reptilian/parts.rsi
     state: l_hand
@@ -499,7 +499,7 @@
   id: SpeciesAdaptorReptilianRArm
   bodyPart: RArm
   markingCategory: RightArm
-  speciesRestriction: [Vulpkanin, SlimePerson, Human, Rodentia, Feroxi, Oni, IPC, Reptilian]
+  speciesRestriction: [Vulpkanin, SlimePerson, Human, Rodentia, Feroxi, Oni, IPC, Reptilian, Kitsune]
   sprites:
   - sprite: Mobs/Species/Reptilian/parts.rsi
     state: r_arm
@@ -508,7 +508,7 @@
   id: SpeciesAdaptorReptilianRHand
   bodyPart: RHand
   markingCategory: RightHand
-  speciesRestriction: [Vulpkanin, SlimePerson, Human, Rodentia, Feroxi, Oni, IPC, Reptilian]
+  speciesRestriction: [Vulpkanin, SlimePerson, Human, Rodentia, Feroxi, Oni, IPC, Reptilian, Kitsune]
   sprites:
   - sprite: Mobs/Species/Reptilian/parts.rsi
     state: r_hand
@@ -517,7 +517,7 @@
   id: SpeciesAdaptorReptilianLLeg
   bodyPart: LLeg
   markingCategory: LeftLeg
-  speciesRestriction: [Vulpkanin, SlimePerson, Human, Rodentia, Feroxi, Oni, IPC, Reptilian]
+  speciesRestriction: [Vulpkanin, SlimePerson, Human, Rodentia, Feroxi, Oni, IPC, Reptilian, Kitsune]
   sprites:
   - sprite: Mobs/Species/Reptilian/parts.rsi
     state: l_leg
@@ -526,7 +526,7 @@
   id: SpeciesAdaptorReptilianLFoot
   bodyPart: LFoot
   markingCategory: LeftFoot
-  speciesRestriction: [Vulpkanin, SlimePerson, Human, Rodentia, Feroxi, Oni, IPC, Reptilian]
+  speciesRestriction: [Vulpkanin, SlimePerson, Human, Rodentia, Feroxi, Oni, IPC, Reptilian, Kitsune]
   sprites:
   - sprite: Mobs/Species/Reptilian/parts.rsi
     state: l_foot
@@ -535,7 +535,7 @@
   id: SpeciesAdaptorReptilianRLeg
   bodyPart: RLeg
   markingCategory: RightLeg
-  speciesRestriction: [Vulpkanin, SlimePerson, Human, Rodentia, Feroxi, Oni, IPC, Reptilian]
+  speciesRestriction: [Vulpkanin, SlimePerson, Human, Rodentia, Feroxi, Oni, IPC, Reptilian, Kitsune]
   sprites:
   - sprite: Mobs/Species/Reptilian/parts.rsi
     state: r_leg
@@ -544,7 +544,7 @@
   id: SpeciesAdaptorReptilianRFoot
   bodyPart: RFoot
   markingCategory: RightFoot
-  speciesRestriction: [Vulpkanin, SlimePerson, Human, Rodentia, Feroxi, Oni, IPC, Reptilian]
+  speciesRestriction: [Vulpkanin, SlimePerson, Human, Rodentia, Feroxi, Oni, IPC, Reptilian, Kitsune]
   sprites:
   - sprite: Mobs/Species/Reptilian/parts.rsi
     state: r_foot

--- a/Resources/Prototypes/_Floof/Entities/Mobs/Customization/Markings/tails.yml
+++ b/Resources/Prototypes/_Floof/Entities/Mobs/Customization/Markings/tails.yml
@@ -2,7 +2,7 @@
   id: TailAxolotl
   bodyPart: Tail
   markingCategory: Tail
-  speciesRestriction: [Reptilian, SlimePerson, IPC, Rodentia, Vulpkanin, Felinid, Human, Oni]
+  speciesRestriction: [Reptilian, SlimePerson, IPC, Rodentia, Vulpkanin, Felinid, Human, Oni, Kitsune]
   sprites:
     - sprite: SimpleStation14/Mobs/Customization/tails32x32.rsi
       state: axolotl
@@ -11,7 +11,7 @@
   id: TailEasternDragon
   bodyPart: Tail
   markingCategory: Tail
-  speciesRestriction: [Reptilian, SlimePerson, IPC, Rodentia, Vulpkanin, Felinid, Human, Oni]
+  speciesRestriction: [Reptilian, SlimePerson, IPC, Rodentia, Vulpkanin, Felinid, Human, Oni, Kitsune]
   sprites:
     - sprite: SimpleStation14/Mobs/Customization/tails32x32.rsi
       state: easternd_primary
@@ -22,7 +22,7 @@
   id: TailFish
   bodyPart: Tail
   markingCategory: Tail
-  speciesRestriction: [Reptilian, SlimePerson, IPC, Rodentia, Vulpkanin, Felinid, Human, Oni]
+  speciesRestriction: [Reptilian, SlimePerson, IPC, Rodentia, Vulpkanin, Felinid, Human, Oni, Kitsune]
   sprites:
     - sprite: SimpleStation14/Mobs/Customization/tails32x32.rsi
       state: fish_primary
@@ -33,7 +33,7 @@
   id: TailGecko
   bodyPart: Tail
   markingCategory: Tail
-  speciesRestriction: [Reptilian, SlimePerson, IPC, Rodentia, Vulpkanin, Felinid, Human, Oni]
+  speciesRestriction: [Reptilian, SlimePerson, IPC, Rodentia, Vulpkanin, Felinid, Human, Oni, Kitsune]
   sprites:
     - sprite: SimpleStation14/Mobs/Customization/tails32x32.rsi
       state: gecko_primary
@@ -46,7 +46,7 @@
   id: TailMaw
   bodyPart: Tail
   markingCategory: Tail
-  speciesRestriction: [Reptilian, SlimePerson, IPC, Rodentia, Vulpkanin, Felinid, Human, Oni]
+  speciesRestriction: [Reptilian, SlimePerson, IPC, Rodentia, Vulpkanin, Felinid, Human, Oni, Kitsune]
   sprites:
     - sprite: SimpleStation14/Mobs/Customization/tails32x32.rsi
       state: maw
@@ -55,7 +55,7 @@
   id: TailSnake
   bodyPart: Tail
   markingCategory: Tail
-  speciesRestriction: [Reptilian, SlimePerson, IPC, Rodentia, Vulpkanin, Felinid, Human, Oni]
+  speciesRestriction: [Reptilian, SlimePerson, IPC, Rodentia, Vulpkanin, Felinid, Human, Oni, Kitsune]
   sprites:
     - sprite: SimpleStation14/Mobs/Customization/tails32x32.rsi
       state: snake
@@ -64,7 +64,7 @@
   id: TailSuccubus
   bodyPart: Tail
   markingCategory: Tail
-  speciesRestriction: [Reptilian, SlimePerson, IPC, Rodentia, Vulpkanin, Felinid, Human, Oni]
+  speciesRestriction: [Reptilian, SlimePerson, IPC, Rodentia, Vulpkanin, Felinid, Human, Oni, Kitsune]
   sprites:
     - sprite: SimpleStation14/Mobs/Customization/tails32x32.rsi
       state: succubus
@@ -73,7 +73,7 @@
   id: TailTentacle
   bodyPart: Tail
   markingCategory: Tail
-  speciesRestriction: [Reptilian, SlimePerson, IPC, Rodentia, Vulpkanin, Felinid, Human, Oni]
+  speciesRestriction: [Reptilian, SlimePerson, IPC, Rodentia, Vulpkanin, Felinid, Human, Oni, Kitsune]
   sprites:
     - sprite: SimpleStation14/Mobs/Customization/tails32x32.rsi
       state: tentacle

--- a/Resources/Prototypes/_Floof/Entities/Mobs/Customization/Markings/unique.yml
+++ b/Resources/Prototypes/_Floof/Entities/Mobs/Customization/Markings/unique.yml
@@ -2,7 +2,7 @@
   id: SingleAntenna
   bodyPart: HeadTop
   markingCategory: Head
-  speciesRestriction: [Reptilian, SlimePerson, Rodentia, Vulpkanin, Felinid, Human, Oni]
+  speciesRestriction: [Reptilian, SlimePerson, Rodentia, Vulpkanin, Felinid, Human, Oni, Kitsune]
   sprites:
   - sprite: _Floof/Mobs/Customization/unique.rsi
     state: singleantennaprimary

--- a/Resources/Prototypes/_Floof/Entities/Mobs/Customization/Markings/vulpkanin.yml
+++ b/Resources/Prototypes/_Floof/Entities/Mobs/Customization/Markings/vulpkanin.yml
@@ -3,7 +3,7 @@
   id: VulpSnoutSwiftWhite
   bodyPart: Snout
   markingCategory: Snout
-  speciesRestriction: [Vulpkanin, SlimePerson, IPC]
+  speciesRestriction: [Vulpkanin, SlimePerson, IPC, Kitsune]
   sprites:
     - sprite: _Floof/Mobs/Customization/Vulpkanin/head_markings.rsi
       state: vulpine-lines-white
@@ -12,7 +12,7 @@
   id: VulpSnoutVulpineWhite
   bodyPart: Snout
   markingCategory: Snout
-  speciesRestriction: [Vulpkanin, SlimePerson, IPC]
+  speciesRestriction: [Vulpkanin, SlimePerson, IPC, Kitsune]
   sprites:
     - sprite: DeltaV/Mobs/Customization/Vulpkanin/head_markings.rsi
       state: vulpine
@@ -24,7 +24,7 @@
   id: VulpPointsFadeLegL
   markingCategory: LeftLeg
   bodyPart: LLeg
-  speciesRestriction: [Vulpkanin, SlimePerson, IPC]
+  speciesRestriction: [Vulpkanin, SlimePerson, IPC, Kitsune]
   sprites:
     - sprite: _Floof/Mobs/Customization/Vulpkanin/body_markings.rsi
       state: points_fade-legsL
@@ -33,7 +33,7 @@
   id: VulpPointsSharpLegL
   markingCategory: LeftLeg
   bodyPart: LLeg
-  speciesRestriction: [Vulpkanin, SlimePerson, IPC]
+  speciesRestriction: [Vulpkanin, SlimePerson, IPC, Kitsune]
   sprites:
     - sprite: _Floof/Mobs/Customization/Vulpkanin/body_markings.rsi
       state: points_sharp-legsL
@@ -42,7 +42,7 @@
   id: VulpPointsCrestLegL
   markingCategory: LeftLeg
   bodyPart: LLeg
-  speciesRestriction: [Vulpkanin, SlimePerson, IPC]
+  speciesRestriction: [Vulpkanin, SlimePerson, IPC, Kitsune]
   sprites:
     - sprite: _Floof/Mobs/Customization/Vulpkanin/body_markings.rsi
       state: points_crest-legsL
@@ -51,7 +51,7 @@
   id: VulpPointsFadeLegR
   markingCategory: RightLeg
   bodyPart: RLeg
-  speciesRestriction: [Vulpkanin, SlimePerson, IPC]
+  speciesRestriction: [Vulpkanin, SlimePerson, IPC, Kitsune]
   sprites:
     - sprite: _Floof/Mobs/Customization/Vulpkanin/body_markings.rsi
       state: points_fade-legsR
@@ -60,7 +60,7 @@
   id: VulpPointsSharpLegR
   markingCategory: RightLeg
   bodyPart: RLeg
-  speciesRestriction: [Vulpkanin, SlimePerson, IPC]
+  speciesRestriction: [Vulpkanin, SlimePerson, IPC, Kitsune]
   sprites:
     - sprite: _Floof/Mobs/Customization/Vulpkanin/body_markings.rsi
       state: points_sharp-legsR
@@ -69,7 +69,7 @@
   id: VulpPointsCrestLegR
   markingCategory: RightLeg
   bodyPart: RLeg
-  speciesRestriction: [Vulpkanin, SlimePerson, IPC]
+  speciesRestriction: [Vulpkanin, SlimePerson, IPC, Kitsune]
   sprites:
     - sprite: _Floof/Mobs/Customization/Vulpkanin/body_markings.rsi
       state: points_crest-legsR
@@ -78,7 +78,7 @@
   id: VulpPointsFadeArmL
   markingCategory: LeftArm
   bodyPart: LArm
-  speciesRestriction: [Vulpkanin, SlimePerson, IPC]
+  speciesRestriction: [Vulpkanin, SlimePerson, IPC, Kitsune]
   sprites:
     - sprite: _Floof/Mobs/Customization/Vulpkanin/body_markings.rsi
       state: points_fade-armsL
@@ -87,7 +87,7 @@
   id: VulpPointsSharpArmL
   markingCategory: LeftArm
   bodyPart: LArm
-  speciesRestriction: [Vulpkanin, SlimePerson, IPC]
+  speciesRestriction: [Vulpkanin, SlimePerson, IPC, Kitsune]
   sprites:
     - sprite: _Floof/Mobs/Customization/Vulpkanin/body_markings.rsi
       state: points_sharp-armsL
@@ -96,7 +96,7 @@
   id: VulpPointsCrestArmL
   markingCategory: LeftArm
   bodyPart: LArm
-  speciesRestriction: [Vulpkanin, SlimePerson, IPC]
+  speciesRestriction: [Vulpkanin, SlimePerson, IPC, Kitsune]
   sprites:
     - sprite: _Floof/Mobs/Customization/Vulpkanin/body_markings.rsi
       state: points_crest-armsL
@@ -105,7 +105,7 @@
   id: VulpPointsFadeArmR
   markingCategory: RightArm
   bodyPart: RArm
-  speciesRestriction: [Vulpkanin, SlimePerson, IPC]
+  speciesRestriction: [Vulpkanin, SlimePerson, IPC, Kitsune]
   sprites:
     - sprite: _Floof/Mobs/Customization/Vulpkanin/body_markings.rsi
       state: points_fade-armsR
@@ -114,7 +114,7 @@
   id: VulpPointsSharpArmR
   markingCategory: RightArm
   bodyPart: RArm
-  speciesRestriction: [Vulpkanin, SlimePerson, IPC]
+  speciesRestriction: [Vulpkanin, SlimePerson, IPC, Kitsune]
   sprites:
     - sprite: _Floof/Mobs/Customization/Vulpkanin/body_markings.rsi
       state: points_sharp-armsR
@@ -123,7 +123,7 @@
   id: VulpPointsCrestArmR
   markingCategory: RightArm
   bodyPart: RArm
-  speciesRestriction: [Vulpkanin, SlimePerson, IPC]
+  speciesRestriction: [Vulpkanin, SlimePerson, IPC, Kitsune]
   sprites:
     - sprite: _Floof/Mobs/Customization/Vulpkanin/body_markings.rsi
       state: points_crest-armsR
@@ -132,7 +132,7 @@
   id: VulpPointsHandsRight
   markingCategory: RightHand
   bodyPart: RHand
-  speciesRestriction: [Vulpkanin, SlimePerson, IPC]
+  speciesRestriction: [Vulpkanin, SlimePerson, IPC, Kitsune]
   sprites:
     - sprite: _Floof/Mobs/Customization/Vulpkanin/body_markings.rsi
       state: points_handR
@@ -141,7 +141,7 @@
   id: VulpPointsHandsLeft
   markingCategory: LeftHand
   bodyPart: LHand
-  speciesRestriction: [Vulpkanin, SlimePerson, IPC]
+  speciesRestriction: [Vulpkanin, SlimePerson, IPC, Kitsune]
   sprites:
     - sprite: _Floof/Mobs/Customization/Vulpkanin/body_markings.rsi
       state: points_handL
@@ -150,7 +150,7 @@
   id: VulpPointsFeetRight
   markingCategory: RightFoot
   bodyPart: RFoot
-  speciesRestriction: [Vulpkanin, SlimePerson, IPC]
+  speciesRestriction: [Vulpkanin, SlimePerson, IPC, Kitsune]
   sprites:
     - sprite: _Floof/Mobs/Customization/Vulpkanin/body_markings.rsi
       state: points_feetR
@@ -159,7 +159,7 @@
   id: VulpPointsFeetLeft
   markingCategory: LeftFoot
   bodyPart: LFoot
-  speciesRestriction: [Vulpkanin, SlimePerson, IPC]
+  speciesRestriction: [Vulpkanin, SlimePerson, IPC, Kitsune]
   sprites:
     - sprite: _Floof/Mobs/Customization/Vulpkanin/body_markings.rsi
       state: points_feetL

--- a/Resources/Prototypes/_Floof/Entities/Mobs/Customization/Markings/wings.yml
+++ b/Resources/Prototypes/_Floof/Entities/Mobs/Customization/Markings/wings.yml
@@ -2,7 +2,7 @@
   id: WingsDragon
   bodyPart: Wings
   markingCategory: Wings
-  speciesRestriction: [Reptilian, SlimePerson, IPC, Rodentia, Vulpkanin, Felinid, Human, Oni]
+  speciesRestriction: [Reptilian, SlimePerson, IPC, Rodentia, Vulpkanin, Felinid, Human, Oni, Kitsune]
   sprites:
     - sprite: SimpleStation14/Mobs/Customization/wings96x34.rsi
       state: dragon
@@ -11,7 +11,7 @@
   id: WingsFly
   bodyPart: Wings
   markingCategory: Wings
-  speciesRestriction: [Reptilian, SlimePerson, IPC, Rodentia, Vulpkanin, Felinid, Human, Oni]
+  speciesRestriction: [Reptilian, SlimePerson, IPC, Rodentia, Vulpkanin, Felinid, Human, Oni, Kitsune]
   sprites:
     - sprite: SimpleStation14/Mobs/Customization/wings96x34.rsi
       state: fly
@@ -20,7 +20,7 @@
   id: WingsRobotic
   bodyPart: Wings
   markingCategory: Wings
-  speciesRestriction: [Reptilian, SlimePerson, IPC, Rodentia, Vulpkanin, Felinid, Human, Oni]
+  speciesRestriction: [Reptilian, SlimePerson, IPC, Rodentia, Vulpkanin, Felinid, Human, Oni, Kitsune]
   sprites:
     - sprite: SimpleStation14/Mobs/Customization/wings96x34.rsi
       state: robotic
@@ -29,7 +29,7 @@
   id: WingsSkeleton
   bodyPart: Wings
   markingCategory: Wings
-  speciesRestriction: [Reptilian, SlimePerson, IPC, Rodentia, Vulpkanin, Felinid, Human, Oni]
+  speciesRestriction: [Reptilian, SlimePerson, IPC, Rodentia, Vulpkanin, Felinid, Human, Oni, Kitsune]
   sprites:
     - sprite: SimpleStation14/Mobs/Customization/wings96x34.rsi
       state: skeleton
@@ -38,7 +38,7 @@
   id: WingsHarpy
   bodyPart: Wings
   markingCategory: Wings
-  speciesRestriction: [Reptilian, SlimePerson, IPC, Rodentia, Vulpkanin, Felinid, Human, Oni]
+  speciesRestriction: [Reptilian, SlimePerson, IPC, Rodentia, Vulpkanin, Felinid, Human, Oni, Kitsune]
   sprites:
     - sprite: SimpleStation14/Mobs/Customization/wings64x32.rsi
       state: harpy
@@ -47,7 +47,7 @@
   id: WingsHarpyBionic
   bodyPart: Wings
   markingCategory: Wings
-  speciesRestriction: [Reptilian, SlimePerson, IPC, Rodentia, Vulpkanin, Felinid, Human, Oni]
+  speciesRestriction: [Reptilian, SlimePerson, IPC, Rodentia, Vulpkanin, Felinid, Human, Oni, Kitsune]
   sprites:
     - sprite: _Floof/Mobs/Customization/wings64-32.rsi
       state: bionic_wings_tone_1


### PR DESCRIPTION
<!--
This is a semi-strict format, you can add/remove sections as needed but the order/format should be kept the same
Remove these comments before submitting
-->

# Description

<!--
Explain this PR in as much detail as applicable

Some example prompts to consider:
How might this affect the game? The codebase?
What might be some alternatives to this?
How/Who does this benefit/hurt [the game/codebase]?
-->

This PR aims to diversify the marking choices for Kitsune, along with bringing them up to speed with the other humanoid and Vulpkanin species. Marking points are increased to match it's peers and the addition of a wing marking slot.

No new content has been curated. Only things that has changed is the markings Kitsune have access to.

---

# Changelog

<!--
You can add an author after the `:cl:` to change the name that appears in the changelog (ex: `:cl: Death`)
Leaving it blank will default to your GitHub display name
This includes all available types for the changelog
-->

:cl: M3739
- tweak: Kitsune now have access to a wider variety of markings.
