### PR TITLE
Fix Block Game Ui

### DIFF
--- a/Content.Client/Arcade/BlockGameMenu.cs
+++ b/Content.Client/Arcade/BlockGameMenu.cs
@@ -64,6 +64,11 @@ namespace Content.Client.Arcade
 
             MinSize = SetSize = new Vector2(410, 490);
 
+            // there's no point in resizing this since the game itself won't resize.
+            // if at some point in the future we have the ability to resize with a locked aspect ratio,
+            // this should be reworked to allow making the game bigger
+            Resizable = false;
+
             var resourceCache = IoCManager.Resolve<IResourceCache>();
             var backgroundTexture = resourceCache.GetTexture("/Textures/Interface/Nano/button.svg.96dpi.png");
 
@@ -95,12 +100,14 @@ namespace Content.Client.Arcade
             _gameRootContainer.AddChild(_pointsLabel);
             _gameRootContainer.AddChild(new Control
             {
-                MinSize = new Vector2(1, 10)
+                MinSize = new Vector2(1, 10),
+                VerticalExpand = true
             });
 
             var gameBox = new BoxContainer
             {
-                Orientation = LayoutOrientation.Horizontal
+                Orientation = LayoutOrientation.Horizontal,
+                HorizontalAlignment = HAlignment.Center,
             };
             gameBox.AddChild(SetupHoldBox(backgroundTexture));
             gameBox.AddChild(new Control
@@ -118,7 +125,8 @@ namespace Content.Client.Arcade
 
             _gameRootContainer.AddChild(new Control
             {
-                MinSize = new Vector2(1, 10)
+                MinSize = new Vector2(1, 10),
+                VerticalExpand = true
             });
 
             _pauseButton = new Button
@@ -379,7 +387,6 @@ namespace Content.Client.Arcade
             var gamePanel = new PanelContainer
             {
                 PanelOverride = back,
-                HorizontalExpand = true,
                 SizeFlagsStretchRatio = 60
             };
             var backgroundPanel = new PanelContainer
@@ -441,7 +448,6 @@ namespace Content.Client.Arcade
             var grid = new GridContainer
             {
                 Columns = 1,
-                HorizontalExpand = true,
                 SizeFlagsStretchRatio = 20
             };
 


### PR DESCRIPTION
<!--
This is a semi-strict format, you can add/remove sections as needed but the order/format should be kept the same
Remove these comments before submitting
-->

# Description

<!--
Explain this PR in as much detail as applicable

Some example prompts to consider:
How might this affect the game? The codebase?
What might be some alternatives to this?
How/Who does this benefit/hurt [the game/codebase]?
-->

NT Block Game was looking kinda off. Fixed and makes UI look better at larger sizes too (but I disabled the ability to resize the window since the game itself wouldn't resize anyway)

---

<!--
This is default collapsed, readers click to expand it and see all your media
The PR media section can get very large at times, so this is a good way to keep it clean
The title is written using HTML tags
The title must be within the <summary> tags or you won't see it
-->

<details><summary><h1>Media</h1></summary>
<p>

before:
![Screenshot_20250623_114701](https://github.com/user-attachments/assets/7037da9b-7035-4849-b07c-c1553ab9be0c)
after:
![Screenshot_20250623_114457](https://github.com/user-attachments/assets/7d40ff66-2fce-49cb-9ad6-4ad950997f66)


</p>
</details>

---

# Changelog

<!--
You can add an author after the `:cl:` to change the name that appears in the changelog (ex: `:cl: Death`)
Leaving it blank will default to your GitHub display name
This includes all available types for the changelog
-->

:cl:
- Restored the NT Block Game to its former glory