### PR TITLE
No Duplicate Random Map

### DIFF
--- a/Content.Server/Voting/Managers/VoteManager.DefaultVotes.cs
+++ b/Content.Server/Voting/Managers/VoteManager.DefaultVotes.cs
@@ -212,6 +212,7 @@ namespace Content.Server.Voting.Managers
 
         private void CreateMapVote(ICommonSession? initiator)
         {
+            var lastMap = _gameMapManager.GetSelectedMap(); // Floof
             var maps = _gameMapManager.CurrentlyEligibleMaps().ToDictionary(map => map, map => map.MapName);
 
             var alone = _playerManager.PlayerCount == 1 && initiator != null;
@@ -244,6 +245,10 @@ namespace Content.Server.Voting.Managers
                 GameMapPrototype picked;
                 if (args.Winners.Contains(randomMapData)) // Floof section - random map
                 {
+                    // Don't select the same map for the second time in a row
+                    if (lastMap is not null && maps.ContainsKey(lastMap))
+                        maps.Remove(lastMap);
+
                     picked = _random.Pick(maps.Keys);
                     _chatManager.DispatchServerAnnouncement(
                         Loc.GetString("ui-vote-map-random-win", ("picked", maps[picked])));


### PR DESCRIPTION
# Description
Resolves #1163

Was tested by starting & restarting the round about 10 times in a row, each time selecting "random map" with 4 eligible maps, didn't get any duplicates, which gives me a 94.3% confidence this works.

# Changelog
:cl:
- tweak: Voting for random map will no longer result in the last map being chosen for the second time (unless the vote was called manually, or the current map got changed)
