### PR TITLE
Use Encryption Keys Instead of Intrinsic Radio Channels for pAI

### DIFF
--- a/Content.Shared/Radio/EntitySystems/EncryptionKeySystem.cs
+++ b/Content.Shared/Radio/EntitySystems/EncryptionKeySystem.cs
@@ -40,6 +40,7 @@ public sealed partial class EncryptionKeySystem : EntitySystem
         SubscribeLocalEvent<EncryptionKeyHolderComponent, ExaminedEvent>(OnHolderExamined);
 
         SubscribeLocalEvent<EncryptionKeyHolderComponent, ComponentStartup>(OnStartup);
+        SubscribeLocalEvent<EncryptionKeyHolderComponent, MapInitEvent>(OnMapInit);
         SubscribeLocalEvent<EncryptionKeyHolderComponent, InteractUsingEvent>(OnInteractUsing);
         SubscribeLocalEvent<EncryptionKeyHolderComponent, EntInsertedIntoContainerMessage>(OnContainerModified);
         SubscribeLocalEvent<EncryptionKeyHolderComponent, EntRemovedFromContainerMessage>(OnContainerModified);
@@ -181,6 +182,10 @@ public sealed partial class EncryptionKeySystem : EntitySystem
     private void OnStartup(EntityUid uid, EncryptionKeyHolderComponent component, ComponentStartup args)
     {
         component.KeyContainer = _container.EnsureContainer<Container>(uid, EncryptionKeyHolderComponent.KeyContainerName);
+    }
+
+    private void OnMapInit(EntityUid uid, EncryptionKeyHolderComponent component, MapInitEvent args)
+    {
         UpdateChannels(uid, component);
     }
 

--- a/Content.Shared/Radio/EntitySystems/EncryptionKeySystem.cs
+++ b/Content.Shared/Radio/EntitySystems/EncryptionKeySystem.cs
@@ -51,19 +51,31 @@ public sealed partial class EncryptionKeySystem : EntitySystem
         if (args.Cancelled)
             return;
 
+        // Floof: fix unremovable keys being removed by PickupOrDrop, count number successfully popped out
+        var poppedOut = 0;
         var contained = component.KeyContainer.ContainedEntities.ToArray();
-        _container.EmptyContainer(component.KeyContainer, reparent: false);
         foreach (var ent in contained)
         {
+            if (!_container.TryRemoveFromContainer(ent))
+                continue;
             _hands.PickupOrDrop(args.User, ent);
+            poppedOut++;
         }
 
         if (!_timing.IsFirstTimePredicted)
             return;
 
         // TODO add predicted pop-up overrides.
+        // Floof: locale strings for unremovable keys
         if (_net.IsServer)
-            _popup.PopupEntity(Loc.GetString("encryption-keys-all-extracted"), uid, args.User);
+        {
+            if (poppedOut == contained.Length)
+                _popup.PopupEntity(Loc.GetString("encryption-keys-all-extracted", ("count", poppedOut)), uid, args.User);
+            else if (poppedOut > 0)
+                _popup.PopupEntity(Loc.GetString("encryption-keys-some-extracted", ("count", poppedOut)), uid, args.User);
+            else
+                _popup.PopupEntity(Loc.GetString("encryption-keys-none-extracted", ("remaining", contained.Length)), uid, args.User);
+        }
 
         _audio.PlayPredicted(component.KeyExtractionSound, uid, args.User);
     }

--- a/Resources/Locale/en-US/radio/components/encryption-key-component.ftl
+++ b/Resources/Locale/en-US/radio/components/encryption-key-component.ftl
@@ -1,6 +1,18 @@
 encryption-key-successfully-installed = You put the encryption key inside.
 encryption-key-slots-already-full = There is no place for another encryption key.
-encryption-keys-all-extracted = You pop out the encryption keys!
+# Floof: locale strings for unremovable keys, pluralization handling
+encryption-keys-all-extracted = { $count ->
+    [one] You pop out the encryption key!
+    *[other] You pop out the encryption keys!
+}
+encryption-keys-some-extracted = { $count ->
+    [one] You pop out one of the encryption keys!
+    *[other] You pop out some of the encryption keys!
+}
+encryption-keys-none-extracted = { $remaining ->
+    [one] The encryption key is unremovable!
+    *[other] The encryption keys are unremovable!
+}
 encryption-keys-no-keys = This device has no encryption keys!
 encryption-keys-are-locked = Encryption key slots are locked!
 encryption-keys-panel-locked = Open maintenance panel first!

--- a/Resources/Prototypes/Entities/Objects/Devices/encryption_keys.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/encryption_keys.yml
@@ -236,6 +236,13 @@
     - state: crypt_silver
     - state: rd_label
 
+# Floof: used for pAI
+- type: entity
+  parent: EncryptionKeyBinary
+  id: EncryptionKeyBinaryUnremoveable
+  components:
+    - type: Unremoveable
+
 - type: entity
   parent: EncryptionKey
   id: EncryptionKeyFreelance

--- a/Resources/Prototypes/Entities/Objects/Fun/pai.yml
+++ b/Resources/Prototypes/Entities/Objects/Fun/pai.yml
@@ -46,6 +46,9 @@
   - type: EncryptionKeyHolder
     keySlots: 4
     keysExtractionMethod: Screwing
+  - type: ContainerContainer
+    containers:
+      key_slots: !type:Container
   - type: ContainerFill
     containers:
       key_slots:
@@ -53,7 +56,13 @@
       - EncryptionKeyCommon
   - type: IntrinsicRadioReceiver
   - type: IntrinsicRadioTransmitter
+    channels:
+    - Binary
+    - Common
   - type: ActiveRadio
+    channels:
+    - Binary
+    - Common
   - type: DoAfter
   - type: Actions
   - type: TypingIndicator
@@ -124,7 +133,15 @@
       - EncryptionKeyCommon
       - EncryptionKeySyndie
   - type: IntrinsicRadioTransmitter
+    channels:
+    - Binary
+    - Common
+    - Syndicate
   - type: ActiveRadio
+    channels:
+    - Binary
+    - Common
+    - Syndicate
   - type: Appearance
   - type: GenericVisualizer
     visuals:

--- a/Resources/Prototypes/Entities/Objects/Fun/pai.yml
+++ b/Resources/Prototypes/Entities/Objects/Fun/pai.yml
@@ -42,14 +42,18 @@
     stopSearchVerbText: pai-system-stop-searching-verb-text
     stopSearchVerbPopup: pai-system-stopped-searching
   - type: Examiner
+  # Floof: use encryption keys instead of intrinsic radio channels
+  - type: EncryptionKeyHolder
+    keySlots: 4
+    keysExtractionMethod: Screwing
+  - type: ContainerFill
+    containers:
+      key_slots:
+      - EncryptionKeyBinaryUnremoveable
+      - EncryptionKeyCommon
   - type: IntrinsicRadioReceiver
   - type: IntrinsicRadioTransmitter
-    channels:
-    - Binary
   - type: ActiveRadio
-    channels:
-    - Binary
-    - Common
   - type: DoAfter
   - type: Actions
   - type: TypingIndicator
@@ -109,12 +113,18 @@
   - type: ToggleableGhostRole
     roleName: pai-system-role-name-syndicate
     roleDescription: pai-system-role-description-syndicate
+  # Floof: use encryption keys instead of intrinsic radio channels
+  - type: EncryptionKeyHolder
+    keySlots: 4
+    keysExtractionMethod: Screwing
+  - type: ContainerFill
+    containers:
+      key_slots:
+      - EncryptionKeyBinaryUnremoveable
+      - EncryptionKeyCommon
+      - EncryptionKeySyndie
   - type: IntrinsicRadioTransmitter
-    channels:
-    - Syndicate
   - type: ActiveRadio
-    channels:
-    - Syndicate
   - type: Appearance
   - type: GenericVisualizer
     visuals:


### PR DESCRIPTION
# Description

I decided against making them require a lock, since it's similar to a headset as something you carry around on your person. If your pAI gets stolen and encryption keys dumped, that's your problem.

This change incidentally adds the ability to talk on the Common channel by default (they could only listen on it before). There's no good way for me to align it with the old behavior while still allowing to use encryption keys, and it would be confusing for players.

---

# Changelog

:cl:
- tweak: pAIs now use encryption keys, allowing them to talk on more than just the binary channel