### PR TITLE
Increase Cadet Slots on Tortgua

### DIFF
--- a/Resources/Prototypes/Maps/tortuga.yml
+++ b/Resources/Prototypes/Maps/tortuga.yml
@@ -49,7 +49,7 @@
             Prisoner: [ 2, 3 ]
             PrisonGuard: [ 1, 1 ]
             SecurityOfficer: [ 6, 9 ]
-            SecurityCadet: [ 1, 1 ]
+            SecurityCadet: [ 2, 4 ]
             Warden: [ 1, 1 ]
             SeniorOfficer: [ 1, 1 ]
           #service


### PR DESCRIPTION
# Description

Added three more cadet slots to Tortuga since there was only one cadet slot, the total is now four for the map.

---

# TODO

- [x] Add more cadet slots to Tortuga

<details><summary><h1>Map Renders</h1></summary>
<p>


No image needed.


</p>
</details>

---

# Changelog

:cl:
- tweak: Increased the amount of cadet slots on Tortuga from one to four.