### PR TITLE
Rebalance Ethanol Thresholds

### DIFF
--- a/Resources/Prototypes/Reagents/Consumable/Drink/alcohol.yml
+++ b/Resources/Prototypes/Reagents/Consumable/Drink/alcohol.yml
@@ -165,7 +165,7 @@
       - !type:HealthChange
         conditions:
         - !type:ReagentThreshold
-          min: 45
+          min: 30 # Floof - reduced from 45
         damage:
           types:
             Poison: 1
@@ -174,7 +174,7 @@
         conditions:
         - !type:ReagentThreshold
           reagent: Ethanol
-          min: 12
+          min: 25 # Floof - increased from 12
         # dwarves immune to vomiting from alcohol
         - !type:OrganType
           type: Dwarf
@@ -186,8 +186,8 @@
           type: LiquorLifeline
         - !type:ReagentThreshold
           reagent: Ethanol
-          min: 0.10
-          max: 0.49
+          min: 0.20 # Floof
+          max: 0.99 # Floof
         damage:   # NOTE: all damage sets for LiquorLifeline are halved due to
           groups: # LightweightDrunkComponent making ethanol half as potent
             Brute: -0.4
@@ -201,8 +201,8 @@
           type: LiquorLifeline
         - !type:ReagentThreshold
           reagent: Ethanol
-          min: 0.50
-          max: 6.99
+          min: 1.0 # Floof
+          max: 13.99 # Floof
         damage:
           groups:
             Brute: -0.8
@@ -216,8 +216,8 @@
           type: LiquorLifeline
         - !type:ReagentThreshold
           reagent: Ethanol
-          min: 7.00
-          max: 10.99
+          min: 14.0 # Floof
+          max: 21.99 # Floof
         damage:
           groups:
             Brute: -1.6
@@ -231,8 +231,8 @@
           type: LiquorLifeline
         - !type:ReagentThreshold
           reagent: Ethanol
-          min: 11
-          max: 14.99
+          min: 22 # Floof
+          max: 29.99 # Floof
         damage:
           groups:
             Brute: -3.2
@@ -246,7 +246,7 @@
           type: LiquorLifeline
         - !type:ReagentThreshold
           reagent: Ethanol
-          min: 15 # Overdose threshold
+          min: 30 # Overdose threshold # Floof - everything was doubled
         damage:
           groups:
             Brute: -4.8


### PR DESCRIPTION
# Description
Previously EE has increased the ethanol poisoning threshold from 15u to 45u, but left the vomiting threshold unchanged at 12u.

This slightly tones down the poisoning threshold (45->30), but instead increases the vomiting threshold (12->25), allowing people to chug more booze before letting the floor bugs taste it.

Also changes the healing thresholds from "Liquor lifeline" to match the new values.

# Changelog
:cl:
- tweak: You can now drink almost twice as much alcohol before starting to puke, but also 33% less before starting to get poisoned.
- tweak: Liquor lifeline now also requires drinking twice as much to match the new thresholds.