### PR TITLE
Bootleg Surgery+

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Tools/jaws_of_life.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/jaws_of_life.yml
@@ -66,6 +66,22 @@
     difficulty: 3
     recipes:
       - JawsOfLife
+    # Floof Shitmed - Improvised Tools
+  - type: Retractor
+    speed: 1
+  - type: Hemostat
+    speed: 1
+  - type: Tweezers
+    speed: 1
+  - type: SurgeryTool
+    startSound:
+      path: /Audio/Items/jaws_pry.ogg
+      params:
+        variation: 0.125
+    endSound:
+      path: /Audio/Items/jaws_pry.ogg
+      params:
+        variation: 0.125   
 
 - type: entity
   name: syndicate jaws of life

--- a/Resources/Prototypes/Entities/Objects/Tools/tools.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/tools.yml
@@ -686,6 +686,26 @@
           state: omnitool-pulsing
         changeSound:
           path: /Audio/Items/change_drill.ogg
+    # Floof Shitmed - Improv Tools, this is more so for consistency and unlikely to be used     
+  - type: SurgeryTool
+    startSound:
+      path: /Audio/_Shitmed/Medical/Surgery/saw.ogg
+  - type: Hemostat
+    speed: 0.9
+  - type: Scalpel
+    speed: 0.9
+  - type: Drill
+    speed: 0.9
+  - type: BoneSetter
+    speed: 0.9
+  - type: Retractor
+    speed: 0.9
+  - type: BoneSaw
+    speed: 0.9
+  - type: Tweezers
+    speed: 0.9
+  - type: Tending
+    speed: 0.9
 
 #Other
 - type: entity

--- a/Resources/Prototypes/Entities/Objects/Tools/tools.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/tools.yml
@@ -492,7 +492,6 @@
     endSound:
       path: /Audio/Medical/Surgery/retractor2.ogg
 
-
 - type: entity
   id: RCD
   parent: BaseItem

--- a/Resources/Prototypes/Entities/Objects/Tools/tools.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/tools.yml
@@ -481,6 +481,17 @@
     difficulty: 2
     recipes:
       - PowerDrill
+    # Floof Shitmed - Still not the intended tool but faster
+  - type: Retractor
+    speed: 1
+  - type: Tending
+    speed: 1
+  - type: SurgeryTool # Not using the power drill noise or it'll be really annoying on repeat
+    startSound:
+      collection: Screwdriver
+    endSound:
+      path: /Audio/Medical/Surgery/retractor2.ogg
+
 
 - type: entity
   id: RCD

--- a/Resources/Prototypes/Entities/Objects/Tools/welders.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/welders.yml
@@ -216,7 +216,7 @@
       - ReagentId: WeldingFuel
         Quantity: 1
   - type: Tool
-    speedModifier: 1.3 # it being faster is fine
+    speedModifier: 1.0 # it being faster is fine
     # Floof Shitmed - Improvised Tools
   - type: Cautery
     speed: 1.0

--- a/Resources/Prototypes/Entities/Objects/Tools/welders.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/welders.yml
@@ -216,7 +216,7 @@
       - ReagentId: WeldingFuel
         Quantity: 1
   - type: Tool
-    speedModifier: 1.5 # For whatever reason this item didn't have this when an advanced industrial welding tool did
+    speedModifier: 1.3 # it being faster is fine
     # Floof Shitmed - Improvised Tools
   - type: Cautery
     speed: 1.0

--- a/Resources/Prototypes/Entities/Objects/Tools/welders.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/welders.yml
@@ -219,7 +219,7 @@
     speedModifier: 1.5 # For whatever reason this item didn't have this when an advanced industrial welding tool did
     # Floof Shitmed - Improvised Tools
   - type: Cautery
-    speed: 1.3
+    speed: 1.0
   - type: SurgeryTool
     startSound:
       collection: Welder

--- a/Resources/Prototypes/Entities/Objects/Tools/welders.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/welders.yml
@@ -151,6 +151,14 @@
         - ReagentId: WeldingFuel
           Quantity: 250
         maxVol: 250
+    # Floof Shitmed - Improvised Tools
+  - type: Cautery
+    speed: 1
+  - type: SurgeryTool
+    startSound:
+      collection: Welder
+    endSound:
+      collection: WelderOff
 
 - type: entity
   name: advanced industrial welding tool
@@ -171,6 +179,14 @@
         maxVol: 250
   - type: Tool
     speedModifier: 1.3
+    # Floof Shitmed - Improvised Tools
+  - type: Cautery
+    speed: 1
+  - type: SurgeryTool
+    startSound:
+      collection: Welder
+    endSound:
+      collection: WelderOff
 
 - type: entity
   name: experimental welding tool
@@ -199,6 +215,16 @@
       reagents:
       - ReagentId: WeldingFuel
         Quantity: 1
+  - type: Tool
+    speedModifier: 1.5 # For whatever reason this item didn't have this when an advanced industrial welding tool did
+    # Floof Shitmed - Improvised Tools
+  - type: Cautery
+    speed: 1.3
+  - type: SurgeryTool
+    startSound:
+      collection: Welder
+    endSound:
+      collection: WelderOff
 
 - type: entity
   name: emergency welding tool
@@ -226,3 +252,11 @@
     enabled: false
     radius: 1.0
     color: orange
+    # Floof Shitmed - Improvised Tools
+  - type: Cautery
+    speed: 0.5 #slower
+  - type: SurgeryTool
+    startSound:
+      collection: Welder
+    endSound:
+      collection: WelderOff


### PR DESCRIPTION
# Description

Adds Surgery Tool lines to advanced tools since they were lacking those over normal tools, they're as fast as normal surgery tools due to their powered nature, but still worse then advanced surgery tools.

Also added welders use speed for experimental welder because advanced industrial had a speed bonus but the experimental didn't. 

# Changelog

:cl:
- add: Added Surgery Tool tags to advanced tools
- add: Added use speed bonus to Experimental Welder
