### PR TITLE
Fix NoCargoOrderArbitrage Test Fail.

### DIFF
--- a/Resources/Prototypes/Catalog/Cargo/cargo_vending.yml
+++ b/Resources/Prototypes/Catalog/Cargo/cargo_vending.yml
@@ -33,7 +33,7 @@
     sprite: Objects/Specific/Service/vending_machine_restock.rsi
     state: base
   product: CrateVendingMachineRestockClothesFilled
-  cost: 1500
+  cost: 1700
   category: cargoproduct-category-name-service
   group: market
 


### PR DESCRIPTION
# Description

Title

Clothes Restock costs 1500 but sells for 1670.
This PR changes the price to be 1700 to fix the test fails.

---

# Changelog

:cl:
- tweak: Increased the Clothes Vending Restock price.
