### PR TITLE
Shitmed Organ Fixes

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/NPCs/carp.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/carp.yml
@@ -244,9 +244,8 @@
         Dead:
           Base: dead
           BaseUnshaded: dead_mouth
-    - type: Body
-      prototype: Bloodsucker
-      requiredLegs: 1
+    - type: Body # Shitmed - Adds carp organs.
+      prototype: Carp
     - type: Butcherable
       spawned:
         - id: FoodMeatFish

--- a/Resources/Prototypes/_Shitmed/Body/Organs/Animal/space.yml
+++ b/Resources/Prototypes/_Shitmed/Body/Organs/Animal/space.yml
@@ -16,6 +16,15 @@
     onAdd:
     - type: PressureImmunity
 
+- type: entity # Floof - Does nothing new for now, mostly just to show it came from a dragon
+  parent: OrganAnimalHeart
+  id: OrganDragonHeart
+  name: dragon heart
+  components:
+  - type: Organ
+    onAdd:
+    - type: PressureImmunity
+
 - type: entity
   parent: OrganAnimalHeart
   id: OrganGoliathHeart
@@ -38,6 +47,7 @@
     - type: ActionGun
       action: ActionDragonsBreath
       gunProto: DragonsBreathGun
+    - type: BreathingImmunity # Floof - Dragons are just evolved carps
 
 - type: entity
   parent: OrganHumanEyes
@@ -76,6 +86,7 @@
     - type: StealthOnMove
       passiveVisibilityRate: -0.25
       movementVisibilityRate: 0.25
+    - type: PressureImmunity # Floof - Rarer but completely useless outside of actual antag stuff
   - type: Sprite
     sprite: _Shitmed/Mobs/Species/Space/Cobra/organs.rsi
     state: heart-on

--- a/Resources/Prototypes/_Shitmed/Body/Organs/Animal/space.yml
+++ b/Resources/Prototypes/_Shitmed/Body/Organs/Animal/space.yml
@@ -33,6 +33,7 @@
   - type: Organ
     onAdd:
     - type: GoliathTentacle
+    - type: PressureImmunity # Floof - Goliaths? Where?
   - type: Sprite
     sprite: _Shitmed/Mobs/Species/Space/Goliath/organs.rsi
     state: heart-on

--- a/Resources/Prototypes/_Shitmed/Body/Prototypes/Animal/dragon.yml
+++ b/Resources/Prototypes/_Shitmed/Body/Prototypes/Animal/dragon.yml
@@ -11,7 +11,7 @@
         lungs: OrganDragonLungs
         stomach: OrganAnimalStomach
         liver: OrganAnimalLiver
-        heart: OrganAnimalHeart
+        heart: OrganDragonHeart
         kidneys: OrganAnimalKidneys
     legs:
       part: LegsAnimal

--- a/Resources/Prototypes/_Shitmed/Body/Prototypes/Animal/dragon.yml
+++ b/Resources/Prototypes/_Shitmed/Body/Prototypes/Animal/dragon.yml
@@ -11,7 +11,7 @@
         lungs: OrganDragonLungs
         stomach: OrganAnimalStomach
         liver: OrganAnimalLiver
-        heart: OrganDragonHeart
+        heart: OrganDragonHeart # Floof
         kidneys: OrganAnimalKidneys
     legs:
       part: LegsAnimal

--- a/Resources/Prototypes/_Shitmed/Body/Prototypes/Animal/goliath.yml
+++ b/Resources/Prototypes/_Shitmed/Body/Prototypes/Animal/goliath.yml
@@ -8,7 +8,7 @@
       connections:
       - legs
       organs:
-        lungs: OrganAnimalLungs
+        lungs: OrganSpaceAnimalLungs # Floof
         stomach: OrganAnimalStomach
         liver: OrganAnimalLiver
         heart: OrganGoliathHeart # Allows you to use a slower version of their tentacles.

--- a/Resources/Prototypes/_Shitmed/Body/Prototypes/Animal/spacecobra.yml
+++ b/Resources/Prototypes/_Shitmed/Body/Prototypes/Animal/spacecobra.yml
@@ -8,7 +8,7 @@
       connections:
       - legs
       organs:
-        lungs: OrganAnimalLungs
+        lungs: OrganSpaceAnimalLungs # Floof
         stomach: OrganAnimalStomach
         liver: OrganAnimalLiver
         heart: OrganCobraHeart # Allows you to become invisible.


### PR DESCRIPTION
# Description

Fixes Shitmed issues that were unaddressed upstream
it may seem strong but the amount of people who get normal carp organs installed are few and far inbetween

# Changelog

:cl:
- fix: Fixed Sharkminnows, Space Cobras and Goliaths not having Space Organs
- fix: Fixed Dragon Lungs not having the effect of Space Lungs despite just being a bigger carp
- added: Added Dragon Heart, does the same thing a Space Heart does but just labeled differently so you know its from a dragon for RP value
