### PR TITLE
Mantis Rework - Mantis Is Security Again

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/Ears/headsets.yml
+++ b/Resources/Prototypes/Entities/Clothing/Ears/headsets.yml
@@ -180,6 +180,23 @@
   - type: Clothing
     sprite: Clothing/Ears/Headsets/science.rsi
 
+- type: entity # Floof
+  parent: ClothingHeadset
+  id: ClothingHeadsetMantis
+  name: mantis headset # DeltaV - Epistemics Department replacing Science
+  description: A sciency headset used by the Mantis. # DeltaV - Epistemics Department replacing Science
+  components:
+  - type: ContainerFill
+    containers:
+      key_slots:
+      - EncryptionKeyScience
+      - EncryptionKeyCommon
+      - EncryptionKeySecurity
+  - type: Sprite
+    sprite: Clothing/Ears/Headsets/science.rsi
+  - type: Clothing
+    sprite: Clothing/Ears/Headsets/science.rsi
+
 - type: entity
   parent: ClothingHeadsetScience
   id: ClothingHeadsetMedicalScience

--- a/Resources/Prototypes/Nyanotrasen/Entities/Objects/Devices/pda.yml
+++ b/Resources/Prototypes/Nyanotrasen/Entities/Objects/Devices/pda.yml
@@ -120,6 +120,14 @@
   components:
   - type: Pda
     id: ForensicMantisIDCard
+    bookSlot: # Frontier
+      startingItem: HyperlinkBookSecuritySop # Floof - M3739 - #607
+      priority: -2
+      whitelist:
+        tags:
+        - BookSpaceLaw
+        - BookJusticeSop # Floof - M3739 - #607
+        - BookSecuritySop # Floof - M3739 - #607
     state: pda-science
   - type: Icon
     state: pda-science
@@ -130,3 +138,6 @@
      - NewsReaderCartridge
      - GlimmerMonitorCartridge
      - NanoChatCartridge
+     - CrimeAssistCartridge # Floof
+     - LogProbeCartridge
+     - SecWatchCartridge # DeltaV: SecWatch replaces WantedList

--- a/Resources/Prototypes/Nyanotrasen/Roles/Jobs/Epistemics/forensicmantis.yml
+++ b/Resources/Prototypes/Nyanotrasen/Roles/Jobs/Epistemics/forensicmantis.yml
@@ -9,6 +9,8 @@
     - !type:DepartmentTimeRequirement
       department: Epistemics # DeltaV - Epistemics Department replacing Science
       min: 3600
+      department: Security # Floof
+      min: 14400 # Floofstation - 4 hour
     - !type:CharacterLogicOrRequirement
       requirements:
         - !type:CharacterSpeciesRequirement

--- a/Resources/Prototypes/Nyanotrasen/Roles/Jobs/Epistemics/forensicmantis.yml
+++ b/Resources/Prototypes/Nyanotrasen/Roles/Jobs/Epistemics/forensicmantis.yml
@@ -21,12 +21,15 @@
   startingGear: ForensicMantisGear
   icon: "JobIconForensicMantis"
   supervisors: job-supervisors-rd
-  antagAdvantage: 5
-  canBeAntag: true
+  canBeAntag: false # Floof
   access:
   - Research
   - Maintenance
   - Mantis # DeltaV - Mantis, see Resources/Prototypes/DeltaV/Access/epistemics.yml
+  - Security # Floof
+  - Service
+  - External
+  - Cryogenics
   special:
   - !type:AddComponentSpecial
     components:
@@ -39,6 +42,8 @@
         - MetapsionicPower
         - TelepathyPower
         - AssayPower
+  - !type:AddImplantSpecial # Floof
+    implants: [ MindShieldImplant ]
 
 - type: startingGear
   id: ForensicMantisGear

--- a/Resources/Prototypes/Nyanotrasen/Roles/Jobs/Epistemics/forensicmantis.yml
+++ b/Resources/Prototypes/Nyanotrasen/Roles/Jobs/Epistemics/forensicmantis.yml
@@ -54,7 +54,7 @@
     head: ClothingHeadHatFezMantis
     id: ForensicMantisPDA
     eyes: ClothingEyesGlassesSunglasses
-    ears: ClothingHeadsetScience
+    ears: ClothingHeadsetMantis
     gloves: ClothingHandsGlovesColorWhite
     outerClothing: ClothingOuterCoatMantis
     belt: ClothingBeltMantis

--- a/Resources/Prototypes/Nyanotrasen/Roles/Jobs/Epistemics/forensicmantis.yml
+++ b/Resources/Prototypes/Nyanotrasen/Roles/Jobs/Epistemics/forensicmantis.yml
@@ -54,7 +54,7 @@
     head: ClothingHeadHatFezMantis
     id: ForensicMantisPDA
     eyes: ClothingEyesGlassesSunglasses
-    ears: ClothingHeadsetMantis
+    ears: ClothingHeadsetMantis # Floof
     gloves: ClothingHandsGlovesColorWhite
     outerClothing: ClothingOuterCoatMantis
     belt: ClothingBeltMantis

--- a/Resources/Prototypes/Nyanotrasen/Roles/Jobs/Epistemics/forensicmantis.yml
+++ b/Resources/Prototypes/Nyanotrasen/Roles/Jobs/Epistemics/forensicmantis.yml
@@ -9,6 +9,7 @@
     - !type:DepartmentTimeRequirement
       department: Epistemics # DeltaV - Epistemics Department replacing Science
       min: 3600
+    - !type:CharacterDepartmentTimeRequirement
       department: Security # Floof
       min: 14400 # Floofstation - 4 hour
     - !type:CharacterLogicOrRequirement


### PR DESCRIPTION
# Description

Mantis has been re-added to security, disabled their ability to be antags.
Their SoP will need to be fixed.

Why?
They're the psychic detective, they exist to stop psychic crimes, them being an antag is almost as detrimental as the detective being able to be an antag. They literally start with a gun. People are complaining that Mantis needs a new job.

# Changelog

:cl:
- tweak: Tweaked Mantis to being Security again
