### PR TITLE
Slide Papers and Mails Through Doors

### DIFF
--- a/Content.Shared/Physics/CollisionGroup.cs
+++ b/Content.Shared/Physics/CollisionGroup.cs
@@ -70,6 +70,8 @@ public enum CollisionGroup
     // Soap, spills
     SlipLayer = MidImpassable | LowImpassable,
     ItemMask = Impassable | HighImpassable,
+
+    ItemSlideUnderDoorMask = Impassable | LowImpassable, // FLOOF ADD: Allows some items to slide under doors
     ThrownItem = Impassable | HighImpassable | BulletImpassable,
     WallLayer = Opaque | Impassable | HighImpassable | MidImpassable | LowImpassable | BulletImpassable | InteractImpassable,
     GlassLayer = Impassable | HighImpassable | MidImpassable | LowImpassable | BulletImpassable | InteractImpassable,

--- a/Resources/Prototypes/Entities/Objects/Misc/paper.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/paper.yml
@@ -77,6 +77,19 @@
     sound: /Audio/SimpleStation14/Items/Handling/paper_drop.ogg
   - type: EmitSoundOnLand
     sound: /Audio/SimpleStation14/Items/Handling/paper_drop.ogg
+  # FLOOF ADD START: Slide papers and such under doors
+  - type: Fixtures
+    fixtures:
+      fix1:
+        shape:
+          !type:PhysShapeAabb
+          bounds: "-0.25,-0.25,0.25,0.25"
+        density: 20
+        mask:
+        - ItemSlideUnderDoorMask
+        restitution: 0.3
+        friction: 0.2
+  # FLOOF ADD END
 
 - type: entity
   name: paper scrap
@@ -845,3 +858,16 @@
   - type: Construction
     graph: PaperEnvelope
     node: envelope
+  # FLOOF ADD START: Slide papers and such under doors
+  - type: Fixtures
+    fixtures:
+      fix1:
+        shape:
+          !type:PhysShapeAabb
+          bounds: "-0.25,-0.25,0.25,0.25"
+        density: 20
+        mask:
+        - ItemSlideUnderDoorMask
+        restitution: 0.3
+        friction: 0.2
+  # FLOOF ADD END

--- a/Resources/Prototypes/Entities/Objects/Specific/Mail/base_mail_large.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Mail/base_mail_large.yml
@@ -71,6 +71,19 @@
   - type: MultiHandedItem
   - type: Mail
     isLarge: true
+  # FLOOF ADD START: Slide papers and such under doors
+  - type: Fixtures
+    fixtures:
+      fix1:
+        shape:
+          !type:PhysShapeAabb
+          bounds: "-0.25,-0.25,0.25,0.25"
+        density: 20
+        mask:
+        - ItemMask # so u cant throw huge boxes under doors
+        restitution: 0.3
+        friction: 0.2
+  # FLOOF ADD END
 
 - type: entity
   categories: [ HideSpawnMenu ]

--- a/Resources/Prototypes/EstacaoPirata/Entities/Objects/Misc/base.yml
+++ b/Resources/Prototypes/EstacaoPirata/Entities/Objects/Misc/base.yml
@@ -64,6 +64,19 @@
         type: CardHandMenuBoundUserInterface
   # - type: ActivatableUI # Frontier
   #   key: enum.CardUiKey.Key # Frontier
+  # FLOOF ADD START: Slide papers and such under doors
+  - type: Fixtures
+    fixtures:
+      fix1:
+        shape:
+          !type:PhysShapeAabb
+          bounds: "-0.25,-0.25,0.25,0.25"
+        density: 20
+        mask:
+        - ItemSlideUnderDoorMask
+        restitution: 0.3
+        friction: 0.2
+  # FLOOF ADD END
 
 - type: entity
   parent: CardStackBase

--- a/Resources/Prototypes/EstacaoPirata/Entities/Objects/Misc/black_cards.yml
+++ b/Resources/Prototypes/EstacaoPirata/Entities/Objects/Misc/black_cards.yml
@@ -111,6 +111,19 @@
       state: singlecard_down_black
     flipped: true
   # - type: StripMenuHidden # Floof
+  # FLOOF ADD START: Slide papers and such under doors
+  - type: Fixtures
+    fixtures:
+      fix1:
+        shape:
+          !type:PhysShapeAabb
+          bounds: "-0.25,-0.25,0.25,0.25"
+        density: 20
+        mask:
+        - ItemSlideUnderDoorMask
+        restitution: 0.3
+        friction: 0.2
+  # FLOOF ADD END
 
 # region Black Cards
 

--- a/Resources/Prototypes/Nyanotrasen/Entities/Objects/Specific/Mail/base_mail.yml
+++ b/Resources/Prototypes/Nyanotrasen/Entities/Objects/Specific/Mail/base_mail.yml
@@ -107,6 +107,19 @@
   - type: LanguageKnowledge
     speaks: [TauCetiBasic] # So that them foreigners can't understand what the broken mail is saying
     understands: []
+  # FLOOF ADD START: Slide papers and such under doors
+  - type: Fixtures
+    fixtures:
+      fix1:
+        shape:
+          !type:PhysShapeAabb
+          bounds: "-0.25,-0.25,0.25,0.25"
+        density: 20
+        mask:
+        - ItemSlideUnderDoorMask
+        restitution: 0.3
+        friction: 0.2
+  # FLOOF ADD END
 
 # This empty parcel is allowed to exist and evade the tests for the admin
 # mailto command.


### PR DESCRIPTION
# Description

Papers (and anything descending of paper), envelopes, playing cards, and non-package mail no longer collide with doors. Basically if a mouse can go through it, bureaucracy can too.

Now you can slide notes under doors, and deliver mail to people banging in dorms! Send people secret admirer notes! Hand out surveys about their current dorms experiences! Have all your important paperwork fly out the airlock!

About that last part, folders and such *dont* go through doors, so if you dont want those Vital Secret Documents just flying out into space in that one in a billion situation where something launches it into a door leading out into space, just put it in a folder or something!

---

# Changelog

:cl: Superlagg
- tweak: Papers, Envelopes, Playing Cards, and Small Mail can now be slid under doors! You can do this by just tossing it through the door, kinda like mice!
