### PR TITLE
Blood Tomato Eatable by Vampires

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/produce.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/produce.yml
@@ -946,6 +946,7 @@
     tags:
     - Fruit # Fuck you they're a fruit
     - Vegetable
+    - BloodTomato # For Vampirism users to Succ on
   - type: FoodSequenceElement
     entries:
       Skewer: TomatoSkewer

--- a/Resources/Prototypes/_Floof/Traits/physical.yml
+++ b/Resources/Prototypes/_Floof/Traits/physical.yml
@@ -27,6 +27,7 @@
           - Pill
           - Crayon
           - Paper
+          - BloodTomato
 
 - type: trait
   id: HollowFangs

--- a/Resources/Prototypes/tags.yml
+++ b/Resources/Prototypes/tags.yml
@@ -68,6 +68,9 @@
   id: Bloodpack
 
 - type: Tag
+  id: BloodTomato
+
+- type: Tag
   id: BodyBag
 
 - type: Tag


### PR DESCRIPTION

Added tags for blood tomato into the vampirism food whitelist for the purpose of Vampires being able to 'consume' blood tomatoes due to their Blood content. 
It provides a way of vampires to get blood from 'natural' means with the help of botany.
Blood tomatoes are also present in the mail pool, so now in a situation where said vampire gets a mail with blood tomatoes in them they can happily chew away at them instead of asking the bartender or chef for a grinder only go get their 10 blood units in a beaker.