### PR TITLE
Improve the mirror-pr.sh Script

### DIFF
--- a/Scripts/git/mirror-pr.sh
+++ b/Scripts/git/mirror-pr.sh
@@ -1,9 +1,25 @@
 #!/bin/bash
 set -e
 
-PRNUM=$1 # First arg to a shell script
+HELPSTR="Usage: $( basename $0 ) <PR number> [remote to push to] [GitHub repo to pull from] [GitHub repo to create a PR in]
+For example: $( basename $0 ) 1002 floofstation space-wizards/space-station-14 fansana/floofstation1
 
-pr_info=$(gh pr view https://github.com/simple-station/einstein-engines/pull/$PRNUM --json number,title,headRefName,mergeCommit,body)
+This script will cherry-pick a pull request from a GitHub repo into a new branch and make a pull request for you.
+
+Default pull remote is 'upstream', default GitHub repo is 'simple-station/einstein-engines', default GitHub repo to create a PR in is 'fansana/floofstation1'"
+
+PRNUM=$1 # First arg to a shell script
+if [[ -z $PRNUM || $PRNUM == "--help" || $PRNUM == "-h" ]]; then
+    echo "$HELPSTR"
+    exit 1
+fi
+PUSH_REMOTE=${2:-upstream}
+PULL_REPO=${3:-simple-station/einstein-engines}
+PUSH_REPO=${4:-fansana/floofstation1}
+
+echo "Pulling from $PULL_REPO and pushing to $PUSH_REMOTE, then creating a PR in $PUSH_REPO"
+
+pr_info=$(gh pr view "https://github.com/${PULL_REPO}/pull/$PRNUM" --json number,title,headRefName,mergeCommit,body)
 merge_commit=$(echo "$pr_info" | jq -r .mergeCommit.oid)
 title=$(echo "$pr_info" | jq -r .title)
 body=$(echo "$pr_info" | jq -r .body)
@@ -16,34 +32,49 @@ current_branch=$(git rev-parse --abbrev-ref HEAD)
 if [ "$current_branch" != "$target_branch" ]; then
     echo "Resetting current branch"
     git checkout master
-    git pull
+    git pull "$PUSH_REMOTE" master
 
     parent_count=$(git rev-list --parents -n 1 "$merge_commit" | wc -w)
 
     echo "Creating branch"
     git checkout -b upstream/$PRNUM
-    if [ "$parent_count" -gt 2 ]; then
-        if ! git cherry-pick -m 1 $merge_commit; then
-            read -r
-            git cherry-pick --continue --no-edit
-        fi
-    else
-        if ! git cherry-pick $merge_commit; then
-            read -r
-            git cherry-pick --continue --no-edit
-        fi
+
+    # If this commit has two parents, pick the first one. This is not a safe way to do it, TODO: prompt the user?
+    cherry_pick_cmd="git cherry-pick"
+    [ "$parent_count" -gt 2 ] && cherry_pick_cmd+=" -m 1"
+
+    if ! $cherry_pick_cmd $merge_commit; then
+        echo "Resolve the merge conflicts manually and hit enter."
+        read -r
+        git cherry-pick --continue --no-edit
     fi
-    git push
+    git push -u "$PUSH_REMOTE"
 fi
 
 if [ -f .git/CHERRY_PICK_HEAD ]; then
-    git cherry-pick --continue --no-edit
-    git push
+    echo "Trying to finish the cherry-pick..."
+    git cherry-pick --continue --no-edit || exit 1;
 fi
+
+echo "Type in any optional description you want to appear in the PR. You can add line breaks by typing \n."
+read -r opt_description
+opt_description=$( echo -n "$opt_description" ) # Process escape sequences
 
 body=$(echo "$pr_info" | jq -r .body)
 body1=$(echo "$body" | sed 's/:cl:/:cl: EinsteinEngines/g')
-body2=$(printf "Upstream PR: https://github.com/simple-station/einstein-engines/pull/%s\n%s" "$PRNUM" "$body1")
-gh pr create --base master --head "upstream/$PRNUM" --title "Upstream Merge #$PRNUM | $title" --body "$body2"
+body2=$(
+    printf "Upstream PR: https://github.com/simple-station/einstein-engines/pull/%s\n\n" "$PRNUM"
+    echo "$opt_description"
+    echo
+    echo "-----"
+    echo
+    echo "$body1"
+)
 
+echo "PR description is as follows:"
+echo "$body2"
+echo "Press enter to proceed or CTRL+C to cancel."
+read
 
+git push "$PUSH_REMOTE"
+gh pr create --repo "$PUSH_REPO" --base master --head "upstream/$PRNUM" --title "Upstream Merge #$PRNUM | $title" --body "$body2"


### PR DESCRIPTION
# Description

Added arguments to change the push remote and repos to pull changes from and create a PR in; added a help message and made it error out if no PR number is provided, added a way to enter optional description.

Also made it not error out if you don't have fansana/floofstation1 as your default push remote.

Tested here: https://github.com/Mnemotechnician/floofstation/pull/1

Example I/O (from the PR above):
```sh
./mirror-pr.sh 1000 origin-floofstation-fork simple-station/einstein-engines mnemotechnician/floofstation
```
```
Pulling from simple-station/einstein-engines and pushing to origin-floofstation-fork, then creating a PR in mnemotechnician/floofstation
Creating PR for: Uncomment Grapple And Tether Guns
```
```
Resetting current branch
M       Scripts/git/mirror-pr.sh
Switched to branch 'master'
Your branch is ahead of 'origin-floofstation-fork/master' by 389 commits.
  (use "git push" to publish your local commits)
From https://github.com/mnemotechnician/floofstation
 * branch                  master     -> FETCH_HEAD
Already up to date.
Creating branch
Switched to a new branch 'upstream/1000'
Auto-merging Resources/Prototypes/Entities/Structures/Machines/lathe.yml
Auto-merging Resources/Prototypes/Recipes/Lathes/devices.yml
CONFLICT (content): Merge conflict in Resources/Prototypes/Recipes/Lathes/devices.yml
Auto-merging Resources/Prototypes/Recipes/Lathes/robotics.yml
Auto-merging Resources/Prototypes/Research/experimental.yml
Auto-merging Resources/Prototypes/Research/industrial.yml
CONFLICT (content): Merge conflict in Resources/Prototypes/Research/industrial.yml
error: could not apply 1c25688131... Uncomment Grapple And Tether Guns (#1000)
hint: After resolving the conflicts, mark them with
hint: "git add/rm <pathspec>", then run
hint: "git cherry-pick --continue".
hint: You can instead skip this commit with "git cherry-pick --skip".
hint: To abort and get back to the state before "git cherry-pick",
hint: run "git cherry-pick --abort".
hint: Disable this message with "git config set advice.mergeConflict false"
Resolve the merge conflicts manually and hit enter.

```
enter

```
On branch upstream/1000
You are currently cherry-picking commit 1c25688131.
```
```
Type in any optional description you want to appear in the PR. You can add line breaks by typing \n.
```
```
This is a test PR. If it appears in the wrong repo, you have the right to punch me. Just not too hard.    
```
```
PR description is as follows:
Upstream PR: https://github.com/simple-station/einstein-engines/pull/1000

This is a test PR. If it appears in the wrong repo, you have the right to punch me. Just not too hard.
-----
# Description

Pretty easy PR, this just uncomments Grapple & Tether Guns, such that players can once again obtain them from Science.

# Changelog

:cl: EinsteinEngines
- add: Grapple & Tether Guns have been re-added.
Press enter to proceed or CTRL+C to cancel.

```
enter
```
Enumerating objects: 1, done.
Counting objects: 100% (1/1), done.
Writing objects: 100% (1/1), 230 bytes | 230.00 KiB/s, done.
Total 1 (delta 0), reused 0 (delta 0), pack-reused 0 (from 0)
remote: This repository moved. Please use the new location:
remote:   https://github.com/Mnemotechnician/floofstation.git
remote: 
remote: Create a pull request for 'upstream/1000' on GitHub by visiting:
remote:      https://github.com/Mnemotechnician/floofstation/pull/new/upstream/1000
remote: 
To https://github.com/mnemotechnician/floofstation
 * [new branch]            upstream/1000 -> upstream/1000

Creating pull request for upstream/1000 into master in Mnemotechnician/floofstation

https://github.com/Mnemotechnician/floofstation/pull/1

```

# Changelog
N/A
