### PR TITLE
LPO Inherits Character Appearance

### DIFF
--- a/Resources/Prototypes/DeltaV/Entities/Mobs/Player/human.yml
+++ b/Resources/Prototypes/DeltaV/Entities/Mobs/Player/human.yml
@@ -12,3 +12,4 @@
     - type: AutoImplant
       implants:
       - DeathAcidifierImplant
+    - type: AntagLoadProfileRule # Floofstation


### PR DESCRIPTION
# Description

Adds a line that should allow Listening Post Operatives to inherit their character profile appearance

# Changelog

:cl:
- tweak: Tweaked it so LPOs spawn as your character
