### PR TITLE
Uniform Printer Public Nudity Permit Recipe

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
@@ -1684,6 +1684,7 @@
       - ClothingHandsChefWarmers
       - ClothingUnderSocksChef
       - ClothingUniformChefThong
+      - ClothingUniformNudityPermit
       # Floofstation section end
   - type: EmagLatheRecipes
     emagStaticRecipes:
@@ -1969,7 +1970,7 @@
       # - PlushieFeistyBartender
       # - PlushieCoolVulp
       # - PlushieNoticeableSecurityOfficer
-      - PlushieAvaliHOP 
+      - PlushieAvaliHOP
       - PlushieKoboldCefJustice
       #Floof Plushies - End
   - type: EmagLatheRecipes

--- a/Resources/Prototypes/_Floof/Recipes/Lathes/clothing.yml
+++ b/Resources/Prototypes/_Floof/Recipes/Lathes/clothing.yml
@@ -77,3 +77,14 @@
   materials:
     Cloth: 250 # Two utility belts plus some connecting straps
     Steel: 50 # Because buckles
+
+- type: latheRecipe
+  id: ClothingUniformNudityPermit
+  icon:
+    sprite: _Floof/Clothing/Uniforms/nuditypermit.rsi
+    state: icon
+  result: ClothingUniformNudityPermit
+  category: ClothingOther # Floof - add uniform printer clothing categories
+  completetime: 2
+  materials:
+    Durathread: 100


### PR DESCRIPTION
<!--
This is a semi-strict format, you can add/remove sections as needed but the order/format should be kept the same
Remove these comments before submitting
-->

# Description

<!--
Explain this PR in as much detail as applicable

Some example prompts to consider:
How might this affect the game? The codebase?
What might be some alternatives to this?
How/Who does this benefit/hurt [the game/codebase]?
-->

Add public nudity permit recipe to HoP's uniform printer.
It makes sense for a public nudity permit to be something HoP can issue on Floof. Cost is one durathread.

---

<!--
This is default collapsed, readers click to expand it and see all your media
The PR media section can get very large at times, so this is a good way to keep it clean
The title is written using HTML tags
The title must be within the <summary> tags or you won't see it
-->

<details><summary><h1>Media</h1></summary>
<p>

![pnplathe](https://github.com/user-attachments/assets/d2019ac1-48ef-4e0c-babd-b2be7afc460d)


</p>
</details>

---

# Changelog

<!--
You can add an author after the `:cl:` to change the name that appears in the changelog (ex: `:cl: Death`)
Leaving it blank will default to your GitHub display name
This includes all available types for the changelog
-->

:cl:
- add: Added public nudity permit recipe to HoP's uniform printer.
