### PR TITLE
Thermal Regulator Affected by Mass

### DIFF
--- a/Content.Server/Body/Components/ThermalRegulatorComponent.cs
+++ b/Content.Server/Body/Components/ThermalRegulatorComponent.cs
@@ -1,10 +1,11 @@
+using Content.Server._Floof.HeightAdjust;
 using Content.Server.Body.Systems;
 using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom;
 
 namespace Content.Server.Body.Components;
 
 [RegisterComponent]
-[Access(typeof(ThermalRegulatorSystem))]
+[Access(typeof(ThermalRegulatorSystem), typeof(ThermalRegulatorAdjustSystem))] // Floof - friends
 public sealed partial class ThermalRegulatorComponent : Component
 {
     /// <summary>

--- a/Content.Server/HeightAdjust/BloodstreamAdjustSystem.cs
+++ b/Content.Server/HeightAdjust/BloodstreamAdjustSystem.cs
@@ -34,7 +34,7 @@ public sealed class BloodstreamAdjustSystem : EntitySystem
 
         var bloodSolution = bloodSolutionEnt.Value.Comp.Solution;
 
-        var factor = Math.Pow(_contests.MassContest(ent, bypassClamp: true, rangeFactor: 4f), ent.Comp.Power);
+        var factor = Math.Pow(_contests.MassContest(ent, bypassClamp: true, rangeFactor: 4f), ent.Comp.Power) / ent.Comp.OldFactor; // Floof - oldFactor
         factor = Math.Clamp(factor, ent.Comp.Min, ent.Comp.Max);
 
         var newVolume = bloodstream.BloodMaxVolume * factor;
@@ -43,6 +43,7 @@ public sealed class BloodstreamAdjustSystem : EntitySystem
         bloodSolution.SetContents([new ReagentQuantity(bloodstream.BloodReagent, newBloodLevel, null)], false);
 
         _bloodstream.SetBloodMaxVolume(ent.Owner, newVolume, bloodstream);
+        ent.Comp.OldFactor = factor; // Floof
 
         return true;
     }

--- a/Content.Server/HeightAdjust/BloodstreamAffectedByMassComponent.cs
+++ b/Content.Server/HeightAdjust/BloodstreamAffectedByMassComponent.cs
@@ -23,4 +23,11 @@ public sealed partial class BloodstreamAffectedByMassComponent : Component
     /// </summary>
     [DataField]
     public float Power = 1f;
+
+    // Floofstation
+    /// <summary>
+    ///     by how much has the mob's bloodstream volume been adjusted already?
+    /// </summary>
+    [DataField]
+    public double OldFactor = 1f;
 }

--- a/Content.Server/_Floof/HeightAdjust/ThermalRegulatorAdjustSystem.cs
+++ b/Content.Server/_Floof/HeightAdjust/ThermalRegulatorAdjustSystem.cs
@@ -1,0 +1,39 @@
+using Content.Server.Body.Components;
+using Content.Shared.Contests;
+using Content.Shared.HeightAdjust;
+
+namespace Content.Server._Floof.HeightAdjust;
+
+public sealed class ThermalRegulatorAdjustSystem : EntitySystem
+{
+    [Dependency] private readonly ContestsSystem _contests = default!;
+
+    public override void Initialize()
+    {
+        SubscribeLocalEvent<ThermalRegulatorAffectedByMassComponent, MapInitEvent>((uid, comp, _) => TryAdjust((uid, comp)));
+        SubscribeLocalEvent<ThermalRegulatorAffectedByMassComponent, HeightAdjustedEvent>((uid, comp, _) => TryAdjust((uid, comp)));
+    }
+
+    /// <summary>
+    ///     Adjusts the bloodstream of the specified entity based on the settings provided by the component.
+    /// </summary>
+    public bool TryAdjust(Entity<ThermalRegulatorAffectedByMassComponent> ent)
+    {
+        if (!TryComp<ThermalRegulatorComponent>(ent, out var thermals))
+            return false;
+
+        // We raise to the power of 2/3 due to the square-cube law:
+        // a mob 2x the size loses/gains 4x more heat through their surface area, but generates 8x the heat throughout their volume
+        // this is merely an approximation to keep things more fair and prevent us from punishing smaller people too much
+        var factor = MathF.Pow(_contests.MassContest(ent, bypassClamp: true, rangeFactor: 10), 1.5f) / ent.Comp.OldFactor;
+        thermals.MetabolismHeat *= (float) factor;
+        thermals.RadiatedHeat *= (float) factor;
+        thermals.ImplicitHeatRegulation *= (float) factor;
+        thermals.ShiveringHeatRegulation *= (float) factor;
+        thermals.SweatHeatRegulation *= (float) factor;
+
+        ent.Comp.OldFactor = factor;
+
+        return true;
+    }
+}

--- a/Content.Server/_Floof/HeightAdjust/ThermalRegulatorAdjustSystem.cs
+++ b/Content.Server/_Floof/HeightAdjust/ThermalRegulatorAdjustSystem.cs
@@ -25,7 +25,7 @@ public sealed class ThermalRegulatorAdjustSystem : EntitySystem
         // We raise to the power of 2/3 due to the square-cube law:
         // a mob 2x the size loses/gains 4x more heat through their surface area, but generates 8x the heat throughout their volume
         // this is merely an approximation to keep things more fair and prevent us from punishing smaller people too much
-        var factor = MathF.Pow(_contests.MassContest(ent, bypassClamp: true, rangeFactor: 10), 1.5f) / ent.Comp.OldFactor;
+        var factor = MathF.Pow(_contests.MassContest(ent, bypassClamp: true, rangeFactor: 10), 0.6f) / ent.Comp.OldFactor;
         thermals.MetabolismHeat *= (float) factor;
         thermals.RadiatedHeat *= (float) factor;
         thermals.ImplicitHeatRegulation *= (float) factor;

--- a/Content.Server/_Floof/HeightAdjust/ThermalRegulatorAffectedByMassComponent.cs
+++ b/Content.Server/_Floof/HeightAdjust/ThermalRegulatorAffectedByMassComponent.cs
@@ -1,0 +1,30 @@
+namespace Content.Server._Floof.HeightAdjust;
+
+/// <summary>
+///     When applied to a humanoid or any mob, adjusts their blood level based on the mass contest between them
+///     and an average humanoid.
+///     <br/>
+///     The formula for the resulting bloodstream volume is <code>V = BloodMaxVolume * MassContest^Power</code>
+///     clamped between the specified Min and Max values.
+/// </summary>
+[RegisterComponent]
+public sealed partial class ThermalRegulatorAffectedByMassComponent : Component
+{
+    /// <summary>
+    ///     Minimum and maximum resulting volume factors. A minimum value of 0.5 means that the resulting volume will be at least 50% of the original.
+    /// </summary>
+    [DataField]
+    public float Min = 1 / 3f, Max = 3f;
+
+    /// <summary>
+    ///     The power to which the outcome of the mass contest will be risen.
+    /// </summary>
+    [DataField]
+    public float Power { get; set; } = 1f;
+
+    /// <summary>
+    ///     by how much has the mob's bloodstream volume been adjusted already?
+    /// </summary>
+    [DataField]
+    public double OldFactor = 1f;
+}

--- a/Resources/Prototypes/Entities/Mobs/Species/base.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/base.yml
@@ -335,6 +335,7 @@
   - type: Shoving
   - type: BloodstreamAffectedByMass
     power: 0.6 # A minimum size felinid will have 30% blood, a minimum size vulp will have 60%, a maximum size oni will have ~200%
+  - type: ThermalRegulatorAffectedByMass # Floofstation
 
 - type: entity
   save: false

--- a/Resources/Prototypes/_Floof/Entities/Mobs/Species/shadekin.yml
+++ b/Resources/Prototypes/_Floof/Entities/Mobs/Species/shadekin.yml
@@ -86,6 +86,7 @@
     - type: Shoving
     - type: BloodstreamAffectedByMass
       power: 0.6
+    - type: ThermalRegulatorAffectedByMass # Floofstation
     - type: Hunger
     - type: Thirst
     - type: Carriable


### PR DESCRIPTION
# Description
The speed at which atmos-exposed mobs exchange heat with the atmosphere depends on the mass of the mob (specifically, their heat capacity, which in turn is specific heat times their mass), but their thermal regulation (loss and gain of heat through sweating, radiation, shivering, and other ways) is not. This fixes this issue by introducing a system to adjust the mob's ThermalRegulationComponent stats based on their size multiplier.

Also fixes the bug where BloodstreamAdjustSystem would not account for multiple height adjusts in a row, resulting in the multiplier stacking.

TODO
- [X] Do this
- [X] Test this

<details><summary><h1>Media</h1></summary>
<p>

![image](https://github.com/user-attachments/assets/d6c3f13c-7514-41e8-bce2-1c04e6e772a9)


</p>
</details>

# Changelog
:cl:
- fix: The speed at which your characters body regulates its heat now depends on its mass. This means that 4 kg rodentia will no longer regulate its temperature 17 times faster than a 70 kg human.