### PR TITLE
Atmos Tech TC Fix

### DIFF
--- a/Resources/Prototypes/Roles/Jobs/Engineering/atmospheric_technician.yml
+++ b/Resources/Prototypes/Roles/Jobs/Engineering/atmospheric_technician.yml
@@ -7,7 +7,7 @@
   - !type:CharacterDepartmentTimeRequirement
     department: Engineering
     min: 3600 # Floofstation - 1 hour
-  antagAdvantage: 5 # Floof - Reduced TC: External Access + Fireaxe + Free Hardsuit, but they cannot pump chemicals into the air supply en masse.
+  antagAdvantage: 3 # Floof - Reduced TC: External Access + Fireaxe + Free Hardsuit, but they cannot pump chemicals into the air supply en masse.
   startingGear: AtmosphericTechnicianGear
   icon: "JobIconAtmosphericTechnician"
   supervisors: job-supervisors-ce


### PR DESCRIPTION
# Description

Gives Atmos 2 more TC to be in line with Senior Engineers. Atmos are forbidden from doing all the mass destruction crimes they're usually able of doing on a LRP server on Floof.

# Changelog

:cl:
- tweak: Added 2 TC back to Atmos Techs to be more in line with Engineers

