### PR TITLE
Bluespace Cigar

### DIFF
--- a/Resources/Prototypes/CharacterItemGroups/Generic/miscItemGroups.yml
+++ b/Resources/Prototypes/CharacterItemGroups/Generic/miscItemGroups.yml
@@ -22,7 +22,7 @@
     - type: loadout
       id: LoadoutItemJoint
     - type: loadout
-      id: LoadoutItemCigarBluespaceAddict
+      id: LoadoutItemCigarBluespaceAddict # Floofstation
     - type: loadout
       id: LoadoutItemCigarBluespace      
 

--- a/Resources/Prototypes/CharacterItemGroups/Generic/miscItemGroups.yml
+++ b/Resources/Prototypes/CharacterItemGroups/Generic/miscItemGroups.yml
@@ -21,6 +21,10 @@
       id: LoadoutItemBlunt
     - type: loadout
       id: LoadoutItemJoint
+    - type: loadout
+      id: LoadoutItemCigarBluespaceAddict
+    - type: loadout
+      id: LoadoutItemCigarBluespace      
 
 - type: characterItemGroup
   id: LoadoutLighters

--- a/Resources/Prototypes/Entities/Objects/Consumable/Smokeables/Cigars/cigar.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Smokeables/Cigars/cigar.yml
@@ -69,3 +69,40 @@
     solutions:
       smokable:
         maxVol: 20
+
+- type: entity # Floofstation
+  id: CigarBluespace
+  parent: Cigar
+  name: bluespace cigar
+  description: A cigar designed using bluespace technology for nicotine addicts and the most hedonistic of smokers.
+  components:
+  - type: Sprite
+    sprite: Objects/Consumable/Smokeables/Cigars/cigar-gold.rsi
+    state: unlit-icon
+  - type: Clothing
+    sprite: Objects/Consumable/Smokeables/Cigars/cigar-gold.rsi
+    slots: [ mask ]
+    equippedPrefix: unlit
+  - type: Item
+    size: Tiny
+  - type: SolutionContainerManager
+    solutions:
+      smokable:
+        maxVol: 6480
+        reagents:
+          - ReagentId: Nicotine
+            Quantity: 6480 # 12 hours
+
+- type: entity # If somehow, 12 hours pass
+  id: CigarBluespaceSpent
+  parent: CigarBluespace
+  suffix: spent
+  components:
+  - type: Sprite
+    state: burnt-icon
+  - type: Smokable
+    state: Burnt
+  - type: SolutionContainerManager
+    solutions:
+      smokable:
+        maxVol: 6480

--- a/Resources/Prototypes/Entities/Objects/Consumable/Smokeables/Cigars/cigar.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Smokeables/Cigars/cigar.yml
@@ -77,7 +77,7 @@
   description: A cigar designed using bluespace technology for nicotine addicts and the most hedonistic of smokers.
   components:
   - type: Sprite
-    sprite: Objects/Consumable/Smokeables/Cigars/cigar-gold.rsi # Placeholder
+    sprite: Objects/Consumable/Smokeables/Cigars/cigar-gold.rsi # Placeholder - Will glow blue
     state: unlit-icon
   - type: Clothing
     sprite: Objects/Consumable/Smokeables/Cigars/cigar-gold.rsi

--- a/Resources/Prototypes/Entities/Objects/Consumable/Smokeables/Cigars/cigar.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Smokeables/Cigars/cigar.yml
@@ -77,7 +77,7 @@
   description: A cigar designed using bluespace technology for nicotine addicts and the most hedonistic of smokers.
   components:
   - type: Sprite
-    sprite: Objects/Consumable/Smokeables/Cigars/cigar-gold.rsi
+    sprite: Objects/Consumable/Smokeables/Cigars/cigar-gold.rsi # Placeholder
     state: unlit-icon
   - type: Clothing
     sprite: Objects/Consumable/Smokeables/Cigars/cigar-gold.rsi

--- a/Resources/Prototypes/_Floof/Loadouts/Generic/items.yml
+++ b/Resources/Prototypes/_Floof/Loadouts/Generic/items.yml
@@ -133,3 +133,26 @@
       group: LoadoutPets
   functions:
     - !type:LoadoutMakeFollower
+
+- type: loadout
+  id: LoadoutItemCigarBluespaceAddict
+  category: Items
+  cost: 2
+  items:
+    - CigarBluespace
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: LoadoutSmokes
+    - !type:CharacterTraitRequirement
+      traits:
+        - AddictionNicotine
+
+- type: loadout
+  id: LoadoutItemCigarBluespace
+  category: Items
+  cost: 5
+  items:
+    - CigarBluespace
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: LoadoutSmokes

--- a/Resources/Prototypes/_Floof/Loadouts/Generic/items.yml
+++ b/Resources/Prototypes/_Floof/Loadouts/Generic/items.yml
@@ -138,6 +138,7 @@
   id: LoadoutItemCigarBluespaceAddict
   category: Items
   cost: 2
+  canBeHeirloom: true
   items:
     - CigarBluespace
   requirements:
@@ -151,6 +152,7 @@
   id: LoadoutItemCigarBluespace
   category: Items
   cost: 5
+  canBeHeirloom: true
   items:
     - CigarBluespace
   requirements:


### PR DESCRIPTION
# Description

A cigar made for the rich and hedonistic (or nicotine addicts) designed by the Astaroth Corporation and powered by Bluespace Technology to last forever (12 hours) for your nicotine needs. 

It's just a cigar that lasts 12 hours, it's in the loadout, cheaper for addicts. it's planned to glow blue instead of red/yellow, and smokables are to have a dim glow in the dark. But that's on the backlog. 

# TODO

- [x] Framework
- [ ] Sprite - Glows Blue - TO BE DONE AT A LATER DATE BY SOMEONE ELSE
- [ ] Smokables to dimly glow in the dark (Bluespace glows blue) - ALSO SOMEONE ELSE NEEDS TO FIGURE THIS

# Changelog

:cl:
- add: Added Bluespace Cigar, available via loadout.

