### PR TITLE
Clarify Paradox Opt Out

### DIFF
--- a/Resources/Locale/en-US/Blep/consent.ftl
+++ b/Resources/Locale/en-US/Blep/consent.ftl
@@ -31,4 +31,4 @@ consent-Hypno-name = Hypnosis
 consent-Hypno-desc = Allow yourself to be hypnotized.
 
 consent-NoClone-name = Disallow Paradox Anomaly
-consent-NoClone-desc = Disallow yourself to be the target of a paradox anomaly clone.
+consent-NoClone-desc = Turn this on to disallow Paradox clones of yourself.


### PR DESCRIPTION
# Description

Changes the description of the Paradox consent toggle to clarify that it will only prevent Paradox clones in the ON state.