### PR TITLE
Oracle Rewards Normality

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Specific/oracle.yml
+++ b/Resources/Prototypes/Entities/Structures/Specific/oracle.yml
@@ -80,8 +80,11 @@
   id: OracleRewardCrystals
   weights:
     MaterialBluespace1: 3
+    MaterialNormality1: 3
     MaterialBluespace3: 10
+    MaterialNormality3: 10
     MaterialBluespace5: 2
+    MaterialNormality5: 2
 
 - type: weightedRandom
   id: OracleRewardReagents

--- a/Resources/Prototypes/Entities/Structures/Specific/oracle.yml
+++ b/Resources/Prototypes/Entities/Structures/Specific/oracle.yml
@@ -80,11 +80,9 @@
   id: OracleRewardCrystals
   weights:
     MaterialBluespace1: 3
-    MaterialNormality1: 3
     MaterialBluespace3: 10
-    MaterialNormality3: 10
     MaterialBluespace5: 2
-    MaterialNormality5: 2
+    MaterialNormality1: 5
 
 - type: weightedRandom
   id: OracleRewardReagents


### PR DESCRIPTION
# Description

Adds normality crystals to the oracle reward pool. Same weights as their bluespace counterparts.

---

# Changelog

:cl: sprkl
- tweak: The Oracle can now grant normality crystals when given offerings.
