### PR TITLE
Fix Default Health Examine

### DIFF
--- a/Content.Shared/HealthExaminable/HealthExaminableSystem.cs
+++ b/Content.Shared/HealthExaminable/HealthExaminableSystem.cs
@@ -215,7 +215,7 @@ public sealed class HealthExaminableSystem : EntitySystem
         using (args.PushGroup(nameof(HealthExaminableComponent)))
         {
             // only show the default health inspect, leave self-aware to the actual health examine action
-            args.PushMessage(CreateMarkup(args.Examiner, component, damage, false));
+            args.PushMessage(CreateMarkup(examinedUid, component, damage, false));
         }
     }
 }


### PR DESCRIPTION
was passing in the wrong entity

:cl:
- fix: Fixed basic examine health info using the wrong entity