### PR TITLE
Fish Labeler Buff

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/Player/dragon.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/dragon.yml
@@ -143,6 +143,7 @@
     tags:
     - CannotSuicide
     - DoorBumpOpener
+    - Carp
   - type: NightVision
     isActive: true
     color: "#808080"


### PR DESCRIPTION
# Description

In the most pointless way, adds the Carp Tag to Space Dragons so they can be labeled with the Fish Labeler.

Why?
I tried to label a dragon earlier, it's just a bigger fish.

# Changelog
:cl:
- tweak: Tweaked Fish Labeler to Label Dragons

