### PR TITLE
Show Carried Entities in Examine Text, Translate Numbers To Words

### DIFF
--- a/Content.Server/Chat/Systems/ChatSystem.cs
+++ b/Content.Server/Chat/Systems/ChatSystem.cs
@@ -995,7 +995,15 @@ public sealed partial class ChatSystem : SharedChatSystem
     }
 
     // ReSharper disable once InconsistentNaming
-    private string SanitizeInGameICMessage(EntityUid source, string message, out string? emoteStr, bool capitalize = true, bool punctuate = false, bool capitalizeTheWordI = true)
+    private string SanitizeInGameICMessage(
+        EntityUid source,
+        string message,
+        out string? emoteStr,
+        bool capitalize = true,
+        bool punctuate = false,
+        bool capitalizeTheWordI = true,
+        bool numbersAsWords = true // Floof
+    )
     {
         var newMessage = message.Trim();
         newMessage = SanitizeMessageReplaceWords(newMessage);
@@ -1004,6 +1012,8 @@ public sealed partial class ChatSystem : SharedChatSystem
             newMessage = SanitizeMessageCapital(newMessage);
         if (capitalizeTheWordI)
             newMessage = SanitizeMessageCapitalizeTheWordI(newMessage, "i");
+        if (numbersAsWords) // Floof
+            newMessage = SanitizeMessageNumbersAsWords(newMessage);
         if (punctuate)
             newMessage = SanitizeMessagePeriod(newMessage);
 

--- a/Content.Shared/Chat/SharedChatSystem.cs
+++ b/Content.Shared/Chat/SharedChatSystem.cs
@@ -1,5 +1,6 @@
 using System.Collections.Frozen;
 using System.Text.RegularExpressions;
+using Content.Shared.Localizations;
 using Content.Shared.Popups;
 using Content.Shared.Radio;
 using Content.Shared.Speech;
@@ -193,6 +194,16 @@ public abstract class SharedChatSystem : EntitySystem
         }
 
         return message;
+    }
+
+    private static readonly Regex NumberRegex = new(@"-?\d+(\.\d+)?");
+    // Floof
+    public string SanitizeMessageNumbersAsWords(string message)
+    {
+        if (string.IsNullOrEmpty(message))
+            return message;
+
+        return NumberRegex.Replace(message, match => ContentLocalizationManager.FormatNumberWords(match.Value));
     }
 
     public static string SanitizeAnnouncement(string message, int maxLength = 0, int maxNewlines = 2)

--- a/Content.Shared/Hands/EntitySystems/SharedHandsSystem.cs
+++ b/Content.Shared/Hands/EntitySystems/SharedHandsSystem.cs
@@ -6,6 +6,7 @@ using Content.Shared.Hands.Components;
 using Content.Shared.Interaction;
 using Content.Shared.Inventory;
 using Content.Shared.Inventory.VirtualItem;
+using Content.Shared.Movement.Pulling.Systems;
 using Content.Shared.Storage.EntitySystems;
 using Robust.Shared.Containers;
 using Robust.Shared.Input.Binding;
@@ -22,6 +23,7 @@ public abstract partial class SharedHandsSystem
     [Dependency] private readonly SharedStorageSystem _storage = default!;
     [Dependency] protected readonly SharedTransformSystem TransformSystem = default!;
     [Dependency] private readonly SharedVirtualItemSystem _virtualSystem = default!;
+    [Dependency] private readonly PullingSystem _pulling = default!; // Floof
 
     protected event Action<Entity<HandsComponent>?>? OnHandSetActive;
 

--- a/Content.Shared/Localizations/ContentLocalizationManager.cs
+++ b/Content.Shared/Localizations/ContentLocalizationManager.cs
@@ -232,9 +232,9 @@ namespace Content.Shared.Localizations
         }
 
         // Floof
-        private static readonly string[] OneToNineteen =
+        private static readonly string[] ZeroToNineteen =
         [
-            "one", "two", "three", "four", "five", "six", "seven", "eight", "nine",
+            "zero", "one", "two", "three", "four", "five", "six", "seven", "eight", "nine",
             "ten", "eleven", "twelve", "thirteen", "fourteen", "fifteen", "sixteen", "seventeen", "eighteen", "nineteen"
         ];
 
@@ -243,47 +243,84 @@ namespace Content.Shared.Localizations
             "twenty", "thirty", "forty", "fifty", "sixty", "seventy", "eighty", "ninety"
         ];
 
-        // adapted from https://stackoverflow.com/a/18493408
-        static string NumberToEnglishText(long n, bool isFirst = false)
+        // each is 10^x starting with x=3 and incrementing by 3
+        private static readonly string[] LargeNumberNames =
+        [
+            "thousand",
+            "million",
+            "billion",
+            "trillion",
+            "quadrillion",
+            "quintillion",
+            "sextillion",
+            "septillion",
+            "octillion",
+            "nonillion",
+            "decillion",
+            "undecillion",
+            "duodecillion",
+            "tredecillion",
+            "quattuordecillion",
+            "quindecillion",
+            "sexdecillion",
+            "septendecillion",
+            "octodecillion",
+            "novemdecillion",
+            "vigintillion"
+        ];
+
+        // HEAVILY adapted from https://stackoverflow.com/a/18493408
+        // rewritten entirely with string handling functions because BigInteger isn't allowed in sandbox...
+        private static string IntToEnglishText(string n, bool isFirst = false)
         {
+            n = n.TrimStart('0');
             string result;
-            if(isFirst && n == 0)
+            if(isFirst && n == "")
                 result = "zero";
-            else if(n < 0)
-                result = "negative " + NumberToEnglishText(-n);
-            else if(n == 0)
+            else if(n.StartsWith("-"))
+                result = "negative " + IntToEnglishText(n[1..]);
+            else if(n == "")
                 result = "";
-            else if(n <= 9)
-                result = OneToNineteen[n - 1] + " ";
-            else if(n <= 19)
-                result = OneToNineteen[n - 1] + (isFirst ? null : " ");
-            else if(n <= 99)
-                result = TwentyToNinety[n / 10 - 2] + (n % 10 > 0 ? "-" + NumberToEnglishText(n % 10) : null);
-            else if(n <= 999)
-                result = NumberToEnglishText(n / 100) + "hundred " + (n % 100 > 0 ? "and " + NumberToEnglishText(n % 100) : null);
-            else if(n <= 999999)
-                result = NumberToEnglishText(n / 1000) + "thousand " + NumberToEnglishText(n % 1000);
-            else if(n <= 999999999)
-                result = NumberToEnglishText(n / 1000000) + "million " + NumberToEnglishText(n % 1000000);
+            else if(n.Length == 1)
+                result = ZeroToNineteen[int.Parse(n)] + " ";
+            else if(n.Length == 2 && n.StartsWith('1'))
+                result = ZeroToNineteen[int.Parse(n)] + (isFirst ? null : " ");
+            else if(n.Length == 2)
+                result = TwentyToNinety[int.Parse(n) / 10 - 2] + (n[1] != '0' ? "-" + IntToEnglishText(n[1].ToString()) : null);
+            else if(n.Length == 3)
+                result = IntToEnglishText(n[0].ToString()) + "hundred " + (n[1..3] != "00" ? "and " + IntToEnglishText(n[1..3]) : null);
+            else if (n.Length <= 6 + 3 * LargeNumberNames.Length)
+            {
+                var divRem = Math.DivRem(n.Length, 3);
+                if (divRem.Remainder == 0)
+                {
+                    divRem.Remainder = 3;
+                    divRem.Quotient -= 1;
+                }
+                result = IntToEnglishText(n[..divRem.Remainder]) + LargeNumberNames[divRem.Quotient - 1] + ", " +
+                    IntToEnglishText(n[divRem.Remainder..]);
+            }
             else
-                result = NumberToEnglishText(n / 1000000000) + "billion " + NumberToEnglishText(n % 1000000000);
-            if(isFirst) {
+                result = n; // if it's bigger than 999 vigintillion, just fucking bail
+            if(isFirst)
                 result = result.Trim();
+            return result;
+        }
+
+        public static string FormatNumberWords(string number)
+        {
+            var parts = number.Split(".");
+            var result = IntToEnglishText(parts[0], true);
+            if (parts.TryGetValue(1, out var fractional))
+            {
+                result += " point";
+                foreach (var digit in fractional)
+                    result += " " + ZeroToNineteen[int.Parse(digit.ToString())];
             }
             return result;
         }
 
-        private static ILocValue FormatNumberWords(LocArgs args)
-        {
-            var count = ((LocValueNumber) args.Args[0]).Value;
-
-            var integral = (long) Math.Truncate(count);
-            var fractional = count - integral;
-
-            var result = NumberToEnglishText(integral, true);
-
-            // TODO: handle fractional part
-            return new LocValueString(result);
-        }
+        private static ILocValue FormatNumberWords(LocArgs args) =>
+            new LocValueString(FormatNumberWords(args.Args[0].Value!.ToString()!));
     }
 }

--- a/Content.Shared/Localizations/ContentLocalizationManager.cs
+++ b/Content.Shared/Localizations/ContentLocalizationManager.cs
@@ -47,6 +47,7 @@ namespace Content.Shared.Localizations
 
             _loc.AddFunction(cultureEn, "MAKEPLURAL", FormatMakePlural);
             _loc.AddFunction(cultureEn, "MANY", FormatMany);
+            _loc.AddFunction(cultureEn, "NUMBER-WORDS", FormatNumberWords); // Floof
         }
 
         private ILocValue FormatMany(LocArgs args)
@@ -228,6 +229,61 @@ namespace Content.Shared.Localizations
             );
 
             return new LocValueString(res);
+        }
+
+        // Floof
+        private static readonly string[] OneToNineteen =
+        [
+            "one", "two", "three", "four", "five", "six", "seven", "eight", "nine",
+            "ten", "eleven", "twelve", "thirteen", "fourteen", "fifteen", "sixteen", "seventeen", "eighteen", "nineteen"
+        ];
+
+        private static readonly string[] TwentyToNinety =
+        [
+            "twenty", "thirty", "forty", "fifty", "sixty", "seventy", "eighty", "ninety"
+        ];
+
+        // adapted from https://stackoverflow.com/a/18493408
+        static string NumberToEnglishText(long n, bool isFirst = false)
+        {
+            string result;
+            if(isFirst && n == 0)
+                result = "zero";
+            else if(n < 0)
+                result = "negative " + NumberToEnglishText(-n);
+            else if(n == 0)
+                result = "";
+            else if(n <= 9)
+                result = OneToNineteen[n - 1] + " ";
+            else if(n <= 19)
+                result = OneToNineteen[n - 1] + (isFirst ? null : " ");
+            else if(n <= 99)
+                result = TwentyToNinety[n / 10 - 2] + (n % 10 > 0 ? "-" + NumberToEnglishText(n % 10) : null);
+            else if(n <= 999)
+                result = NumberToEnglishText(n / 100) + "hundred " + (n % 100 > 0 ? "and " + NumberToEnglishText(n % 100) : null);
+            else if(n <= 999999)
+                result = NumberToEnglishText(n / 1000) + "thousand " + NumberToEnglishText(n % 1000);
+            else if(n <= 999999999)
+                result = NumberToEnglishText(n / 1000000) + "million " + NumberToEnglishText(n % 1000000);
+            else
+                result = NumberToEnglishText(n / 1000000000) + "billion " + NumberToEnglishText(n % 1000000000);
+            if(isFirst) {
+                result = result.Trim();
+            }
+            return result;
+        }
+
+        private static ILocValue FormatNumberWords(LocArgs args)
+        {
+            var count = ((LocValueNumber) args.Args[0]).Value;
+
+            var integral = (long) Math.Truncate(count);
+            var fractional = count - integral;
+
+            var result = NumberToEnglishText(integral, true);
+
+            // TODO: handle fractional part
+            return new LocValueString(result);
         }
     }
 }

--- a/Resources/Locale/en-US/hands/hands-system.ftl
+++ b/Resources/Locale/en-US/hands/hands-system.ftl
@@ -1,6 +1,17 @@
 # Examine text after when they're holding something (in-hand)
 comp-hands-examine = { CAPITALIZE(SUBJECT($user)) } { CONJUGATE-BE($user) } holding { $items }.
 comp-hands-examine-empty = { CAPITALIZE(SUBJECT($user)) } { CONJUGATE-BE($user) } not holding anything.
-comp-hands-examine-wrapper = { INDEFINITE($item) } [color=paleturquoise]{$item}[/color]
+
+# Floof
+comp-hands-examine-wrapper = { PROPER($item) ->
+    *[false] { INDEFINITE($item) } [color=paleturquoise]{$item}[/color]
+    [true] [color=paleturquoise]{$item}[/color]
+}
+
+comp-hands-examine-cuffed-all = { CAPITALIZE(POSS-ADJ($user)) } hands are cuffed.
+comp-hands-examine-cuffed-some = { CAPITALIZE(NUMBER-WORDS($number)) } of { POSS-ADJ($user) } hands are cuffed.
+
+comp-hands-examine-drag = { CAPITALIZE(SUBJECT($user)) } { CONJUGATE-BE($user) } dragging { $item }.
+# End Floof
 
 hands-system-blocked-by = Blocked by


### PR DESCRIPTION
# Description

contains a nasty hack but i checked and i'm pretty sure cuffs are the only thing that both shows a virtual item in your hand and is parented to you besides carrying shit?

---

# Media

<img width="480" height="227" alt="image" src="https://github.com/user-attachments/assets/041bd25a-1bfe-48ed-940a-5489e3de320f" />

---

# Changelog

:cl:
- add: People you're carrying will now show up in your examine popup.
- add: Literal numbers in speech are now translated to words.