### PR TITLE
#Polishing Patch - Clown Rat

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
@@ -1774,7 +1774,6 @@
       Skewer: RatSkewer
   - type: NightVision
     isActive: true
-    toggleAction: null
     color: "#808080"
     activateSound: null
     deactivateSound: null

--- a/Resources/Prototypes/_Floof/Entities/Mobs/NPCs/clown_abominations.yml
+++ b/Resources/Prototypes/_Floof/Entities/Mobs/NPCs/clown_abominations.yml
@@ -199,18 +199,11 @@
       
 - type: entity
   name: crazed clown rat
-  parent: [ MobClownRat, MobCombat ]
+  parent: [ ModuleCrazedClownRat, MobClownRat, MobCombat ]
   id: MobCrazedClownRat
   description: Despite all their rage, they are still just a clown in a cage. Wait YOU LET IT FREE?
   suffix: Syndicate
   components:
-  - type: NpcFactionMember
-    factions:
-      - Syndicate
-      - Mouse
-  - type: HTN
-    rootTask:
-      task: SimpleHostileCompound
   - type: Destructible
     thresholds:
     - trigger:
@@ -268,39 +261,15 @@
     spawned:
     - id: MobCrazedClownRatHatchling
       amount: 4
-  - type: MeleeWeapon
-    soundHit:
-      path: /Audio/Effects/bite.ogg
-    damage:
-      types:
-        Slash: 2
-        Blunt: 2
-        Piercing: 3
-        Bloodloss: 4
-  - type: MobPrice
-    price: 0
-  - type: GhostRole
-    makeSentient: true
-    allowSpeech: true
-    allowMovement: true
-    name: Crazed Clown Rat
-    description: A plague released upon the world by the Syndicate, go be a menace or bite someones ankle.
-    rules: floof-ghost-role-information-team-antag-rules 
+
  
 - type: entity
   name: crazed clown rat
-  parent: [ MobClownRatHatchling , MobCombat ]
+  parent: [ ModuleCrazedClownRat, MobClownRatHatchling , MobCombat ]
   id: MobCrazedClownRatHatchling
   description: OH GOD THEY ARE MULTIPLYING!
   suffix: Syndicate, Hatchling
   components:
-  - type: NpcFactionMember
-    factions:
-      - Syndicate
-      - Mouse
-  - type: HTN
-    rootTask:
-      task: SimpleHostileCompound
   - type: Destructible
     thresholds:
     - trigger:
@@ -358,57 +327,14 @@
     spawned:
     - id: MobCrazedClownRatFinalHatchling
       amount: 4
-  - type: MeleeWeapon
-    soundHit:
-      path: /Audio/Effects/bite.ogg
-    damage:
-      types:
-        Slash: 2
-        Blunt: 2
-        Piercing: 3
-        Bloodloss: 4
-  - type: MobPrice
-    price: 0
-  - type: GhostRole
-    makeSentient: true
-    allowSpeech: true
-    allowMovement: true
-    name: Crazed Clown Rat
-    description: A plague released upon the world by the Syndicate, go be a menace or bite someones ankle.
-    rules: floof-ghost-role-information-team-antag-rules 
   
 - type: entity
   name: crazed clown rat
-  parent: [ MobClownRatFinalHatchling, MobCombat ]
+  parent: [ ModuleCrazedClownRat, MobClownRatFinalHatchling, MobCombat ]
   id: MobCrazedClownRatFinalHatchling
   description: GOD THERE IS EVEN MORE!
   suffix: Syndicate, Final_Hatchling
-  components:
-  - type: NpcFactionMember
-    factions:
-      - Syndicate
-      - Mouse
-  - type: HTN
-    rootTask:
-      task: SimpleHostileCompound
-  - type: MobPrice
-    price: 10
-  - type: MeleeWeapon
-    soundHit:
-      path: /Audio/Effects/bite.ogg
-    damage:
-      types:
-        Slash: 2
-        Blunt: 2
-        Piercing: 3
-        Bloodloss: 4
-  - type: GhostRole
-    makeSentient: true
-    allowSpeech: true
-    allowMovement: true
-    name: Crazed Clown Rat
-    description: A plague released upon the world by the Syndicate, go be a menace or bite someones ankle.
-    rules: floof-ghost-role-information-team-antag-rules 
+
       
 - type: entity
   name: dehydrated crazed clown rat box
@@ -430,3 +356,34 @@
   - type: Sprite
     sprite: _Floof/Mobs/Animals/clown_rat.rsi
     state: icon-0
+    
+    
+- type: entity
+  abstract: true
+  id: ModuleCrazedClownRat
+  components:
+  - type: NpcFactionMember
+    factions:
+      - Syndicate
+      - Mouse
+  - type: HTN
+    rootTask:
+      task: SimpleHostileCompound
+  - type: MobPrice
+    price: 0
+  - type: MeleeWeapon
+    soundHit:
+      path: /Audio/Effects/bite.ogg
+    damage:
+      types:
+        Slash: 2
+        Blunt: 2
+        Piercing: 2
+        Bloodloss: 4
+  - type: GhostRole
+    makeSentient: true
+    allowSpeech: true
+    allowMovement: true
+    name: Crazed Clown Rat
+    description: A plague released upon the world by the Syndicate, go be a menace or bite someones ankle.
+    rules: floof-ghost-role-information-team-antag-rules 

--- a/Resources/Prototypes/_Floof/Entities/Mobs/NPCs/clown_abominations.yml
+++ b/Resources/Prototypes/_Floof/Entities/Mobs/NPCs/clown_abominations.yml
@@ -14,7 +14,7 @@
       collection: FootstepClownFast
       params:
         pitch: 0.9
-        volume: -8
+        volume: -10
   - type: UseDelay
     delay: 1
   - type: EmitSoundOnUse
@@ -88,6 +88,13 @@
       - !type:GibBehavior { }
   - type: MobPrice
     price: 0
+  - type: GhostRole
+    makeSentient: true
+    allowSpeech: true
+    allowMovement: true
+    name: Clown Rat
+    description: Incarnation of the Honkmothers mischief, go out there and be a menace to society, or get some pets from strangers.
+    rules: floof-ghost-role-information-free-agent-rules 
 
 - type: entity
   name: clown rat
@@ -209,7 +216,7 @@
     - trigger:
         !type:DamageTypeTrigger
         damageType: Slash
-        damage: 60
+        damage: 50
       behaviors:
       - !type:SpawnEntitiesBehavior
         spawnInContainer: true
@@ -221,7 +228,7 @@
     - trigger:
         !type:DamageTypeTrigger
         damageType: Blunt
-        damage: 60
+        damage: 50
       behaviors:
       - !type:SpawnEntitiesBehavior
         spawnInContainer: true
@@ -233,7 +240,7 @@
     - trigger:
         !type:DamageTypeTrigger
         damageType: Piercing
-        damage: 60
+        damage: 50
       behaviors:
       - !type:SpawnEntitiesBehavior
         spawnInContainer: true
@@ -245,7 +252,7 @@
     - trigger:
         !type:DamageTypeTrigger
         damageType: Heat
-        damage: 60
+        damage: 65
       behaviors:
       - !type:SpawnEntitiesBehavior
         spawnInContainer: true
@@ -257,9 +264,29 @@
       - !type:PlaySoundBehavior
         sound:
           collection: MeatLaserImpact
+  - type: Butcherable
+    spawned:
+    - id: MobCrazedClownRatHatchling
+      amount: 4
+  - type: MeleeWeapon
+    soundHit:
+      path: /Audio/Effects/bite.ogg
+    damage:
+      types:
+        Slash: 2
+        Blunt: 2
+        Piercing: 3
+        Bloodloss: 4
   - type: MobPrice
     price: 0
-  
+  - type: GhostRole
+    makeSentient: true
+    allowSpeech: true
+    allowMovement: true
+    name: Crazed Clown Rat
+    description: A plague released upon the world by the Syndicate, go be a menace or bite someones ankle.
+    rules: floof-ghost-role-information-team-antag-rules 
+ 
 - type: entity
   name: crazed clown rat
   parent: [ MobClownRatHatchling , MobCombat ]
@@ -327,8 +354,28 @@
       - !type:PlaySoundBehavior
         sound:
           collection: MeatLaserImpact
+  - type: Butcherable
+    spawned:
+    - id: MobCrazedClownRatFinalHatchling
+      amount: 4
+  - type: MeleeWeapon
+    soundHit:
+      path: /Audio/Effects/bite.ogg
+    damage:
+      types:
+        Slash: 2
+        Blunt: 2
+        Piercing: 3
+        Bloodloss: 4
   - type: MobPrice
     price: 0
+  - type: GhostRole
+    makeSentient: true
+    allowSpeech: true
+    allowMovement: true
+    name: Crazed Clown Rat
+    description: A plague released upon the world by the Syndicate, go be a menace or bite someones ankle.
+    rules: floof-ghost-role-information-team-antag-rules 
   
 - type: entity
   name: crazed clown rat
@@ -346,6 +393,22 @@
       task: SimpleHostileCompound
   - type: MobPrice
     price: 10
+  - type: MeleeWeapon
+    soundHit:
+      path: /Audio/Effects/bite.ogg
+    damage:
+      types:
+        Slash: 2
+        Blunt: 2
+        Piercing: 3
+        Bloodloss: 4
+  - type: GhostRole
+    makeSentient: true
+    allowSpeech: true
+    allowMovement: true
+    name: Crazed Clown Rat
+    description: A plague released upon the world by the Syndicate, go be a menace or bite someones ankle.
+    rules: floof-ghost-role-information-team-antag-rules 
       
 - type: entity
   name: dehydrated crazed clown rat box


### PR DESCRIPTION
# Description

This pr aims to polish up the clown rat.
Changes:
- Made the nightvision on base mouse togglable for better accesbility.
- Added sperate Ghost role categories for the clown rat and crazed clown rat, making fiding them in ghost roles easier
- Fixed the butchering bug on crazed rats, when they would upon butchering turn to regular clown rats.
- Adjusted the spliting thresholds for 1-st generation crazed clown rats (lowered psychal tresholds by 10 to guarntee the first split due to mixed damage, while rasing the burn threshold by 5. the first generation dying without spliting is a huge let down for the price tag, so this aims to make it more consistent)
- Changed the sound of the clown rite for ma slam to a bite (its more accurate and less annoying to hear when there is a lot of rats)
- Added 4 bleed damage and extra 1 pierce damage to crazed clown rats, to justify the price tag of 10tc

Before patch damage:
        Slash: 2
        Blunt: 2
        Piercing: 2

After patch damage:
        Slash: 2
        Blunt: 2
        Piercing: 3
        Bloodloss: 4

---

# TODO

- [x] Polish up the clown rats

---

# Changelog


:cl:

- tweak: Tweaked crazed clown rats

