### PR TITLE
Make All Hats in the Loadout Hairloomable 

### DIFF
--- a/Resources/Prototypes/Loadouts/Generic/head.yml
+++ b/Resources/Prototypes/Loadouts/Generic/head.yml
@@ -1,6 +1,7 @@
 # Hats
 - type: loadout
   id: LoadoutHeadBeaverHat
+  canBeHeirloom: true #FLOOF
   category: Head
   cost: 1
   exclusive: true
@@ -16,6 +17,7 @@
 
 - type: loadout
   id: LoadoutHeadTophat
+  canBeHeirloom: true #FLOOF
   category: Head
   cost: 1
   exclusive: true
@@ -27,6 +29,7 @@
 
 - type: loadout
   id: LoadoutHeadFedoraWhite
+  canBeHeirloom: true #FLOOF
   category: Head
   cost: 1
   exclusive: true
@@ -39,6 +42,7 @@
 
 - type: loadout
   id: LoadoutHeadFlatBlack
+  canBeHeirloom: true #FLOOF
   category: Head
   cost: 1
   exclusive: true
@@ -50,6 +54,7 @@
 
 - type: loadout
   id: LoadoutHeadFlatBrown
+  canBeHeirloom: true #FLOOF
   category: Head
   cost: 1
   exclusive: true
@@ -65,6 +70,7 @@
 
 - type: loadout
   id: LoadoutHeadHatCowboyWhite
+  canBeHeirloom: true #FLOOF
   category: Head
   cost: 1
   exclusive: true
@@ -102,6 +108,7 @@
 
 - type: loadout
   id: LoadoutHeadBellhop
+  canBeHeirloom: true #FLOOF
   category: Head
   cost: 1
   exclusive: true
@@ -113,6 +120,7 @@
 
 - type: loadout
   id: LoadoutHeadPoppy
+  canBeHeirloom: true #FLOOF
   category: Head
   cost: 0
   exclusive: true
@@ -124,6 +132,7 @@
 
 - type: loadout
   id: LoadoutHeadPoppyWhite
+  canBeHeirloom: true #FLOOF
   category: Head
   cost: 0
   exclusive: true
@@ -137,6 +146,7 @@
 # Color Hats
 - type: loadout
   id: LoadoutHeadHatCorpsoft
+  canBeHeirloom: true #FLOOF
   category: Head
   cost: 0
   exclusive: true
@@ -148,6 +158,7 @@
 
 - type: loadout
   id: LoadoutHeadHatCorpsoftFlipped
+  canBeHeirloom: true #FLOOF
   category: Head
   cost: 0
   exclusive: true
@@ -159,6 +170,7 @@
 
 - type: loadout
   id: LoadoutHeadHatMimesoft
+  canBeHeirloom: true #FLOOF
   category: Head
   cost: 0
   exclusive: true
@@ -171,6 +183,7 @@
 
 - type: loadout
   id: LoadoutHeadHatMimesoftFlipped
+  canBeHeirloom: true #FLOOF
   category: Head
   cost: 0
   exclusive: true
@@ -184,6 +197,7 @@
 # Headbands
 - type: loadout
   id: LoadoutHeadBandWhite
+  canBeHeirloom: true #FLOOF
   category: Head
   cost: 0
   exclusive: true
@@ -208,6 +222,7 @@
 
 - type: loadout
   id: LoadoutHeadFishCap
+  canBeHeirloom: true #FLOOF
   category: Head
   cost: 1
   exclusive: true
@@ -223,6 +238,7 @@
 
 - type: loadout
   id: LoadoutHeadRastaHat
+  canBeHeirloom: true #FLOOF
   category: Head
   cost: 2
   exclusive: true
@@ -238,6 +254,7 @@
 
 - type: loadout
   id: LoadoutHeadFez
+  canBeHeirloom: true #FLOOF
   category: Head
   cost: 1
   exclusive: true
@@ -249,6 +266,7 @@
 
 - type: loadout
   id: LoadoutHeadBowlerHat
+  canBeHeirloom: true #FLOOF
   category: Head
   cost: 1
   exclusive: true
@@ -261,6 +279,7 @@
 # Flatcaps
 - type: loadout
   id: LoadoutHeadGreyFlatcap
+  canBeHeirloom: true #FLOOF
   category: Head
   cost: 1
   exclusive: true
@@ -272,6 +291,7 @@
 
 - type: loadout
   id: LoadoutHeadBrownFlatcap
+  canBeHeirloom: true #FLOOF
   category: Head
   cost: 1
   exclusive: true
@@ -288,6 +308,7 @@
 # Berets
 - type: loadout
   id: LoadoutHeadBeretWhite
+  canBeHeirloom: true #FLOOF
   category: Head
   cost: 1
   exclusive: true
@@ -300,6 +321,7 @@
 
 - type: loadout
   id: LoadoutHeadHijabColorable
+  canBeHeirloom: true #FLOOF
   category: Head
   cost: 0
   exclusive: true
@@ -312,6 +334,7 @@
 
 - type: loadout
   id: LoadoutHeadTurbanColorable
+  canBeHeirloom: true #FLOOF
   category: Head
   cost: 0
   exclusive: true
@@ -324,6 +347,7 @@
 
 - type: loadout
   id: LoadoutHeadKippahColorable
+  canBeHeirloom: true #FLOOF
   category: Head
   cost: 0
   exclusive: true

--- a/Resources/Prototypes/Loadouts/Jobs/Epistemics/uncategorized.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Epistemics/uncategorized.yml
@@ -153,6 +153,7 @@
   id: LoadoutHeadHoodTechPriest
   category: Head
   cost: 0
+  canBeHeirloom: true
   exclusive: true
   items:
     - ClothingHeadTechPriest

--- a/Resources/Prototypes/_Floof/Loadouts/Generic/head.yml
+++ b/Resources/Prototypes/_Floof/Loadouts/Generic/head.yml
@@ -1,5 +1,6 @@
 - type: loadout
   id: LoadoutTacticalMaidHeadband
+  canBeHeirloom: true #FLOOF
   category: Head
   cost: 1
   exclusive: true
@@ -16,6 +17,7 @@
 
 - type: loadout
   id: LoadoutHeadHatAnimalCat
+  canBeHeirloom: true #FLOOF
   category: Head
   cost: 0
   exclusive: true
@@ -27,6 +29,7 @@
 
 - type: loadout
   id: LoadoutHeadHatAnimalCatBrown
+  canBeHeirloom: true #FLOOF
   category: Head
   cost: 0
   exclusive: true
@@ -38,6 +41,7 @@
 
 - type: loadout
   id: LoadoutHeadAnimalCatBlack
+  canBeHeirloom: true #FLOOF
   category: Head
   cost: 0
   exclusive: true
@@ -49,6 +53,7 @@
 
 - type: loadout
   id: LoadoutHeadAnimalHeadslime
+  canBeHeirloom: true #FLOOF
   category: Head
   cost: 0
   exclusive: true
@@ -60,6 +65,7 @@
 
 - type: loadout
   id: LoadoutHeadHatAnimalMonkey
+  canBeHeirloom: true #FLOOF
   category: Head
   cost: 0
   exclusive: true
@@ -71,6 +77,7 @@
 
 - type: loadout
   id: LoadoutHeadHatWitch1
+  canBeHeirloom: true #FLOOF
   category: Head
   cost: 0
   exclusive: true
@@ -82,6 +89,7 @@
 
 - type: loadout
   id: LoadoutHeadHatPlaguedoctor
+  canBeHeirloom: true #FLOOF
   category: Head
   cost: 0
   exclusive: true
@@ -93,6 +101,7 @@
 
 - type: loadout
   id: LoadoutHeadHatUshanka
+  canBeHeirloom: true #FLOOF
   category: Head
   cost: 0
   exclusive: true
@@ -104,6 +113,7 @@
 
 - type: loadout
   id: LoadoutHeadHatWitch
+  canBeHeirloom: true #FLOOF
   category: Head
   cost: 0
   exclusive: true
@@ -115,6 +125,7 @@
 
 - type: loadout
   id: LoadoutHeadHatTrucker
+  canBeHeirloom: true #FLOOF
   category: Head
   cost: 0
   exclusive: true
@@ -126,6 +137,7 @@
 
 - type: loadout
   id: LoadoutHeadPaperSack
+  canBeHeirloom: true #FLOOF
   category: Head
   cost: 0
   exclusive: true
@@ -137,6 +149,7 @@
 
 - type: loadout
   id: LoadoutHeadHatFlowerWreath
+  canBeHeirloom: true #FLOOF
   category: Head
   cost: 0
   exclusive: true
@@ -148,6 +161,7 @@
 
 - type: loadout
   id: LoadoutHeadHatSquid
+  canBeHeirloom: true #FLOOF
   category: Head
   cost: 0
   exclusive: true
@@ -159,6 +173,7 @@
 
 - type: loadout
   id: LoadoutHeadHatRedRacoon
+  canBeHeirloom: true #FLOOF
   category: Head
   cost: 0
   exclusive: true
@@ -170,6 +185,7 @@
 
 - type: loadout
   id: LoadoutHeadHatDogEarsCosmetic
+  canBeHeirloom: true #FLOOF
   category: Head
   cost: 1
   exclusive: true
@@ -181,6 +197,7 @@
 
 - type: loadout
   id: LoadoutHeadHatCatEarsCosmetic
+  canBeHeirloom: true #FLOOF
   category: Head
   cost: 1
   exclusive: true
@@ -192,6 +209,7 @@
 
 - type: loadout
   id: LoadoutHeadLily
+  canBeHeirloom: true #FLOOF
   category: Head
   cost: 0
   exclusive: true
@@ -200,7 +218,7 @@
   requirements:
     - !type:CharacterItemGroupRequirement
       group: LoadoutHead
-      
+
 - type: loadout
   id: LoadoutHeadHatHolyWatermelon
   category: Head


### PR DESCRIPTION
# Description

Suggested by a Discord user, they wanted all hats hairloomable Don't see a reason why they can't 


![image](https://github.com/user-attachments/assets/bbdec3be-70be-481f-93a0-0a6e6a1bec86)


# Changelog

:cl:
- tweak: all hats can be Heirlooms now
