### PR TITLE
Heirloom & Loadout Special Menu Tweaks

### DIFF
--- a/Content.Client/Lobby/UI/LoadoutPreferenceSelector.xaml.cs
+++ b/Content.Client/Lobby/UI/LoadoutPreferenceSelector.xaml.cs
@@ -53,6 +53,10 @@ public sealed partial class LoadoutPreferenceSelector : Control
                 UpdatePaint(); // Floof - simpler method call
             HeirloomButton.Pressed = value.CustomHeirloom ?? false;
             PreferenceButton.Pressed = value.Selected;
+
+            // Floof - close the special menu if the loadout is de-selected, since that means editing the loadout will do nothing
+            if (!value.Selected)
+                HeadingButton.Pressed = false;
         }
     }
 
@@ -245,7 +249,7 @@ public sealed partial class LoadoutPreferenceSelector : Control
         };
         HeirloomButton.OnToggled += args =>
         {
-            if (args.Pressed == _preference.Selected) // Floofstation
+            if (args.Pressed == _preference.CustomHeirloom) // Floofstation
                 return;
 
             _preference.CustomHeirloom = args.Pressed ? true : null;
@@ -258,6 +262,7 @@ public sealed partial class LoadoutPreferenceSelector : Control
             if (!args.Pressed)
             {
                 // Destroy, annihilate
+                _special?.Save(); // Because it's counterintuitive that the save button always has to be pressed to save the changes
                 _special?.Dispose();
                 _special = null;
             }

--- a/Content.Client/Lobby/UI/LoadoutPreferenceSelector.xaml.cs
+++ b/Content.Client/Lobby/UI/LoadoutPreferenceSelector.xaml.cs
@@ -55,8 +55,13 @@ public sealed partial class LoadoutPreferenceSelector : Control
             PreferenceButton.Pressed = value.Selected;
 
             // Floof - close the special menu if the loadout is de-selected, since that means editing the loadout will do nothing
+            HeadingButton.Disabled = !value.Selected;
             if (!value.Selected)
+            {
                 HeadingButton.Pressed = false;
+                _special?.Dispose(); // TODO code duplication, RT won't fire the toggle event when changing Pressed; don't wanna deal with it
+                _special = null;
+            }
         }
     }
 

--- a/Content.Client/Lobby/UI/LoadoutPreferenceSelector.xaml.cs
+++ b/Content.Client/Lobby/UI/LoadoutPreferenceSelector.xaml.cs
@@ -257,6 +257,7 @@ public sealed partial class LoadoutPreferenceSelector : Control
             if (args.Pressed == _preference.CustomHeirloom) // Floofstation
                 return;
 
+            _special?.Save();
             _preference.CustomHeirloom = args.Pressed ? true : null;
             PreferenceChanged?.Invoke(Preference);
         };

--- a/Content.Client/Lobby/UI/LoadoutPreferenceSelectorSpecial.xaml.cs
+++ b/Content.Client/Lobby/UI/LoadoutPreferenceSelectorSpecial.xaml.cs
@@ -25,13 +25,7 @@ public sealed partial class LoadoutPreferenceSelectorSpecial : PanelContainer
         RobustXamlLoader.Load(this);
         Parent = parent;
 
-        SaveButton.OnPressed += _ =>
-        {
-            Preference.CustomColorTint = GetColorTint()?.ToHex();
-            Preference.Selected = Parent.PreferenceButton.Pressed;
-            Parent.InvokePreferenceChanged();
-            UpdateState();
-        };
+        SaveButton.OnPressed += _ => Save();
         NameEdit.OnTextChanged += _ =>
             Preference.CustomName = string.IsNullOrEmpty(NameEdit.Text) ? null : NameEdit.Text;
         DescriptionEdit.OnTextChanged += _ =>
@@ -44,6 +38,14 @@ public sealed partial class LoadoutPreferenceSelectorSpecial : PanelContainer
             Parent.UpdatePaint();
         };
 
+        UpdateState();
+    }
+
+    public void Save()
+    {
+        Preference.CustomColorTint = GetColorTint()?.ToHex();
+        Preference.Selected = Parent.PreferenceButton.Pressed;
+        Parent.InvokePreferenceChanged();
         UpdateState();
     }
 


### PR DESCRIPTION
# Description
- Fixes the heirloom button not saving the heirloom status of an item.
- Makes it so that the special settings menu cannot be opened if the relevant loadout item is not selected, and auto-save when it's closed.


# Changelog
:cl:
- fix: The heirloom toggle in loadouts show now work as expected.
- tweak: Loadout special menu can no longer be opened while the loadout is not selected, and will auto-save when it's closed.
