### PR TITLE
Admeme Tool - Dildos

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Fun/immovable_rod.yml
+++ b/Resources/Prototypes/Entities/Objects/Fun/immovable_rod.yml
@@ -7,7 +7,7 @@
   - type: InteractionOutline
   - type: MovementIgnoreGravity
   - type: Sprite
-    sprite: Objects/Fun/immovable_rod.rsi
+    sprite: _Floof/Objects/Fun/Lewd/Toys/Dildos/dildo_canine_red.rsi
     state: icon
     noRot: false
   - type: ImmovableRod

--- a/Resources/Prototypes/Entities/Objects/Fun/immovable_rod.yml
+++ b/Resources/Prototypes/Entities/Objects/Fun/immovable_rod.yml
@@ -7,7 +7,7 @@
   - type: InteractionOutline
   - type: MovementIgnoreGravity
   - type: Sprite
-    sprite: _Floof/Objects/Fun/Lewd/Toys/Dildos/dildo_canine_red.rsi
+    sprite: _Floof/Objects/Fun/Lewd/Toys/Dildos/dildo_canine_red.rsi # Very Obviously Floofstation
     state: icon
     noRot: false
   - type: ImmovableRod

--- a/Resources/Prototypes/_Floof/Entities/Objects/Lewd/dildos.yml
+++ b/Resources/Prototypes/_Floof/Entities/Objects/Lewd/dildos.yml
@@ -104,3 +104,25 @@
   - type: Sprite
     sprite: _Floof/Objects/Fun/Lewd/Toys/Dildos/dildo_double.rsi
     state: icon
+
+- type: entity # Admin Tool
+  parent: BaseDildo
+  id: AdminDildo
+  name: The Penetrator
+  description: A weapon to surpass metal gear...
+  components:
+  - type: Sprite
+    sprite: _Floof/Objects/Fun/Lewd/Toys/Dildos/dildo_human.rsi
+    state: icon
+  - type: MeleeWeapon
+    wideAnimationRotation: 180
+    attackRate: 10
+    range: 2.5
+    angle: 90
+    heavyStaminaCost: 1
+    heavyDamageBaseModifier: 1
+    damage:
+      types:
+        Blunt: 0
+  - type: StaminaDamageOnHit
+    damage: 100


### PR DESCRIPTION
# Description

Adds an Admin Dildo (for admin bits) and replaces the Immovable rod texture with a Red Rocket Dildo.

# Changelog

This does not go in the changelog, there are no player facing changes
