### PR TITLE
Thieving Trait Now only Shows the Silhouette of Pocketed Items

### DIFF
--- a/Content.Shared/Strip/Components/ThievingComponent.cs
+++ b/Content.Shared/Strip/Components/ThievingComponent.cs
@@ -31,4 +31,11 @@ public sealed partial class ThievingComponent : Component
     /// </summary>
     [DataField, AutoNetworkedField]
     public bool IgnoreStripHidden;
+
+    /// <summary>
+    /// Floof: The color of the hidden entity silhouette
+    /// The default is based on the window background color, value-adjusted for contrast with all themes.
+    /// </summary>
+    [DataField, AutoNetworkedField]
+    public Color HiddenEntityColor = Color.FromHex("#AAAAAF");
 }

--- a/Resources/Prototypes/_Floof/Shaders/shaders.yml
+++ b/Resources/Prototypes/_Floof/Shaders/shaders.yml
@@ -1,0 +1,4 @@
+- type: shader
+  id: Silhouette
+  kind: source
+  path: "/Textures/_Floof/Shaders/silhouette.swsl"

--- a/Resources/Textures/_Floof/Shaders/silhouette.swsl
+++ b/Resources/Textures/_Floof/Shaders/silhouette.swsl
@@ -1,0 +1,7 @@
+uniform highp vec4 color;
+
+void fragment() {
+    highp vec4 tex_color = zTexture(UV);
+
+    COLOR = tex_color.a > 0.0 ? color : vec4(0.0);
+}


### PR DESCRIPTION
# Description

the full item is still visible to admin ghosts or anyone with BypassInteractionChecksComponent

---

<details><summary><h1>Media</h1></summary>
<p>

![image](https://github.com/user-attachments/assets/759d64fa-0dac-43b0-bc5e-888573d5926f)

</p>
</details>

---

# Changelog

:cl:
- tweak: Thieving trait now only shows the silhouette of pocketed items