### PR TITLE
Add Health Info to Basic Examine Action

### DIFF
--- a/Content.Server/Body/Systems/BloodstreamSystem.cs
+++ b/Content.Server/Body/Systems/BloodstreamSystem.cs
@@ -244,7 +244,9 @@ public sealed class BloodstreamSystem : EntitySystem
         // Shows profusely bleeding at half the max bleed rate.
         if (ent.Comp.BleedAmount > ent.Comp.MaxBleedAmount / 2)
         {
-            args.Message.PushNewline();
+            // Floof: allow empty messages for basic examine
+            if (!args.Message.IsEmpty)
+                args.Message.PushNewline();
             if (!args.IsSelfAware)
                 args.Message.AddMarkup(Loc.GetString("bloodstream-component-profusely-bleeding", ("target", ent.Owner)));
             else
@@ -253,7 +255,9 @@ public sealed class BloodstreamSystem : EntitySystem
         // Shows bleeding message when bleeding, but less than profusely.
         else if (ent.Comp.BleedAmount > 0)
         {
-            args.Message.PushNewline();
+            // Floof: allow empty messages for basic examine
+            if (!args.Message.IsEmpty)
+                args.Message.PushNewline();
             if (!args.IsSelfAware)
                 args.Message.AddMarkup(Loc.GetString("bloodstream-component-bleeding", ("target", ent.Owner)));
             else
@@ -263,7 +267,9 @@ public sealed class BloodstreamSystem : EntitySystem
         // If the mob's blood level is below the damage threshhold, the pale message is added.
         if (GetBloodLevelPercentage(ent, ent) < ent.Comp.BloodlossThreshold)
         {
-            args.Message.PushNewline();
+            // Floof: allow empty messages for basic examine
+            if (!args.Message.IsEmpty)
+                args.Message.PushNewline();
             if (!args.IsSelfAware)
                 args.Message.AddMarkup(Loc.GetString("bloodstream-component-looks-pale", ("target", ent.Owner)));
             else

--- a/Content.Server/Vampire/BloodSuckerSystem.cs
+++ b/Content.Server/Vampire/BloodSuckerSystem.cs
@@ -75,7 +75,9 @@ namespace Content.Server.Vampiric
 
         private void OnHealthExamined(EntityUid uid, BloodSuckedComponent component, HealthBeingExaminedEvent args)
         {
-            args.Message.PushNewline();
+            // Floof: allow empty messages for basic examine
+            if (!args.Message.IsEmpty)
+                args.Message.PushNewline();
             args.Message.AddMarkup(Loc.GetString("bloodsucked-health-examine", ("target", uid)));
         }
 


### PR DESCRIPTION
<!--
This is a semi-strict format, you can add/remove sections as needed but the order/format should be kept the same
Remove these comments before submitting
-->

# Description

<!--
Explain this PR in as much detail as applicable

Some example prompts to consider:
How might this affect the game? The codebase?
What might be some alternatives to this?
How/Who does this benefit/hurt [the game/codebase]?
-->

adds info from the health examine action to the default examine, because health examine is woefully underused outside of cases where you already know someone is injured. this allows people to more easily notice minor injuries and react accordingly in-character, enhancing the roleplay experience.

default examine will only display health info when there are injuries to display and will only show the basic health examine text, ignoring the self-aware trait. this has the slight benefit of giving self-aware players a better idea of what everyone else can see from looking at them.

---

<!--
This is default collapsed, readers click to expand it and see all your media
The PR media section can get very large at times, so this is a good way to keep it clean
The title is written using HTML tags
The title must be within the <summary> tags or you won't see it
-->

<details><summary><h1>Media</h1></summary>
<p>

![Screenshot_20250624_123939](https://github.com/user-attachments/assets/08aad18c-46e1-43b7-b868-c62988f67b52)
![Screenshot_20250624_123758](https://github.com/user-attachments/assets/55786544-c92c-4257-b3f3-023334faf47c)
![Screenshot_20250624_123820](https://github.com/user-attachments/assets/cbda3e91-42e2-4abe-ad6f-b90611e01bd1)


</p>
</details>

---

# Changelog

<!--
You can add an author after the `:cl:` to change the name that appears in the changelog (ex: `:cl: Death`)
Leaving it blank will default to your GitHub display name
This includes all available types for the changelog
-->

:cl:
- Added health information to the default examine window, so you can show off your pretty bruises <3