### PR TITLE
100% Orange Juice - Commission PR

### DIFF
--- a/Resources/Locale/en-US/_Floof/traits/traits.ftl
+++ b/Resources/Locale/en-US/_Floof/traits/traits.ftl
@@ -151,3 +151,6 @@ trait-description-Tiny =
     Note: [color=red]this will not display in the character creation menu, and will only apply the effects in-game.[/color]
 
 examine-tiny-trait-message = {CAPITALIZE(SUBJECT($entity))} is tiny. Handle with care!
+
+trait-name-RealOrangeJuice = 100% Orange Juice
+trait-description-RealOrangeJuice = You are a 100% organic pulp-free Orange Juice Reagent Slime.

--- a/Resources/Prototypes/_Floof/Traits/physical.yml
+++ b/Resources/Prototypes/_Floof/Traits/physical.yml
@@ -254,4 +254,39 @@
   - !type:TraitAddComponent
     components:
     - type: FixtureDensityModifier
-      factor: 1.4 # Lets try the opposite of lightweight, yeah?
+
+- type: trait # Commission for Karin
+  id: RealOrangeJuice
+  category: Physical
+  points: 0
+  requirements:
+  - !type:CharacterJobRequirement
+    inverted: true
+    jobs:
+    - Borg
+    - MedicalBorg
+  - !type:CharacterSpeciesRequirement
+    species:
+    - SlimePerson
+  - !type:CharacterTraitRequirement
+    inverted: true
+    traits:
+    - MilkProducer
+  functions:
+  - !type:TraitAddComponent
+    components:
+    - type: MilkProducer
+      solutionname: "breasts"
+    - type: SolutionContainerManager
+      solutions:
+        breasts:
+          maxVol: 50
+          reagents:
+          - ReagentId: JuiceOrange 
+            Quantity: 50
+    - type: MeleeChemicalInjector
+      solution: bloodstream
+      transferAmount: 2
+  - !type:TraitReplaceComponent
+    - type: Bloodstream
+      bloodReagent: JuiceOrange

--- a/Resources/Prototypes/_Floof/Traits/physical.yml
+++ b/Resources/Prototypes/_Floof/Traits/physical.yml
@@ -289,6 +289,12 @@
       solution: bloodstream
       transferAmount: 2
     - type: Bloodstream
+      bloodlossDamage:
+        types:
+          Bloodloss: 0.5
+      bloodlossHealDamage:
+        types:
+          Bloodloss: -1
       bloodReagent: JuiceOrange
       bloodRegenerationHunger: 2
       bloodRegenerationThirst: 2 

--- a/Resources/Prototypes/_Floof/Traits/physical.yml
+++ b/Resources/Prototypes/_Floof/Traits/physical.yml
@@ -290,3 +290,5 @@
       transferAmount: 2
     - type: Bloodstream
       bloodReagent: JuiceOrange
+      bloodRegenerationHunger: 2
+      bloodRegenerationThirst: 2 

--- a/Resources/Prototypes/_Floof/Traits/physical.yml
+++ b/Resources/Prototypes/_Floof/Traits/physical.yml
@@ -254,6 +254,7 @@
   - !type:TraitAddComponent
     components:
     - type: FixtureDensityModifier
+      factor: 1.4 # Lets try the opposite of lightweight, yeah?
 
 - type: trait # Commission for Karin
   id: RealOrangeJuice
@@ -287,6 +288,5 @@
     - type: MeleeChemicalInjector
       solution: bloodstream
       transferAmount: 2
-  - !type:TraitReplaceComponent
     - type: Bloodstream
       bloodReagent: JuiceOrange


### PR DESCRIPTION
# Description

PR Commission created for Karin, for the cost of one half eaten sandwich, one eternal love, and a possible art commission.
Completely unlikely to be merged unless she bribes all the maintainers.

Adds a slime only trait, that changes the bloodstream to orange juice, breast milk to orange juice, and adds the reagent slime on hit effect which injects the bloodstream (orange juice).

Only setting to open to see if the Milk Producer component works with reagents other then milk.