### PR TITLE
Rename Golemancer Back to Roboticist

### DIFF
--- a/Resources/Locale/en-US/job/job-names.ftl
+++ b/Resources/Locale/en-US/job/job-names.ftl
@@ -12,7 +12,8 @@ job-name-senior-physician = Senior Physician
 job-name-scientist = Acolyte
 job-name-research-assistant = Noviciate
 job-name-rd = Mystagogue
-job-name-roboticist = Golemancer
+# Floof - renamed back
+job-name-roboticist = Roboticist
 job-name-psychologist = Psychologist
 job-name-intern = Medical Intern
 job-name-doctor = Medical Doctor
@@ -111,7 +112,8 @@ JobQuartermaster = Logistics Officer
 JobReporter = Reporter
 JobResearchAssistant = Noviciate
 JobResearchDirector = Mystagogue
-JobRoboticist = Golemancer
+# Floof - renamed
+JobRoboticist = Roboticist
 JobSalvageSpecialist = Salvage Specialist
 JobScientist = Acolyte
 JobSecurityCadet = Security Cadet

--- a/Resources/Locale/en-US/loadouts/categories.ftl
+++ b/Resources/Locale/en-US/loadouts/categories.ftl
@@ -36,7 +36,8 @@ loadout-category-JobsEpistemicsAAUncategorized = All Epistemiologists
 loadout-category-JobsEpistemicsAcolyte = Acolyte
 loadout-category-JobsEpistemicsCataloger = Cataloger
 loadout-category-JobsEpistemicsChaplain = Chaplain
-loadout-category-JobsEpistemicsGolemancer = Golemancer
+# Floof - renamed back
+loadout-category-JobsEpistemicsGolemancer = Roboticist
 loadout-category-JobsEpistemicsMystagogue = Mystagogue
 loadout-category-JobsEpistemicsMystic = Mystic
 loadout-category-JobsEpistemicsNoviciate = Noviciate

--- a/Resources/Locale/en-US/loadouts/itemgroups.ftl
+++ b/Resources/Locale/en-US/loadouts/itemgroups.ftl
@@ -234,19 +234,20 @@ character-item-group-LoadoutChaplainShoes = Chaplain Shoes
 character-item-group-LoadoutChaplainUniforms = Chaplain Uniforms
 
 # Epistemics - Golemancer
-character-item-group-LoadoutGolemancerBackpacks = Golemancer Backpacks
-character-item-group-LoadoutGolemancerBelt = Golemancer Belt
-character-item-group-LoadoutGolemancerEars = Golemancer Ears
-character-item-group-LoadoutGolemancerEquipment = Golemancer Equipment
-character-item-group-LoadoutGolemancerEyes = Golemancer Eyewear
-character-item-group-LoadoutGolemancerGloves = Golemancer Gloves
-character-item-group-LoadoutGolemancerHead = Golemancer Headgear
-character-item-group-LoadoutGolemancerId = Golemancer Id
-character-item-group-LoadoutGolemancerNeck = Golemancer Neckwear
-character-item-group-LoadoutGolemancerMask = Golemancer Masks
-character-item-group-LoadoutGolemancerOuter = Golemancer Outerwear
-character-item-group-LoadoutGolemancerShoes = Golemancer Shoes
-character-item-group-LoadoutGolemancerUniforms = Golemancer Uniforms
+# Floof - all renamed back
+character-item-group-LoadoutGolemancerBackpacks = Roboticist Backpacks
+character-item-group-LoadoutGolemancerBelt = Roboticist Belt
+character-item-group-LoadoutGolemancerEars = Roboticist Ears
+character-item-group-LoadoutGolemancerEquipment = Roboticist Equipment
+character-item-group-LoadoutGolemancerEyes = Roboticist Eyewear
+character-item-group-LoadoutGolemancerGloves = Roboticist Gloves
+character-item-group-LoadoutGolemancerHead = Roboticist Headgear
+character-item-group-LoadoutGolemancerId = Roboticist Id
+character-item-group-LoadoutGolemancerNeck = Roboticist Neckwear
+character-item-group-LoadoutGolemancerMask = Roboticist Masks
+character-item-group-LoadoutGolemancerOuter = Roboticist Outerwear
+character-item-group-LoadoutGolemancerShoes = Roboticist Shoes
+character-item-group-LoadoutGolemancerUniforms = Roboticist Uniforms
 
 # Epistemics - Mystagogue
 character-item-group-LoadoutMystagogueBackpacks = Mystagogue Backpacks


### PR DESCRIPTION
# Description
By a popular demand. Didn't change prototype names for backwards compatibility.

# Changelog
:cl:
- tweak: Roboticist is back.