### PR TITLE
Fix Roundstart Loop Caused by Invalid Loadouts

### DIFF
--- a/Content.Server/Clothing/Systems/LoadoutSystem.cs
+++ b/Content.Server/Clothing/Systems/LoadoutSystem.cs
@@ -121,7 +121,7 @@ public sealed class LoadoutSystem : EntitySystem
         #if EXCEPTION_TOLERANCE
         catch (Exception e) // Also floofstation
         {
-            Log.Error("Caught exception while spawning loadouts.", e)
+            Log.Error("Caught exception while spawning loadouts.", e);
         }
         #endif
 

--- a/Content.Server/Clothing/Systems/LoadoutSystem.cs
+++ b/Content.Server/Clothing/Systems/LoadoutSystem.cs
@@ -90,7 +90,13 @@ public sealed class LoadoutSystem : EntitySystem
         }
 
         foreach (var loadout in allLoadouts)
+        #if EXCEPTION_TOLERANCE
+        try // Floofstation - try-catch in exception tolerance mode
+        #endif
         {
+            if (!Exists(loadout.Item1))
+                continue; // Floofstation - skip failed loadouts. This used to cause roundstart loop.
+            
             var loadoutProto = _protoMan.Index<LoadoutPrototype>(loadout.Item2.LoadoutName);
             if (loadoutProto.CustomName && loadout.Item2.CustomName != null)
                 _meta.SetEntityName(loadout.Item1, loadout.Item2.CustomName);
@@ -112,6 +118,12 @@ public sealed class LoadoutSystem : EntitySystem
             foreach (var function in loadoutProto.Functions)
                 function.OnPlayerSpawn(uid, loadout.Item1, _componentFactory, EntityManager, _serialization);
         }
+        #if EXCEPTION_TOLERANCE
+        catch (Exception e) // Also floofstation
+        {
+            Log.Error("Caught exception while spawning loadouts.", e)
+        }
+        #endif
 
         // Pick the heirloom
         if (heirlooms.Any())


### PR DESCRIPTION
# Description
If the loadout system tries to spawn severeal exclusive items where the second item overrides the first, the first item will end up deleted. It however will still be returned from ApplyCharacterLoadout, and the loadout system will later try to paint the already-deleted item, causing an exception to be thrown and round start to be aborted.

This fixes it by checking whether the item actually exists and adding a try-catch statement.

## This will need some basic testing in release mode because the change was web-editted

# Changelog
:cl:
- fix: The roundstart loop bug should now be fixed.