### PR TITLE
Mood System Fix & Heirloom Timeout Extension

### DIFF
--- a/Content.Server/Mood/MoodComponent.cs
+++ b/Content.Server/Mood/MoodComponent.cs
@@ -1,5 +1,7 @@
-﻿using Content.Shared.Alert;
+﻿using System.Threading;
+using Content.Shared.Alert;
 using Content.Shared.FixedPoint;
+using Content.Shared.Mood;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Serialization.TypeSerializers.Implementations.Generic;
 
@@ -22,6 +24,10 @@ public sealed partial class MoodComponent : Component
 
     [ViewVariables(VVAccess.ReadOnly)]
     public readonly Dictionary<string, float> UncategorisedEffects = new();
+
+    // Floofstation - this system is so terrible.
+    [NonSerialized]
+    public readonly Dictionary<ProtoId<MoodEffectPrototype>, CancellationTokenSource> CancellationTokens = new();
 
     /// <summary>
     ///     The formula for the movement speed modifier is SpeedBonusGrowth ^ (MoodLevel - MoodThreshold.Neutral).

--- a/Content.Server/Traits/Assorted/HeirloomSystem.cs
+++ b/Content.Server/Traits/Assorted/HeirloomSystem.cs
@@ -39,7 +39,7 @@ public sealed class HeirloomSystem : EntitySystem
 
         query.Dispose();
 
-        _nextUpdate = _gameTiming.CurTime + TimeSpan.FromSeconds(10);
+        _nextUpdate = _gameTiming.CurTime + TimeSpan.FromSeconds(60); // Floof - less updates because this is quite expensive
     }
 
     private IEnumerable<EntityUid> RecursiveGetAllChildren(EntityUid uid)

--- a/Resources/Prototypes/Mood/genericPositiveEffects.yml
+++ b/Resources/Prototypes/Mood/genericPositiveEffects.yml
@@ -50,5 +50,5 @@
   id: HeirloomSecure
   category: Heirloom
   moodChange: 5
-  timeout: 60 # A bit of time before they realize it's gone
+  timeout: 300 # A bit of time before they realize it's gone # Floof - increased to 5 minutes
   moodletOnEnd: HeirloomLost


### PR DESCRIPTION
# Description
Turns out the mood system relies on Timers to implement mood effect timeouts. Yes, timers. The asynchronous programming tool that has no place in a system like this. And the best part, the system doesn't cancel any previously active timers when applying the same mood effect twice. This means that if you got a mood effect 30 seconds ago, and then got it again (e.g. from two kisses), the reset timer from 30 seconds ago will still keep going, resulting in the moodlet being removed 30 seconds earlier than intended.

This PR attempts to resolve this issue in the least destructive way possible - by introducing a dictionary of CancellationTokenSources to the MoodComponent, providing CancellationTokens to the timers created by the mood system, and cancelling any previously going timers for the same MoodEffectPrototype.

Tested; seems to work correctly.

Also increases the time between checks in the HeirloomSystem from 10 seconds to 1 minute, and increases the heirloom moodlet timeout to 5 minutes.

<details><summary><h1>Media</h1></summary>
<p>

30 minutes of mostly passive testing:


https://github.com/user-attachments/assets/533f781b-9630-4542-8fc9-f15e3fd65605



</p>
</details>

# Changelog
:cl:
- fix: Repeated mood effects (such as that from hunger or nicotine addiction) should no longer cause your mood to flicker.