### PR TITLE
Fix Lightbulb and Light Tube Transmutation Bug

### DIFF
--- a/Resources/Prototypes/Recipes/Lathes/misc.yml
+++ b/Resources/Prototypes/Recipes/Lathes/misc.yml
@@ -1,4 +1,4 @@
-# Begin Changes - Floof - M3739 - LightbulbMoment
+# Begin Changes - Floof - M3739 - #1132
 - type: latheRecipe
   id: LightTube
   result: LightTube
@@ -70,7 +70,7 @@
   materials:
     Steel: 50
     Glass: 100
-# End Changes - Floof - M3739 - LightbulbMoment
+# End Changes - Floof - M3739 - #1132
 
 - type: latheRecipe
   id: GlowstickRed

--- a/Resources/Prototypes/Recipes/Lathes/misc.yml
+++ b/Resources/Prototypes/Recipes/Lathes/misc.yml
@@ -1,3 +1,4 @@
+# Begin Changes - Floof - M3739 - LightbulbMoment
 - type: latheRecipe
   id: LightTube
   result: LightTube
@@ -5,7 +6,7 @@
   completetime: 2
   materials:
     Steel: 50
-    Glass: 50
+    Glass: 100
 
 - type: latheRecipe
   id: LedLightTube
@@ -14,7 +15,7 @@
   completetime: 2
   materials:
     Steel: 50
-    Glass: 50
+    Glass: 100
 
 - type: latheRecipe
   id: SodiumLightTube
@@ -23,7 +24,7 @@
   completetime: 2
   materials:
     Steel: 50
-    Glass: 50
+    Glass: 100
 
 - type: latheRecipe
   id: ExteriorLightTube
@@ -32,7 +33,7 @@
   completetime: 2
   materials:
     Steel: 50
-    Glass: 50
+    Glass: 100
 
 - type: latheRecipe
   id: LightBulb
@@ -41,7 +42,7 @@
   completetime: 2
   materials:
     Steel: 50
-    Glass: 50
+    Glass: 100
 
 - type: latheRecipe
   id: LedLightBulb
@@ -50,7 +51,7 @@
   completetime: 2
   materials:
     Steel: 50
-    Glass: 50
+    Glass: 100
 
 - type: latheRecipe
   id: DimLightBulb
@@ -59,7 +60,7 @@
   completetime: 2
   materials:
     Steel: 50
-    Glass: 50
+    Glass: 100
 
 - type: latheRecipe
   id: WarmLightBulb
@@ -68,7 +69,8 @@
   completetime: 2
   materials:
     Steel: 50
-    Glass: 50
+    Glass: 100
+# End Changes - Floof - M3739 - LightbulbMoment
 
 - type: latheRecipe
   id: GlowstickRed


### PR DESCRIPTION
<!--
This is a semi-strict format, you can add/remove sections as needed but the order/format should be kept the same
Remove these comments before submitting
-->

# Description

<!--
Explain this PR in as much detail as applicable

Some example prompts to consider:
How might this affect the game? The codebase?
What might be some alternatives to this?
How/Who does this benefit/hurt [the game/codebase]?
-->

The PR aims to address the bug where a light tube or light bulb, which costs 0.5 steel and glass, can be welded to be 1 whole glass.

This is fixed by making the glass cost 1 instead of 0.5, making welding it result in the loss of 0.5 steel at the end of it all.

Converting materials is something we'd like to avoid in order to maintain the purpose of materials and their respective uses, while also encouraging the sourcing of these materials to encourage interactions. As inconsequential as this change may be, it eliminates a improper solution to resource shortages.

---

# Changelog

<!--
You can add an author after the `:cl:` to change the name that appears in the changelog (ex: `:cl: Death`)
Leaving it blank will default to your GitHub display name
This includes all available types for the changelog
-->

:cl: M3739
- tweak: Light bulbs and light tubes had their material cost revised and corrected.