### PR TITLE
Fix Nuclear14 Wood Settler Table Dropping Steel Instead of Wood

### DIFF
--- a/Resources/Prototypes/_Nuclear14/Entities/Structures/Furniture/table.yml
+++ b/Resources/Prototypes/_Nuclear14/Entities/Structures/Furniture/table.yml
@@ -458,7 +458,7 @@
 
 - type: entity
   id: N14TableWoodSettler
-  parent: TableWood # Floof - M3739  - NoMoreFreeSteel4U - No more growing steel.
+  parent: TableWood # Floof - M3739  - #1113 - No more growing steel.
   name: wooden table
   description: A wooden table used by settlers.
   components:

--- a/Resources/Prototypes/_Nuclear14/Entities/Structures/Furniture/table.yml
+++ b/Resources/Prototypes/_Nuclear14/Entities/Structures/Furniture/table.yml
@@ -458,7 +458,7 @@
 
 - type: entity
   id: N14TableWoodSettler
-  parent: Table
+  parent: TableWood # Floof - M3739  - NoMoreFreeSteel4U - No more growing steel.
   name: wooden table
   description: A wooden table used by settlers.
   components:


### PR DESCRIPTION
<!--
This is a semi-strict format, you can add/remove sections as needed but the order/format should be kept the same
Remove these comments before submitting
-->

# Description

<!--
Explain this PR in as much detail as applicable

Some example prompts to consider:
How might this affect the game? The codebase?
What might be some alternatives to this?
How/Who does this benefit/hurt [the game/codebase]?
-->

This PR aims to fix a bug relating to a buildable table. Primarily the wooden settler table from Nuclear14.

Upon destruction, this table, despite being built with 2 wooden planks, drops a single sheet of steel. Meaning that not only can you convert wood to steel at a 2:1 ratio, but perma can very easily obtain steel by growing trees and logging them for wood.

This is due to an inheritance of the destructible component from it's parent, `Table` which is made with steel.

This is fixed by changing it's parent, `Table` to be the proper one: `TableWood`.

And finally a fun fact: I witnessed this bug, live, as AHoS, while an admin, who was a fellow perma, watched another perma convert wood to steel in this manner.

---

# Changelog

<!--
You can add an author after the `:cl:` to change the name that appears in the changelog (ex: `:cl: Death`)
Leaving it blank will default to your GitHub display name
This includes all available types for the changelog
-->

:cl: M3739
- fix: You can no longer convert wood to steel by building and destroying a specific wood table variant.
