### PR TITLE
Corrupt Cop

### DIFF
--- a/Resources/Prototypes/Nyanotrasen/Roles/Jobs/Security/prisonguard.yml
+++ b/Resources/Prototypes/Nyanotrasen/Roles/Jobs/Security/prisonguard.yml
@@ -11,7 +11,7 @@
       min: 7200 # 2hr floof
   startingGear: PrisonGuardGear
   alwaysUseSpawner: true
-  canBeAntag: false
+  antagAdvantage: 10 # Starts mindshielded with access to guns and relatively trusted
   icon: "JobIconPrisonGuard"
   supervisors: job-supervisors-warden
   setPreference: true

--- a/Resources/Prototypes/Roles/Jobs/Security/security_cadet.yml
+++ b/Resources/Prototypes/Roles/Jobs/Security/security_cadet.yml
@@ -13,7 +13,7 @@
   startingGear: SecurityCadetGear
   icon: "JobIconSecurityCadet"
   supervisors: job-supervisors-security
-  canBeAntag: false
+  antagAdvantage: 10 # Starts mindshielded with access to guns and relatively trusted
   access:
   - Security
   #- Brig # Delta V: Removed

--- a/Resources/Prototypes/Roles/Jobs/Security/security_officer.yml
+++ b/Resources/Prototypes/Roles/Jobs/Security/security_officer.yml
@@ -10,7 +10,7 @@
   startingGear: SecurityOfficerGear
   icon: "JobIconSecurityOfficer"
   supervisors: job-supervisors-hos
-  canBeAntag: false
+  antagAdvantage: 10 # Starts mindshielded with access to guns and relatively trusted
   access:
   - Security
   #- Brig # Delta V: Removed

--- a/Resources/Prototypes/Roles/Jobs/Security/senior_officer.yml
+++ b/Resources/Prototypes/Roles/Jobs/Security/senior_officer.yml
@@ -11,7 +11,7 @@
   startingGear: SeniorOfficerGear
   icon: "JobIconSeniorOfficer"
   supervisors: job-supervisors-hos
-  canBeAntag: false
+  antagAdvantage: 10 # Starts mindshielded with access to guns and relatively trusted
   access:
   - Security
   #- Brig # Delta V: Removed


### PR DESCRIPTION
# Description

This PR will likely be highly controversial, but this enables Security (not including detectives or wardens) to be antags with a 10 less TC.

Why?
We don't live in a black and white world, where police and security are infallible forces of good. The mindshield isn't a loyalty implant. Deep agents exist and have already infiltrated the upper echelons of our society and structure. Trust no one.

# Changelog

:cl:
- add: The deep sleepers awaken.

