### PR TITLE
Pipe Bomb in Your Mail

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Misc/paper.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/paper.yml
@@ -806,6 +806,7 @@
         whitelist:
           tags:
             - Paper
+            - EnvelopeFiller
   - type: ActivatableUI
     key: enum.PaperUiKey.Key
     requiresComplex: false

--- a/Resources/Prototypes/Entities/Objects/Weapons/Bombs/plastic.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Bombs/plastic.yml
@@ -34,6 +34,9 @@
         base:
           Primed: { state: primed }
           Unprimed: { state: complete }
+  - type: Tag
+    tags:
+    - EnvelopeFiller
 
 - type: entity
   name: composition C-4

--- a/Resources/Prototypes/Entities/Objects/Weapons/Throwable/clusterbang.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Throwable/clusterbang.yml
@@ -143,6 +143,9 @@
   - type: ContainerContainer
     containers:
       cluster-payload: !type:Container
+  - type: Tag
+    tags:
+    - EnvelopeFiller
 
 - type: entity
   parent: GrenadeBase
@@ -172,6 +175,9 @@
   - type: ContainerContainer
     containers:
       cluster-payload: !type:Container
+  - type: Tag
+    tags:
+    - EnvelopeFiller
 
 - type: entity
   parent: GrenadeBase
@@ -201,6 +207,9 @@
   - type: ContainerContainer
     containers:
       cluster-payload: !type:Container
+  - type: Tag
+    tags:
+    - EnvelopeFiller
 
 - type: entity
   parent: SoapSyndie

--- a/Resources/Prototypes/Entities/Objects/Weapons/Throwable/grenades.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Throwable/grenades.yml
@@ -36,6 +36,9 @@
         enum.ConstructionVisuals.Layer:
           Primed: { state: primed }
           Unprimed: { state: icon }
+  - type: Tag
+    tags:
+    - EnvelopeFiller
 
 - type: entity
   name: explosive grenade

--- a/Resources/Prototypes/_Floof/tags.yml
+++ b/Resources/Prototypes/_Floof/tags.yml
@@ -34,3 +34,6 @@
 
 - type: Tag
   id: ShirtlessClothing
+
+- type: Tag
+  id: EnvelopeFiller

--- a/Resources/Prototypes/_Floof/tags.yml
+++ b/Resources/Prototypes/_Floof/tags.yml
@@ -37,3 +37,4 @@
 
 - type: Tag
   id: EnvelopeFiller
+


### PR DESCRIPTION
![Zrzut ekranu 2025-06-10 023933](https://github.com/user-attachments/assets/d6529194-3070-4a25-88a5-03007f16b397)

# Description
This pr allows small explosives, like grenades, c4 and most importantly, pipe bombs to be put in the envelopes.
Adds a new tag for items that can fit in the envelopes, called "EnvelopeFiller"

---

# TODO

- [x] Enjoy

---

<details><summary><h1>Media</h1></summary>
<p>

![image](https://github.com/user-attachments/assets/5ae715a7-1732-432d-9a6d-204115e22b52) 

</p>
</details>

---

# Changelog

:cl:

- tweak: Allowed small explosives to be put inside of the envelopes.

