### PR TITLE
Revenant Buff

### DIFF
--- a/Content.Shared/Revenant/Components/RevenantComponent.cs
+++ b/Content.Shared/Revenant/Components/RevenantComponent.cs
@@ -19,7 +19,7 @@ public sealed partial class RevenantComponent : Component
     /// </summary>
     [DataField, ViewVariables(VVAccess.ReadWrite)]
     [AutoNetworkedField]
-    public FixedPoint2 Essence = 75;
+    public FixedPoint2 Essence = 100;
 
     [DataField("stolenEssenceCurrencyPrototype", customTypeSerializer: typeof(PrototypeIdSerializer<CurrencyPrototype>))]
     public string StolenEssenceCurrencyPrototype = "StolenEssence";
@@ -35,7 +35,7 @@ public sealed partial class RevenantComponent : Component
     /// through harvesting player souls.
     /// </summary>
     [ViewVariables(VVAccess.ReadWrite), DataField("maxEssence")]
-    public FixedPoint2 EssenceRegenCap = 75;
+    public FixedPoint2 EssenceRegenCap = 100;
 
     /// <summary>
     /// The coefficient of damage taken to actual health lost.
@@ -47,7 +47,7 @@ public sealed partial class RevenantComponent : Component
     /// The amount of essence passively generated per second.
     /// </summary>
     [ViewVariables(VVAccess.ReadWrite), DataField("essencePerSecond")]
-    public FixedPoint2 EssencePerSecond = 0.5f;
+    public FixedPoint2 EssencePerSecond = 1f;
 
     [ViewVariables]
     public float Accumulator = 0;

--- a/Resources/Prototypes/Catalog/revenant_catalog.yml
+++ b/Resources/Prototypes/Catalog/revenant_catalog.yml
@@ -43,7 +43,7 @@
   description: Makes nearby electronics stop working properly. Using it leaves you vulnerable to attacks for a long period of time.
   productAction: ActionRevenantMalfunction
   cost:
-    StolenEssence: 125
+    StolenEssence: 100 # Floofstation - Eating 12ish people? In this Economy? You must be insane
   categories:
   - RevenantAbilities
   conditions:

--- a/Resources/Prototypes/Entities/Mobs/NPCs/revenant.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/revenant.yml
@@ -70,18 +70,31 @@
       # troll medical to help get kills
       - StasisBed
       - EmaggableMedibot
+      - CryoPod # Floofstation
       # borg become killer
       - EmagSiliconLaw
+      # cause chaos by emagging lathes
+      - Lathe # Floofstation
+      # cause chaos by emagging PCs and vending machines
+      - VendingMachine # Floofstation
+      - Computer # Floofstation
   - type: PointLight
     color: MediumPurple
     radius: 2
     softness: 1
+  - type: VoiceMask # Floofstation
   - type: UserInterface
     interfaces:
       enum.StoreUiKey.Key:
         type: StoreBoundUserInterface
+      enum.VoiceMaskUIKey.Key:
+        type: VoiceMaskBoundUserInterface # Floofstation
   - type: Visibility
     layer: 2 #ghost vis layer
+  - type: NightVision # Floofstation
+    drawOverlay: false
+    activateSound: null
+    deactivateSound: null
   - type: Store
     categories:
     - RevenantAbilities
@@ -96,6 +109,8 @@
     - RevenantTheme
   - type: Speech
     speechVerb: Ghost
+  - type: Singer # Floofstation - incase you wanted to play spooky music while haunting
+    proto: HarpySinger
   - type: Psionic
     removable: false
     psychognomicDescriptors:
@@ -109,3 +124,5 @@
   - type: Tag
     tags:
       - NoPaint
+      - CanPilot # Floofstation - they can hijack mechs but they will probably eat shit when shot
+      - HarpyEmotes # Floofstation - so they can emote


### PR DESCRIPTION
# Description

Buffs to Revenant, increases their max HP and regen speed, increased number of things that they can emag, added a voice mask, added night vision, added harpy singing, allowed it to pilot mechs (they can die real easy like this), and do emotes.

Why?
They felt like the short straw on impact and RP compared to a Space Dragon. This should spice it up slightly, without making them too dangerous. (still drastically less so then a dragon)

# Changelog
:cl:
- add: Added Voice Mask, Night Vision, Singing, Mech Piloting, Emoting to Revenant.
- tweak: Buffed Revenant HP and Regen, and things they can emag.
