### PR TITLE
Fix Lighters and Matches Not Showing Their Flame

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Tools/lighters.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/lighters.yml
@@ -94,6 +94,7 @@
     fuelConsumption: 0.01
     fuelLitCost: 0.1
     tankSafe: true
+  - type: ItemTogglePointLight
   - type: PointLight
     enabled: false
     netsync: false
@@ -232,6 +233,7 @@
       types:
         Blunt: 1 # does a little bit of damage on hit when off
   - type: DamageOtherOnHit
+  - type: ItemTogglePointLight
   - type: PointLight
     enabled: false
     netsync: false

--- a/Resources/Prototypes/Entities/Objects/Tools/matches.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/matches.yml
@@ -32,6 +32,7 @@
     duration: 10
     igniteSound:
       path: /Audio/Items/match_strike.ogg
+  - type: ItemTogglePointLight
   - type: PointLight
     enabled: false
     radius: 1.1


### PR DESCRIPTION
<!--
This is a semi-strict format, you can add/remove sections as needed but the order/format should be kept the same
Remove these comments before submitting
-->

# Description

<!--
Explain this PR in as much detail as applicable

Some example prompts to consider:
How might this affect the game? The codebase?
What might be some alternatives to this?
How/Who does this benefit/hurt [the game/codebase]?
-->

- Be me
- Light a cig
- lighter shows no flame
- facepalm as I forgot something I should have included into #1086
- cry

---

<!--
This is default collapsed, readers click to expand it and see all your media
The PR media section can get very large at times, so this is a good way to keep it clean
The title is written using HTML tags
The title must be within the <summary> tags or you won't see it
-->

<details><summary><h1>Media</h1></summary>
<p>

![image](https://github.com/user-attachments/assets/7e1a3a72-d154-4657-a8fc-bab43c924d61)
![image](https://github.com/user-attachments/assets/2e5cf53c-a98b-4754-b34f-41899a7a883b)
![image](https://github.com/user-attachments/assets/17c130f1-b020-4c35-9f88-2754a74b0f5c)


</p>
</details>

---

# Changelog

<!--
You can add an author after the `:cl:` to change the name that appears in the changelog (ex: `:cl: Death`)
Leaving it blank will default to your GitHub display name
This includes all available types for the changelog
-->

:cl: M3739
- fix: Lighters and matches should now properly emit light.
