### PR TITLE
Fentanyl Rename

### DIFF
--- a/Resources/Locale/en-US/_Goobstation/reagents/meta/narcotics.ftl
+++ b/Resources/Locale/en-US/_Goobstation/reagents/meta/narcotics.ftl
@@ -1,2 +1,2 @@
-reagent-name-fentanyl = Fentanyl
+reagent-name-fentanyl = Ventanyl
 reagent-desc-fentanyl = A horrifyingly toxic street drug with a laundry list of side-effects. If you do drugs, you go to hell before you die!

--- a/Resources/Prototypes/_Goobstation/Reagents/narcotics.yml
+++ b/Resources/Prototypes/_Goobstation/Reagents/narcotics.yml
@@ -1,5 +1,5 @@
 - type: reagent
-  id: Fentanyl
+  id: Ventanyl
   name: reagent-name-fentanyl
   group: Narcotics
   desc: reagent-desc-fentanyl

--- a/Resources/Prototypes/_Goobstation/Recipes/Reactions/narcotics.yml
+++ b/Resources/Prototypes/_Goobstation/Recipes/Reactions/narcotics.yml
@@ -1,5 +1,5 @@
 - type: reaction
-  id: Fentanyl
+  id: Ventanyl
   minTemp: 410
   maxTemp: 420 # no lavabeaker for the lazy chemist
   reactants:
@@ -12,6 +12,6 @@
     Bleach:
       amount: 1
   products:
-    Fentanyl: 1
+    Ventanyl: 1
     VentCrud: 1
     SpaceGlue: 2


### PR DESCRIPTION
# Description

It being named Fentanyl was apparently too on the nose, Ventanyl was the most agreed on name change.

# Changelog
:cl:
- tweak: Fentanyl renamed to Ventanyl

