### PR TITLE
Make Hiding Under Tables Obscure You From HUDs

### DIFF
--- a/Content.Client/StatusIcon/StatusIconSystem.cs
+++ b/Content.Client/StatusIcon/StatusIconSystem.cs
@@ -1,10 +1,13 @@
 using Content.Shared.CCVar;
 using Content.Shared.Ghost;
+using Content.Shared.Physics;
 using Content.Shared.StatusIcon;
 using Content.Shared.StatusIcon.Components;
 using Content.Shared.Stealth.Components;
 using Content.Shared.Whitelist;
+using Robust.Client.GameObjects;
 using Robust.Client.Graphics;
+using Robust.Client.Physics;
 using Robust.Client.Player;
 using Robust.Shared.Configuration;
 
@@ -19,6 +22,7 @@ public sealed class StatusIconSystem : SharedStatusIconSystem
     [Dependency] private readonly IOverlayManager _overlay = default!;
     [Dependency] private readonly IPlayerManager _playerManager = default!;
     [Dependency] private readonly EntityWhitelistSystem _entityWhitelist = default!;
+    [Dependency] private readonly PhysicsSystem _physics = default!;
 
     private bool _globalEnabled;
     private bool _localEnabled;
@@ -87,6 +91,16 @@ public sealed class StatusIconSystem : SharedStatusIconSystem
 
         if (data.ShowTo != null && !_entityWhitelist.IsValid(data.ShowTo, viewer))
             return false;
+
+        // Floof
+        if (data.HideUnderTables && TryComp(ent, out SpriteComponent? sprite) && sprite.DrawDepth < (int) Shared.DrawDepth.DrawDepth.Objects)
+        {
+            var aabb = _physics.GetHardAABB(ent);
+            foreach (var body in _physics.GetEntitiesIntersectingBody(ent, (int) CollisionGroup.TableLayer))
+                // Allow a little wiggle room with the margins
+                if (_physics.GetHardAABB(body).Enlarged(1.1f).Encloses(aabb))
+                    return false;
+        }
 
         return true;
     }

--- a/Content.Shared/StatusIcon/StatusIconPrototype.cs
+++ b/Content.Shared/StatusIcon/StatusIconPrototype.cs
@@ -45,6 +45,12 @@ public partial class StatusIconData : IComparable<StatusIconData>
     public bool HideOnStealth = true;
 
     /// <summary>
+    /// Floof: Whether or not to hide the icon when the entity is fully concealed under a table.
+    /// </summary>
+    [DataField]
+    public bool HideUnderTables = true;
+
+    /// <summary>
     /// Specifies what entities and components/tags this icon can be shown to.
     /// </summary>
     [DataField]


### PR DESCRIPTION
# Description

This was requested by a user in discord, as they've already been playing as though the feature exists.

---

<details><summary><h1>Media</h1></summary>
<p>

![image](https://github.com/user-attachments/assets/bf9388ce-137d-409a-bf17-a1ba5f3dea68)

</p>
</details>

---

# Changelog

:cl:
- tweak: Hiding under tables now obscures you from HUD overlays