### PR TITLE
Task Adjust I (Bug Fixes)

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/Belt/belts.yml
+++ b/Resources/Prototypes/Entities/Clothing/Belt/belts.yml
@@ -172,9 +172,16 @@
     sprite: Clothing/Belt/assault.rsi
   - type: Storage
     whitelist:
-      tags:
+      tags: # Floof - M3739 - TaskAdjust-I
         - CigPack
         - Taser
+        - SecBeltEquip
+        - Radio
+        - Sidearm
+        - MagazinePistol
+        - MagazineMagnum
+        - CombatKnife
+        - Truncheon
       components:
         - Stunbaton
         - FlashOnTrigger
@@ -183,6 +190,11 @@
         - Handcuff
         - BallisticAmmoProvider
         - Ammo
+        - CartridgeAmmo
+        - DoorRemote
+        - Whistle
+        - HolosignProjector
+        - BalloonPopper
   - type: ItemMapper
     mapLayers:
       flashbang:

--- a/Resources/Prototypes/Entities/Clothing/Belt/belts.yml
+++ b/Resources/Prototypes/Entities/Clothing/Belt/belts.yml
@@ -172,7 +172,7 @@
     sprite: Clothing/Belt/assault.rsi
   - type: Storage
     whitelist:
-      tags: # Floof - M3739 - TaskAdjust-I
+      tags: # Floof - M3739 - #1097
         - CigPack
         - Taser
         - SecBeltEquip

--- a/Resources/Prototypes/Entities/Clothing/Shoes/boots.yml
+++ b/Resources/Prototypes/Entities/Clothing/Shoes/boots.yml
@@ -71,7 +71,7 @@
   - type: Clothing
     sprite: Clothing/Shoes/Boots/combatboots.rsi
   - type: ClothingSlowOnDamageModifier # Floof - M3739 - Strange this isn't on this, when the jackboots have them...
-    modifier: 0.5
+    modifier: 0.8 # Floof - M3739 - TaskAdjust-I
   - type: Tag #Floofstation
     tags:
     - CombatBoots

--- a/Resources/Prototypes/Entities/Clothing/Shoes/boots.yml
+++ b/Resources/Prototypes/Entities/Clothing/Shoes/boots.yml
@@ -71,7 +71,7 @@
   - type: Clothing
     sprite: Clothing/Shoes/Boots/combatboots.rsi
   - type: ClothingSlowOnDamageModifier # Floof - M3739 - Strange this isn't on this, when the jackboots have them...
-    modifier: 0.8 # Floof - M3739 - TaskAdjust-I
+    modifier: 0.8 # Floof - M3739 - #1097
   - type: Tag #Floofstation
     tags:
     - CombatBoots

--- a/Resources/Prototypes/Roles/Jobs/Security/detective.yml
+++ b/Resources/Prototypes/Roles/Jobs/Security/detective.yml
@@ -34,7 +34,7 @@
     outerClothing: ClothingOuterVestDetective
     id: DetectivePDA
     ears: ClothingHeadsetSecurity
-    belt: ClothingBeltSecurityFilled # Floof - M3739 - TaskAdjust-I
+    belt: ClothingBeltSecurityFilled # Floof - M3739 - #1097
   innerClothingSkirt: ClothingUniformJumpskirtDetective
   satchel: ClothingBackpackSatchelSecurity
   duffelbag: ClothingBackpackDuffelSecurity

--- a/Resources/Prototypes/Roles/Jobs/Security/detective.yml
+++ b/Resources/Prototypes/Roles/Jobs/Security/detective.yml
@@ -34,7 +34,7 @@
     outerClothing: ClothingOuterVestDetective
     id: DetectivePDA
     ears: ClothingHeadsetSecurity
-    belt: ClothingBeltHolsterFilled
+    belt: ClothingBeltSecurityFilled # Floof - M3739 - TaskAdjust-I
   innerClothingSkirt: ClothingUniformJumpskirtDetective
   satchel: ClothingBackpackSatchelSecurity
   duffelbag: ClothingBackpackDuffelSecurity

--- a/Resources/Prototypes/_Floof/Entities/Clothing/Shoes/boots.yml
+++ b/Resources/Prototypes/_Floof/Entities/Clothing/Shoes/boots.yml
@@ -16,7 +16,7 @@
     footstepSoundCollection:
       collection: FootstepHighHeels
   - type: ClothingSlowOnDamageModifier
-    modifier: 0.5
+    modifier: 0.8
   - type: Construction
     graph: ClothingShoesCombatHighheelBoots
     node: shoes

--- a/Resources/Prototypes/_Floof/Entities/Clothing/departmental_clothes.yml
+++ b/Resources/Prototypes/_Floof/Entities/Clothing/departmental_clothes.yml
@@ -18,7 +18,7 @@
   - type: FingerprintMask
 
 - type: entity
-  parent: ClothingShoesBase
+  parent: ClothingShoesMilitaryBase
   id: ClothingUnderSocksCaptain
   name: captain's thigh-high socks
   description: A pair of thigh-high socks, styled for a captain.
@@ -27,6 +27,8 @@
     sprite: _Floof/Clothing/Departmental/Command/captsocks.rsi
   - type: Clothing
     sprite: _Floof/Clothing/Departmental/Command/captsocks.rsi
+  - type: ClothingSlowOnDamageModifier
+    modifier: 0.8
 
 - type: entity
   parent: ClothingUniformThongBase
@@ -656,7 +658,7 @@
   - type: Clothing
     sprite: _Floof/Clothing/Departmental/Security/secsocks.rsi
   - type: ClothingSlowOnDamageModifier
-    modifier: 0.5
+    modifier: 0.8
 
 - type: entity
   parent: ClothingUniformThongBase
@@ -696,7 +698,7 @@
   - type: Clothing
     sprite: _Floof/Clothing/Departmental/Security/hossocks.rsi
   - type: ClothingSlowOnDamageModifier
-    modifier: 0.5
+    modifier: 0.8
 
 - type: entity
   parent: ClothingUniformThongBase
@@ -736,7 +738,7 @@
   - type: Clothing
     sprite: _Floof/Clothing/Departmental/Security/detectsocks.rsi
   - type: ClothingSlowOnDamageModifier
-    modifier: 0.5
+    modifier: 0.8
 
 - type: entity
   parent: ClothingUniformThongBase
@@ -776,7 +778,7 @@
   - type: Clothing
     sprite: _Floof/Clothing/Departmental/Security/corpsmansocks.rsi
   - type: ClothingSlowOnDamageModifier
-    modifier: 0.5
+    modifier: 0.8
 
 - type: entity
   parent: ClothingUniformThongBase

--- a/Resources/Prototypes/_Goobstation/Entities/Clothing/Eyes/glasses.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Clothing/Eyes/glasses.yml
@@ -17,7 +17,7 @@
     - HudMedical
   - type: IdentityBlocker
     coverage: EYES
-#  - type: ShowHealthBars | Floof - M3739 - TaskAdjust-I
+#  - type: ShowHealthBars | Floof - M3739 - #1097
 #    damageContainers:
 #    - Biological
 #  - type: ShowHealthIcons

--- a/Resources/Prototypes/_Goobstation/Entities/Clothing/Eyes/glasses.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Clothing/Eyes/glasses.yml
@@ -17,10 +17,10 @@
     - HudMedical
   - type: IdentityBlocker
     coverage: EYES
-  - type: ShowHealthBars
-    damageContainers:
-    - Biological
-  - type: ShowHealthIcons
-    damageContainers:
-    - Biological
+#  - type: ShowHealthBars | Floof - M3739 - TaskAdjust-I
+#    damageContainers:
+#    - Biological
+#  - type: ShowHealthIcons
+#    damageContainers:
+#    - Biological
     


### PR DESCRIPTION
<!--
This is a semi-strict format, you can add/remove sections as needed but the order/format should be kept the same
Remove these comments before submitting
-->

# Description

<!--
Explain this PR in as much detail as applicable

Some example prompts to consider:
How might this affect the game? The codebase?
What might be some alternatives to this?
How/Who does this benefit/hurt [the game/codebase]?
-->

This PR aims to address a series of bugs I have noticed thus far in my ventures in-game.

The list of changes is the following:

- BSO's med sec glasses had their `ShowHealthBars` and `ShowHealthIcons` components commented out to properly inherit  from one of it's parents: `ShowMedicalIcons`
- Actually made #854 apply as intended, and fix the damage slow reduction across the related combat apparel.
- Added damage slow reduction to the Captain's thigh-highs, and make it able to hold a knife or sidearm via parenting to `ClothingShoesMilitaryBase`.
- Made the assault belt able to hold the same things a security belt can hold.
- Changed Detective's belt in `startingGear` to be a security belt. No more free inspector with 2 speed loaders.

---

<!--
This is default collapsed, readers click to expand it and see all your media
The PR media section can get very large at times, so this is a good way to keep it clean
The title is written using HTML tags
The title must be within the <summary> tags or you won't see it
-->

<details><summary><h1>Media</h1></summary>
<p>

![image](https://github.com/user-attachments/assets/561b41ae-b79c-44fc-88ff-75f8eebafd27)
_Figure 1. 'Medsecglasses' reporting a kitsune's vitals._
![image](https://github.com/user-attachments/assets/2ec63d97-2881-4540-b72f-357f3252db67)
_Figure 2. Captain's thigh-highs' newest revision, including a reinforced mesh and a concealed pocket to stash a sidearm or knife._
![image](https://github.com/user-attachments/assets/a823f20c-0d01-4118-9d8c-4ba128405dfd)
_Figure 3. The 'assault belt' demonstrating it's similiar capabilities to a standard-issue security belt._
![image](https://github.com/user-attachments/assets/68af51dd-7fa7-44a2-b848-3d2d9dc34654)
_Figure 4. Revision of the standard-issue kit for a detective on a station assignment. Note usage of a standard-issue security belt instead of a shoulder holster._

</p>
</details>

---

# Changelog

<!--
You can add an author after the `:cl:` to change the name that appears in the changelog (ex: `:cl: Death`)
Leaving it blank will default to your GitHub display name
This includes all available types for the changelog
-->

:cl: M3739
- fix: Blueshield Officer's med sec glasses can now properly read a kitsune's vitals.
- fix: Footwear with damage slow reduction has been revised and corrected.
- fix: It is no longer possible for the detective to start with a free revolver and two speed loaders.