### PR TITLE
Salvage Vend Additions

### DIFF
--- a/Resources/Prototypes/DeltaV/Catalog/VendingMachines/Inventories/salvage_points.yml
+++ b/Resources/Prototypes/DeltaV/Catalog/VendingMachines/Inventories/salvage_points.yml
@@ -25,6 +25,10 @@
     cost: 500
   - id: ClothingBeltSalvageWebbing
     cost: 500
+  - id: ClothingBeltMercWebbing
+    cost: 500
+  - id: ClothingBeltMilitaryWebbing
+    cost: 600
   - id: MedkitBruteFilled
     cost: 600
   - id: MedkitBurnFilled

--- a/Resources/Prototypes/DeltaV/Catalog/VendingMachines/Inventories/salvage_points.yml
+++ b/Resources/Prototypes/DeltaV/Catalog/VendingMachines/Inventories/salvage_points.yml
@@ -69,6 +69,14 @@
   # cost: 6400
   - id: WeaponRifleSVTEmpty
     cost: 6400
+  - id: MagazineBoxLightRifle
+    cost: 1500
+  - id: MagazineLightRifleEmpty
+    cost: 500
+  - id: MagazineBoxRifle
+    cost: 1500
+  - id: MagazineRifleEmpty
+    cost: 500
   - id: SpaceCash1000
     cost: 1000
   # TODO: super resonator for 2500

--- a/Resources/Prototypes/DeltaV/Catalog/VendingMachines/Inventories/salvage_points.yml
+++ b/Resources/Prototypes/DeltaV/Catalog/VendingMachines/Inventories/salvage_points.yml
@@ -69,13 +69,13 @@
   # cost: 6400
   - id: WeaponRifleSVTEmpty
     cost: 6400
-  - id: MagazineBoxLightRifle
+  - id: MagazineBoxLightRifle # Floofstation
     cost: 1500
-  - id: MagazineLightRifleEmpty
+  - id: MagazineNovaliteC1Empty # Floofstation
     cost: 500
-  - id: MagazineBoxRifle
+  - id: MagazineBoxRifle # Floofstation
     cost: 1500
-  - id: MagazineRifleEmpty
+  - id: MagazineRifleEmpty # Floofstation
     cost: 500
   - id: SpaceCash1000
     cost: 1000

--- a/Resources/Prototypes/DeltaV/Catalog/VendingMachines/Inventories/salvage_points.yml
+++ b/Resources/Prototypes/DeltaV/Catalog/VendingMachines/Inventories/salvage_points.yml
@@ -14,6 +14,10 @@
     cost: 1500
   - id: WeaponGrapplingGun
     cost: 300
+  - id: ClothingMaskGasExplorer # Floofstation - Incase you lose yours
+    cost: 300
+  - id: ClothingMaskGasMerc # Floofstation - Alternative drip
+    cost: 300
   # TODO: laser pointer 300, toy facehugger 300
   # TODO: stabilizing serum for 400
   - id: FultonBeacon
@@ -25,27 +29,27 @@
     cost: 500
   - id: ClothingBeltSalvageWebbing
     cost: 500
-  - id: ClothingBeltMercWebbing # Floofstation
+  - id: ClothingBeltMercWebbing # Floofstation - Alternative drip
     cost: 500
-  - id: ClothingBeltMilitaryWebbing # Floofstation
+  - id: ClothingBeltMilitaryWebbing # Floofstation - Alternative drip
     cost: 600
   - id: MedkitBruteFilled
     cost: 600
   - id: MedkitBurnFilled
     cost: 600
-  - id: MedkitToxinFilled # Floofstation
+  - id: MedkitToxinFilled # Floofstation - QoL
     cost: 600
-  - id: MedkitRadiationFilled # Floofstation
+  - id: MedkitRadiationFilled # Floofstation - QoL
     cost: 600
-  - id: MedkitOxygenFilled # Floofstation
+  - id: MedkitOxygenFilled # Floofstation - QoL
     cost: 600
-  - id: MedkitAdvancedFilled # Floofstation
+  - id: MedkitAdvancedFilled # Floofstation - QoL
     cost: 1500
-  - id: ClothingHandsGlovesCombat # Floofstation
+  - id: ClothingHandsGlovesCombat # Floofstation - Alternative drip
     cost: 1500
-  - id: ClothingHandsMercGlovesCombat # Floofstation
+  - id: ClothingHandsMercGlovesCombat # Floofstation - Alternative drip
     cost: 1500
-  - id: ClothingHandsGlovesColorYellow # Floofstation
+  - id: ClothingHandsGlovesColorYellow # Floofstation - Insuls incase they didn't find any on a wreck
     cost: 1400
   # TODO: salvage 5g, 3 implants and a locator for 600
   # TODO: wormhole jaunter for 750
@@ -69,7 +73,7 @@
   # cost: 6400
   - id: WeaponRifleSVTEmpty
     cost: 6400
-  - id: MagazineBoxLightRifle # Floofstation
+  - id: MagazineBoxLightRifle # Floofstation 
     cost: 1500
   - id: MagazineNovaliteC1Empty # Floofstation
     cost: 500

--- a/Resources/Prototypes/DeltaV/Catalog/VendingMachines/Inventories/salvage_points.yml
+++ b/Resources/Prototypes/DeltaV/Catalog/VendingMachines/Inventories/salvage_points.yml
@@ -82,7 +82,7 @@
   - id: MagazineRifleEmpty # Floofstation
     cost: 500
   - id: SpaceCash1000
-    cost: 1000
+    cost: 2000
   # TODO: super resonator for 2500
   # TODO: jump boots for 2500
   - id: ClothingOuterHardsuitSalvage

--- a/Resources/Prototypes/DeltaV/Catalog/VendingMachines/Inventories/salvage_points.yml
+++ b/Resources/Prototypes/DeltaV/Catalog/VendingMachines/Inventories/salvage_points.yml
@@ -25,14 +25,28 @@
     cost: 500
   - id: ClothingBeltSalvageWebbing
     cost: 500
-  - id: ClothingBeltMercWebbing
+  - id: ClothingBeltMercWebbing # Floofstation
     cost: 500
-  - id: ClothingBeltMilitaryWebbing
+  - id: ClothingBeltMilitaryWebbing # Floofstation
     cost: 600
   - id: MedkitBruteFilled
     cost: 600
   - id: MedkitBurnFilled
     cost: 600
+  - id: MedkitToxinFilled # Floofstation
+    cost: 600
+  - id: MedkitRadiationFilled # Floofstation
+    cost: 600
+  - id: MedkitOxygenFilled # Floofstation
+    cost: 600
+  - id: MedkitAdvancedFilled # Floofstation
+    cost: 1500
+  - id: ClothingHandsGlovesCombat # Floofstation
+    cost: 1500
+  - id: ClothingHandsMercGlovesCombat # Floofstation
+    cost: 1500
+  - id: ClothingHandsGlovesColorYellow # Floofstation
+    cost: 1400
   # TODO: salvage 5g, 3 implants and a locator for 600
   # TODO: wormhole jaunter for 750
   - id: WeaponCrusher
@@ -56,7 +70,7 @@
   - id: WeaponRifleSVTEmpty
     cost: 6400
   - id: SpaceCash1000
-    cost: 2000
+    cost: 1000
   # TODO: super resonator for 2500
   # TODO: jump boots for 2500
   - id: ClothingOuterHardsuitSalvage


### PR DESCRIPTION
# Description

Adds small list of items to Salvage's Pointvend.
- Replacement Salvage Gasmask + Alternative
- (QoL they can find insuls on wrecks) Insulated Gloves + Alternative
- Alternative Webbing
- More Medkits
- (I can take it or leave it) Magazines and Ammo Boxes for their guns
- made the point to money ratio better

One day we'll port Lavaland...

# Changelog

:cl:
- add: Added more items to Salvage Vend
