### PR TITLE
Fix Custom Examine Expirations Not Working

### DIFF
--- a/Content.Shared/_Floof/Examine/CustomExamineSystem.cs
+++ b/Content.Shared/_Floof/Examine/CustomExamineSystem.cs
@@ -75,7 +75,7 @@ public abstract class SharedCustomExamineSystem : EntitySystem
 
     private void CheckExpirations(Entity<CustomExamineComponent> ent)
     {
-        bool Check(CustomExamineData data)
+        bool Check(ref CustomExamineData data)
         {
             if (data.Content is null
                 || data.ExpireTime.Ticks <= 0
@@ -87,7 +87,7 @@ public abstract class SharedCustomExamineSystem : EntitySystem
         }
 
         // Note: using | (bitwise or) instead of || (logical or) because the former is not short-circuiting
-        if (Check(ent.Comp.PublicData) | Check(ent.Comp.SubtleData))
+        if (Check(ref ent.Comp.PublicData) | Check(ref ent.Comp.SubtleData))
             Dirty(ent);
     }
 


### PR DESCRIPTION
# Description
I was passing CustomExamineData by-value instead of by-ref. Blegh.

# Changelog
:cl:
- fix: Custom examine texts should now correctly be removed when they expire.