### PR TITLE
Fix Menu Visibility Entity Lookup Flags

### DIFF
--- a/Content.Client/Verbs/VerbSystem.cs
+++ b/Content.Client/Verbs/VerbSystem.cs
@@ -78,7 +78,7 @@ namespace Content.Client.Verbs
 
             // Get entities
             List<EntityUid> entities;
-            var examineFlags = LookupFlags.All & ~LookupFlags.Sensors;
+            var examineFlags = LookupFlags.All// & ~LookupFlags.Sensors; // Floof - DO NOT EXCLUDE SENSORS! It excludes all entities that have a non-hard fixtur, like puddles! See Floofstation#1064 for more info.
 
             // Do we have to do FoV checks?
             if ((visibility & MenuVisibility.NoFov) == 0)

--- a/Content.Client/Verbs/VerbSystem.cs
+++ b/Content.Client/Verbs/VerbSystem.cs
@@ -78,7 +78,7 @@ namespace Content.Client.Verbs
 
             // Get entities
             List<EntityUid> entities;
-            var examineFlags = LookupFlags.All// & ~LookupFlags.Sensors; // Floof - DO NOT EXCLUDE SENSORS! It excludes all entities that have a non-hard fixtur, like puddles! See Floofstation#1064 for more info.
+            var examineFlags = LookupFlags.All// & ~LookupFlags.Sensors; // Floof - DO NOT EXCLUDE SENSORS! It excludes all entities that have a non-hard fixture, like puddles! See Floofstation1#1064 for more info.
 
             // Do we have to do FoV checks?
             if ((visibility & MenuVisibility.NoFov) == 0)

--- a/Content.Client/Verbs/VerbSystem.cs
+++ b/Content.Client/Verbs/VerbSystem.cs
@@ -78,7 +78,7 @@ namespace Content.Client.Verbs
 
             // Get entities
             List<EntityUid> entities;
-            var examineFlags = LookupFlags.All// & ~LookupFlags.Sensors; // Floof - DO NOT EXCLUDE SENSORS! It excludes all entities that have a non-hard fixture, like puddles! See Floofstation1#1064 for more info.
+            var examineFlags = LookupFlags.All; // & ~LookupFlags.Sensors; // Floof - DO NOT EXCLUDE SENSORS! It excludes all entities that have a non-hard fixture, like puddles! See Floofstation1#1064 for more info.
 
             // Do we have to do FoV checks?
             if ((visibility & MenuVisibility.NoFov) == 0)


### PR DESCRIPTION
# Description
The query for it was called with `LookupFlags.All & ~LookupFlags.Sensors` (everything except sensors). And the EntityLookupSystem would ignore all soft fixtures during physics lookup if the lookup flags had Sensors excluded. Puddles very conveniently have only a single non-hard fixture, causing them to be ignored. Why, wizden?


<details><summary><h1>Media</h1></summary>
<p>

![image](https://github.com/user-attachments/assets/0f61fd0b-e532-4ca3-a024-737e02e27ca7)


</p>
</details>

# Changelog
:cl:
- fix: Puddles and other entities with only a non-hard fixture should now correctly display in the entity menu (right click).