### PR TITLE
Logistics Addition - Boards

### DIFF
--- a/Resources/Prototypes/Catalog/Cargo/cargo_circuitboards.yml
+++ b/Resources/Prototypes/Catalog/Cargo/cargo_circuitboards.yml
@@ -7,3 +7,23 @@
   cost: 2000
   category: cargoproduct-category-name-circuitboards
   group: market
+
+﻿- type: cargoProduct
+  id: RDServerBoard
+  icon:
+    sprite: Objects/Misc/module.rsi
+    state: cpuboard
+  product: CrateRDServerBoard
+  cost: 100000
+  category: cargoproduct-category-name-circuitboards
+  group: market
+
+﻿- type: cargoProduct
+  id: AmmoTechFabBoard
+  icon:
+    sprite: Objects/Misc/module.rsi
+    state: cpuboard
+  product: CrateAmmoTechFabBoard
+  cost: 50000
+  category: cargoproduct-category-name-circuitboards
+  group: market

--- a/Resources/Prototypes/Catalog/Cargo/cargo_circuitboards.yml
+++ b/Resources/Prototypes/Catalog/Cargo/cargo_circuitboards.yml
@@ -8,7 +8,7 @@
   category: cargoproduct-category-name-circuitboards
   group: market
 
-﻿- type: cargoProduct
+﻿- type: cargoProduct # Floof
   id: RDServerBoard
   icon:
     sprite: Objects/Misc/module.rsi
@@ -18,7 +18,7 @@
   category: cargoproduct-category-name-circuitboards
   group: market
 
-﻿- type: cargoProduct
+﻿- type: cargoProduct # Floof
   id: AmmoTechFabBoard
   icon:
     sprite: Objects/Misc/module.rsi

--- a/Resources/Prototypes/Catalog/Cargo/cargo_circuitboards.yml
+++ b/Resources/Prototypes/Catalog/Cargo/cargo_circuitboards.yml
@@ -18,7 +18,7 @@
   category: cargoproduct-category-name-circuitboards
   group: market
 
-﻿- type: cargoProduct # Floof
+- type: cargoProduct # Floof
   id: AmmoTechFabBoard
   icon:
     sprite: Objects/Misc/module.rsi

--- a/Resources/Prototypes/Catalog/Cargo/cargo_circuitboards.yml
+++ b/Resources/Prototypes/Catalog/Cargo/cargo_circuitboards.yml
@@ -8,7 +8,7 @@
   category: cargoproduct-category-name-circuitboards
   group: market
 
-﻿- type: cargoProduct # Floof
+- type: cargoProduct # Floof
   id: RDServerBoard
   icon:
     sprite: Objects/Misc/module.rsi

--- a/Resources/Prototypes/Catalog/Fills/Crates/circuitboards.yml
+++ b/Resources/Prototypes/Catalog/Fills/Crates/circuitboards.yml
@@ -10,3 +10,25 @@
           amount: 2
         - id: CrewMonitoringServerMachineCircuitboard
           amount: 2
+
+﻿- type: entity # Floof
+  id: CrateRDServerBoard
+  parent: CrateScienceSecure
+  name: research and development server board
+  description: Has one R&D server board. Requires Epistemics access to open.
+  components:
+    - type: StorageFill
+      contents:
+        - id: ResearchAndDevelopmentServerMachineCircuitboard
+          amount: 1
+
+﻿- type: entity # Floof
+  id: CrateAmmoTechFabBoard
+  parent: CrateWeaponSecure
+  name: ammo tech fabricator board
+  description: Has one ammo tech fabricator board. Requires armory access to open.
+  components:
+    - type: StorageFill
+      contents:
+        - id: AmmoTechFabCircuitboard
+          amount: 1

--- a/Resources/Prototypes/Catalog/Fills/Crates/circuitboards.yml
+++ b/Resources/Prototypes/Catalog/Fills/Crates/circuitboards.yml
@@ -11,7 +11,7 @@
         - id: CrewMonitoringServerMachineCircuitboard
           amount: 2
 
-﻿- type: entity # Floof
+- type: entity # Floof
   id: CrateRDServerBoard
   parent: CrateScienceSecure
   name: research and development server board

--- a/Resources/Prototypes/Catalog/Fills/Crates/circuitboards.yml
+++ b/Resources/Prototypes/Catalog/Fills/Crates/circuitboards.yml
@@ -22,7 +22,7 @@
         - id: ResearchAndDevelopmentServerMachineCircuitboard
           amount: 1
 
-﻿- type: entity # Floof
+- type: entity # Floof
   id: CrateAmmoTechFabBoard
   parent: CrateWeaponSecure
   name: ammo tech fabricator board


### PR DESCRIPTION
# Description

Adds a more reliable way for Logistics to obtain a R&D board and an AmmoFab board.

Why?
The former is so Epistemics can continue the work easier after they finish their initial server. Still reliant on the fact it costs 100k.
The latter is quality of life for Salvage (and traitors), it requires Armory access to open, so you should ask your local Warden. (or just PKA it open), price is set at 50k, since like the RD board they can find one on an expedition.

Prices are placeholder.

# Changelog

:cl:
- add: R&D and Ammo Fab to Cargo's Catalog
