### PR TITLE
People Transfer

### DIFF
--- a/Content.Server/Carrying/CarryingSystem.cs
+++ b/Content.Server/Carrying/CarryingSystem.cs
@@ -309,7 +309,7 @@ namespace Content.Server.Carrying
                 || HasComp<ItemComponent>(carrier)
                 || TryComp<PhysicsComponent>(carrier, out var carrierPhysics)
                 && TryComp<PhysicsComponent>(toCarry, out var toCarryPhysics)
-                && carrierPhysics.Mass < toCarryPhysics.Mass * 2f)
+                && carrierPhysics.Mass * 2f < toCarryPhysics.Mass)
                 return false;
 
             Carry(carrier, toCarry);

--- a/Content.Server/Nyanotrasen/Item/PseudoItem/PseudoItemSystem.cs
+++ b/Content.Server/Nyanotrasen/Item/PseudoItem/PseudoItemSystem.cs
@@ -61,10 +61,6 @@ public sealed class PseudoItemSystem : SharedPseudoItemSystem
 
     protected override void OnGettingPickedUpAttempt(EntityUid uid, PseudoItemComponent component, GettingPickedUpAttemptEvent args)
     {
-        // Floof - prevent pseudo-items from kicking each other out
-        if (TryComp<PseudoItemComponent>(args.User, out var pseudoItemUser) && pseudoItemUser.Active)
-            return;
-
         // Floof - changed this a bit to actually start a do-after
         // Try to pick the entity up instead first
         if (args.User != args.Item

--- a/Content.Server/Nyanotrasen/Item/PseudoItem/PseudoItemSystem.cs
+++ b/Content.Server/Nyanotrasen/Item/PseudoItem/PseudoItemSystem.cs
@@ -61,6 +61,10 @@ public sealed class PseudoItemSystem : SharedPseudoItemSystem
 
     protected override void OnGettingPickedUpAttempt(EntityUid uid, PseudoItemComponent component, GettingPickedUpAttemptEvent args)
     {
+        // Floof - prevent pseudo-items from kicking each other out
+        if (TryComp<PseudoItemComponent>(args.User, out var pseudoItemUser) && pseudoItemUser.Active)
+            return;
+
         // Floof - changed this a bit to actually start a do-after
         // Try to pick the entity up instead first
         if (args.User != args.Item

--- a/Content.Server/OfferItem/OfferItemSystem.ExtendedTransfer.cs
+++ b/Content.Server/OfferItem/OfferItemSystem.ExtendedTransfer.cs
@@ -69,7 +69,7 @@ public sealed class ItemTransferredEvent : HandledEntityEventArgs
     public EntityUid Target;
 
     /// <summary>
-    ///     The actual item being passed around. Can be a virtaul item.
+    ///     The actual item being passed around. Can be a virtual item.
     /// </summary>
     public EntityUid PassedItem;
     /// <summary>

--- a/Content.Server/OfferItem/OfferItemSystem.ExtendedTransfer.cs
+++ b/Content.Server/OfferItem/OfferItemSystem.ExtendedTransfer.cs
@@ -40,7 +40,7 @@ public sealed partial class OfferItemSystem
             return;
 
         _pulling.TryStopPull(oldPuller, ent);
-        args.Handled = _pulling.TryStartPull(args.Target, pulled, null, ent.Comp);
+        args.Handled = _pulling.TryStartPull(args.Target, ent, null, ent.Comp);
     }
 
     private bool TryHandleExtendedTransfer(EntityUid user, EntityUid target, EntityUid offeredItem, EntityUid realItem)

--- a/Content.Server/OfferItem/OfferItemSystem.ExtendedTransfer.cs
+++ b/Content.Server/OfferItem/OfferItemSystem.ExtendedTransfer.cs
@@ -1,0 +1,80 @@
+using Content.Server.Carrying;
+using Content.Shared.Inventory.VirtualItem;
+using Content.Shared.Movement.Pulling.Components;
+using Content.Shared.Movement.Pulling.Systems;
+using Content.Shared.OfferItem;
+
+
+namespace Content.Server.OfferItem;
+
+// this entire class part belongs to floofstation
+public sealed partial class OfferItemSystem
+{
+    [Dependency] private readonly CarryingSystem _carrying = default!;
+    [Dependency] private readonly PullingSystem _pulling = default!;
+
+    public void InitializeTransfers()
+    {
+        SubscribeLocalEvent<BeingCarriedComponent, ItemTransferredEvent>(OnCarryTransfer);
+        SubscribeLocalEvent<PullableComponent, ItemTransferredEvent>(OnPulledTransfer);
+    }
+
+    private void OnCarryTransfer(Entity<BeingCarriedComponent> ent, ref ItemTransferredEvent args)
+    {
+        if (args.Handled
+            || args.PassedItem == args.RealItem // Means the entity is transferred NOT via carrying
+            || args.RealItem is not { Valid: true } carried
+            || ent.Comp.Carrier is not {Valid: true} oldCarrier)
+            return;
+
+        _carrying.DropCarried(oldCarrier, ent);
+        args.Handled = _carrying.TryCarry(args.Target, carried);
+    }
+
+    private void OnPulledTransfer(Entity<PullableComponent> ent, ref ItemTransferredEvent args)
+    {
+        if (args.Handled
+            || args.PassedItem == args.RealItem // Means the entity is transferred NOT via pulling
+            || args.RealItem is not { Valid: true } pulled
+            || ent.Comp.Puller is not {Valid: true} oldPuller)
+            return;
+
+        _pulling.TryStopPull(oldPuller, ent);
+        args.Handled = _pulling.TryStartPull(args.Target, pulled, null, ent.Comp);
+    }
+
+    private bool TryHandleExtendedTransfer(EntityUid user, EntityUid target, EntityUid offeredItem, EntityUid realItem)
+    {
+        var ev = new ItemTransferredEvent
+        {
+            User = user,
+            Target = target,
+            PassedItem = offeredItem,
+            RealItem = realItem,
+        };
+        RaiseLocalEvent(realItem, ref ev);
+        return ev.Handled;
+    }
+}
+
+
+// Floofstation section
+/// <summary>
+///     Raised on the entity that was transferred via item offering.
+/// </summary>
+[ByRefEvent]
+public sealed class ItemTransferredEvent : HandledEntityEventArgs
+{
+    public EntityUid User;
+    public EntityUid Target;
+
+    /// <summary>
+    ///     The actual item being passed around. Can be a virtaul item.
+    /// </summary>
+    public EntityUid PassedItem;
+    /// <summary>
+    ///     If <see cref="PassedItem"/> is a virtual item, this field contains the real item that was transferred.
+    /// </summary>
+    public EntityUid? RealItem;
+}
+// Floofstation section end

--- a/Content.Server/OfferItem/OfferItemSystem.cs
+++ b/Content.Server/OfferItem/OfferItemSystem.cs
@@ -80,11 +80,11 @@ public sealed partial class OfferItemSystem : SharedOfferItemSystem
             }
 
             _popup.PopupEntity(Loc.GetString("offer-item-give",
-                ("item", Identity.Entity(realItem, EntityManager)), // Floof - resolve PseudoItems
+                ("item", Identity.Entity(realItem, EntityManager)), // FLoof - resolve virtual items
                 ("target", Identity.Entity(uid, EntityManager))), component.Target.Value, component.Target.Value);
             _popup.PopupEntity(Loc.GetString("offer-item-give-other",
                     ("user", Identity.Entity(component.Target.Value, EntityManager)),
-                    ("item", Identity.Entity(realItem, EntityManager)), // Floof - resolve PseudoItems
+                    ("item", Identity.Entity(realItem, EntityManager)), // FLoof - resolve virtual items
                     ("target", Identity.Entity(uid, EntityManager)))
                 , component.Target.Value, Filter.PvsExcept(component.Target.Value, entityManager: EntityManager), true);
         }

--- a/Content.Shared/Nyanotrasen/Item/PseudoItem/SharedPseudoItemSystem.cs
+++ b/Content.Shared/Nyanotrasen/Item/PseudoItem/SharedPseudoItemSystem.cs
@@ -120,6 +120,7 @@ public abstract partial class SharedPseudoItemSystem : EntitySystem
     protected virtual void OnGettingPickedUpAttempt(EntityUid uid, PseudoItemComponent component,
         GettingPickedUpAttemptEvent args)
     {
+        args.Cancel();
         // Floof - this is a terrible idea. This triggers every time ANY system checks if a pseudo-item can be picked up.
         // WHY DID YOU DO THAT, NYANOTRASEN???
 

--- a/Content.Shared/OfferItem/OfferItemComponent.cs
+++ b/Content.Shared/OfferItem/OfferItemComponent.cs
@@ -1,6 +1,9 @@
+using System.Diagnostics.CodeAnalysis;
 using Robust.Shared.GameStates;
 using Robust.Shared.Prototypes;
 using Content.Shared.Alert;
+using Content.Shared.Inventory.VirtualItem;
+
 
 namespace Content.Shared.OfferItem;
 
@@ -28,4 +31,9 @@ public sealed partial class OfferItemComponent : Component
 
     [DataField]
     public ProtoId<AlertPrototype> OfferAlert = "Offer";
+
+    // Floofstation section
+    public EntityUid GetRealEntity(EntityManager entityManager) =>
+        entityManager.GetComponentOrNull<VirtualItemComponent>(Item)?.BlockingEntity ?? Item ?? EntityUid.Invalid;
+    // Floofstation section end
 }

--- a/Content.Shared/OfferItem/SharedOfferItemSystem.cs
+++ b/Content.Shared/OfferItem/SharedOfferItemSystem.cs
@@ -1,6 +1,8 @@
 using Content.Shared.Interaction;
 using Content.Shared.IdentityManagement;
 using Content.Shared.Hands.Components;
+using Content.Shared.Inventory.VirtualItem;
+
 
 namespace Content.Shared.OfferItem;
 
@@ -38,12 +40,13 @@ public abstract partial class SharedOfferItemSystem : EntitySystem
         if (offerItem.Item == null)
             return;
 
+        // Floof - if the held item is a pseudo-item, show the underlying item in the popup
         _popup.PopupEntity(Loc.GetString("offer-item-try-give",
-            ("item", Identity.Entity(offerItem.Item.Value, EntityManager)),
+            ("item", Identity.Entity(offerItem.GetRealEntity(EntityManager), EntityManager)), // Floof - resolve PseudoItems
             ("target", Identity.Entity(uid, EntityManager))), component.Target.Value, component.Target.Value);
         _popup.PopupEntity(Loc.GetString("offer-item-try-give-target",
             ("user", Identity.Entity(component.Target.Value, EntityManager)),
-            ("item", Identity.Entity(offerItem.Item.Value, EntityManager))), component.Target.Value, uid);
+            ("item", Identity.Entity(offerItem.GetRealEntity(EntityManager), EntityManager))), component.Target.Value, uid); // Floof - resolve PseudoItems
 
         args.Handled = true;
     }
@@ -73,21 +76,21 @@ public abstract partial class SharedOfferItemSystem : EntitySystem
             if (component.Item != null)
             {
                 _popup.PopupEntity(Loc.GetString("offer-item-no-give",
-                    ("item", Identity.Entity(component.Item.Value, EntityManager)),
+                    ("item", Identity.Entity(component.GetRealEntity(EntityManager), EntityManager)), // Floof - resolve PseudoItems
                     ("target", Identity.Entity(component.Target.Value, EntityManager))), uid, uid);
                 _popup.PopupEntity(Loc.GetString("offer-item-no-give-target",
                     ("user", Identity.Entity(uid, EntityManager)),
-                    ("item", Identity.Entity(component.Item.Value, EntityManager))), uid, component.Target.Value);
+                    ("item", Identity.Entity(component.GetRealEntity(EntityManager), EntityManager))), uid, component.Target.Value); // Floof - resolve PseudoItems
             }
 
             else if (offerItem.Item != null)
             {
                 _popup.PopupEntity(Loc.GetString("offer-item-no-give",
-                    ("item", Identity.Entity(offerItem.Item.Value, EntityManager)),
+                    ("item", Identity.Entity(offerItem.GetRealEntity(EntityManager), EntityManager)), // Floof - resolve PseudoItems
                     ("target", Identity.Entity(uid, EntityManager))), component.Target.Value, component.Target.Value);
                 _popup.PopupEntity(Loc.GetString("offer-item-no-give-target",
                     ("user", Identity.Entity(component.Target.Value, EntityManager)),
-                    ("item", Identity.Entity(offerItem.Item.Value, EntityManager))), component.Target.Value, uid);
+                    ("item", Identity.Entity(offerItem.GetRealEntity(EntityManager), EntityManager))), component.Target.Value, uid); // Floof - resolve PseudoItems
             }
 
             offerItem.IsInOfferMode = false;
@@ -127,11 +130,11 @@ public abstract partial class SharedOfferItemSystem : EntitySystem
         if (offerItem.Item != null)
         {
             _popup.PopupEntity(Loc.GetString("offer-item-no-give",
-                ("item", Identity.Entity(offerItem.Item.Value, EntityManager)),
+                ("item", Identity.Entity(offerItem.GetRealEntity(EntityManager), EntityManager)), // Floof - resolve PseudoItems
                 ("target", Identity.Entity(uid, EntityManager))), component.Target.Value, component.Target.Value);
             _popup.PopupEntity(Loc.GetString("offer-item-no-give-target",
-                ("user", Identity.Entity(component.Target.Value, EntityManager)),
-                ("item", Identity.Entity(offerItem.Item.Value, EntityManager))), component.Target.Value, uid);
+                ("user", Identity.Entity(component.Target.Value, EntityManager)), // Floof - resolve PseudoItems
+                ("item", Identity.Entity(offerItem.GetRealEntity(EntityManager), EntityManager))), component.Target.Value, uid);
         }
 
         if (!offerItem.IsInReceiveMode)

--- a/Content.Shared/OfferItem/SharedOfferItemSystem.cs
+++ b/Content.Shared/OfferItem/SharedOfferItemSystem.cs
@@ -42,11 +42,11 @@ public abstract partial class SharedOfferItemSystem : EntitySystem
 
         // Floof - if the held item is a pseudo-item, show the underlying item in the popup
         _popup.PopupEntity(Loc.GetString("offer-item-try-give",
-            ("item", Identity.Entity(offerItem.GetRealEntity(EntityManager), EntityManager)), // Floof - resolve PseudoItems
+            ("item", Identity.Entity(offerItem.GetRealEntity(EntityManager), EntityManager)), // FLoof - resolve virtual items
             ("target", Identity.Entity(uid, EntityManager))), component.Target.Value, component.Target.Value);
         _popup.PopupEntity(Loc.GetString("offer-item-try-give-target",
             ("user", Identity.Entity(component.Target.Value, EntityManager)),
-            ("item", Identity.Entity(offerItem.GetRealEntity(EntityManager), EntityManager))), component.Target.Value, uid); // Floof - resolve PseudoItems
+            ("item", Identity.Entity(offerItem.GetRealEntity(EntityManager), EntityManager))), component.Target.Value, uid); // FLoof - resolve virtual items
 
         args.Handled = true;
     }
@@ -76,21 +76,21 @@ public abstract partial class SharedOfferItemSystem : EntitySystem
             if (component.Item != null)
             {
                 _popup.PopupEntity(Loc.GetString("offer-item-no-give",
-                    ("item", Identity.Entity(component.GetRealEntity(EntityManager), EntityManager)), // Floof - resolve PseudoItems
+                    ("item", Identity.Entity(component.GetRealEntity(EntityManager), EntityManager)), // FLoof - resolve virtual items
                     ("target", Identity.Entity(component.Target.Value, EntityManager))), uid, uid);
                 _popup.PopupEntity(Loc.GetString("offer-item-no-give-target",
                     ("user", Identity.Entity(uid, EntityManager)),
-                    ("item", Identity.Entity(component.GetRealEntity(EntityManager), EntityManager))), uid, component.Target.Value); // Floof - resolve PseudoItems
+                    ("item", Identity.Entity(component.GetRealEntity(EntityManager), EntityManager))), uid, component.Target.Value); // FLoof - resolve virtual items
             }
 
             else if (offerItem.Item != null)
             {
                 _popup.PopupEntity(Loc.GetString("offer-item-no-give",
-                    ("item", Identity.Entity(offerItem.GetRealEntity(EntityManager), EntityManager)), // Floof - resolve PseudoItems
+                    ("item", Identity.Entity(offerItem.GetRealEntity(EntityManager), EntityManager)), // FLoof - resolve virtual items
                     ("target", Identity.Entity(uid, EntityManager))), component.Target.Value, component.Target.Value);
                 _popup.PopupEntity(Loc.GetString("offer-item-no-give-target",
                     ("user", Identity.Entity(component.Target.Value, EntityManager)),
-                    ("item", Identity.Entity(offerItem.GetRealEntity(EntityManager), EntityManager))), component.Target.Value, uid); // Floof - resolve PseudoItems
+                    ("item", Identity.Entity(offerItem.GetRealEntity(EntityManager), EntityManager))), component.Target.Value, uid); // FLoof - resolve virtual items
             }
 
             offerItem.IsInOfferMode = false;
@@ -130,10 +130,10 @@ public abstract partial class SharedOfferItemSystem : EntitySystem
         if (offerItem.Item != null)
         {
             _popup.PopupEntity(Loc.GetString("offer-item-no-give",
-                ("item", Identity.Entity(offerItem.GetRealEntity(EntityManager), EntityManager)), // Floof - resolve PseudoItems
+                ("item", Identity.Entity(offerItem.GetRealEntity(EntityManager), EntityManager)), // FLoof - resolve virtual items
                 ("target", Identity.Entity(uid, EntityManager))), component.Target.Value, component.Target.Value);
             _popup.PopupEntity(Loc.GetString("offer-item-no-give-target",
-                ("user", Identity.Entity(component.Target.Value, EntityManager)), // Floof - resolve PseudoItems
+                ("user", Identity.Entity(component.Target.Value, EntityManager)), // FLoof - resolve virtual items
                 ("item", Identity.Entity(offerItem.GetRealEntity(EntityManager), EntityManager))), component.Target.Value, uid);
         }
 


### PR DESCRIPTION
# Description
Allows you to transfer carried and pulled people via item offering, for obvious roleplay and gameplay (e.g. prisoner handling) reasons.

Also fixes the bug where pseudo-items could kick each other out from a bag by examining each other.

<details><summary><h1>Media</h1></summary>
<p>


https://github.com/user-attachments/assets/9bcd0f42-4972-4531-b4fa-97840b594e2b



</p>
</details>

---

# Changelog
:cl:
- add: You can now transfer carried and pulled entities via item offering (default keybind is F, as always).
- fix: When several pseudo-items (small people) are inside one container (e.g. a bluespace duffel), they can no longer accidentally kick each other out using the right click menu.
