### PR TITLE
Add Some Missing Components To Quadborgs

### DIFF
--- a/Resources/Prototypes/_Floof/Entities/Mobs/Cyborgs/quadborg.yml
+++ b/Resources/Prototypes/_Floof/Entities/Mobs/Cyborgs/quadborg.yml
@@ -241,6 +241,13 @@
     access: [["Medical"], ["Salvage"], ["Command"], ["Research"]]
   - type: SiliconLawProvider
     laws: Medical
+  - type: FabricateActions
+    actions:
+    - ActionFabricateLollipop
+    - ActionFabricateGumball
+  - type: SurgeryTarget # Shitmed
+  - type: Sanitized # Shitmed
+  - type: SolutionScanner
 
 - type: entity
   id: BorgChassisApex


### PR DESCRIPTION
# Description
Gumballs, lolipops, surgery sanitization, and something else. Copied over from medical quadborgs. I'm assuming it will work as-is, but may need to do some basic testing later since this is web-edited.

# Changelog
:cl:
- fix: Medical quadborgs should now have the same intrinsic chemical analyzer, gumball & lolipop dispenser, and surgery sterilization as basic medical borgs.
