### PR TITLE
Fix Buckled Rotation Breaking After Falling Asleep or Being Knocked Down

### DIFF
--- a/Content.Client/Buckle/BuckleSystem.cs
+++ b/Content.Client/Buckle/BuckleSystem.cs
@@ -21,7 +21,6 @@ internal sealed class BuckleSystem : SharedBuckleSystem
     {
         base.Initialize();
 
-        SubscribeLocalEvent<BuckleComponent, AppearanceChangeEvent>(OnAppearanceChange);
         SubscribeLocalEvent<StrapComponent, MoveEvent>(OnStrapMoveEvent);
         SubscribeLocalEvent<BuckleComponent, BuckledEvent>(OnBuckledEvent);
         SubscribeLocalEvent<BuckleComponent, UnbuckledEvent>(OnUnbuckledEvent);
@@ -115,18 +114,6 @@ internal sealed class BuckleSystem : SharedBuckleSystem
                 buckle.OriginalDrawDepth = null;
             }
         }
-    }
-
-    private void OnAppearanceChange(EntityUid uid, BuckleComponent component, ref AppearanceChangeEvent args)
-    {
-        if (!TryComp<RotationVisualsComponent>(uid, out var rotVisuals)
-            || !Appearance.TryGetData<bool>(uid, BuckleVisuals.Buckled, out var buckled, args.Component)
-            || !buckled || args.Sprite == null)
-            return;
-
-        // Animate strapping yourself to something at a given angle
-        // TODO: Dump this when buckle is better
-        _rotationVisualizerSystem.AnimateSpriteRotation(uid, args.Sprite, rotVisuals.HorizontalRotation, 0.125f);
     }
 
     // Floof section - method for getting the direction of an entity perceived by the local player


### PR DESCRIPTION
# Description

deleted what seems to be a relic from The Before Times. buckling still works, and now you don't flop around like a fish.

---

# Changelog

:cl:
- fix: Resolved a longstanding issue where buckled characters would get all floppy after sleeping or being knocked down.