### PR TITLE
The CJ's New Skirt

### DIFF
--- a/Resources/Prototypes/DeltaV/Entities/Clothing/Uniforms/jumpskirts.yml
+++ b/Resources/Prototypes/DeltaV/Entities/Clothing/Uniforms/jumpskirts.yml
@@ -103,8 +103,8 @@
   - type: Sprite
     sprite: DeltaV/Clothing/Uniforms/Jumpskirt/cj.rsi
   - type: Clothing
-    sprite: DeltaV/Clothing/Uniform/Jumpskirt/cj.rsi
-    
+    sprite: DeltaV/Clothing/Uniforms/Jumpskirt/cj.rsi
+
 - type: entity
   parent: ClothingUniformBase
   id: ClothingUniformJumpskirtClerk


### PR DESCRIPTION
# Description

The Chief Justice's jumpskirt had an incorrect file path, rendering it invisible when used in game. This PR corrects the missing letter from the file path so CJ's that prefer skirts aren't left naked.

---

# Changelog

:cl: sprkl
- fix: Chief Justice's jumpskirt is no longer invisible.
