### PR TITLE
Fix Resomi Tags

### DIFF
--- a/Resources/Prototypes/_Floof/Entities/Mobs/Species/resomi.yml
+++ b/Resources/Prototypes/_Floof/Entities/Mobs/Species/resomi.yml
@@ -209,6 +209,9 @@
     forceSayStringCount: 4 # Default is 7. I was not creative enough to come up with 7 right now. Send help.
   - type: Tag
     tags:
+      - CanPilot
+      - FootstepSound
+      - DoorBumpOpener
       - ResomiEmotes
 
 - type: entity


### PR DESCRIPTION
# Description
Adds the following missing tags to resomi:
    - CanPilot
    - FootstepSound
    - DoorBumpOpener

Which have been inadvertently overwritten by the emotes tag.

# Changelog
:cl:
- fix: Resomi are now licensed as nanotrasen citizen and as such can open doors by bumping into them, can pilot spaceships, and will make footstep sounds when walking.