### PR TITLE
Don't Serialize DeviceNetworkComponent.Configurators

### DIFF
--- a/Content.Server/DeviceNetwork/Components/DeviceNetworkComponent.cs
+++ b/Content.Server/DeviceNetwork/Components/DeviceNetworkComponent.cs
@@ -1,6 +1,7 @@
 using Content.Server.DeviceNetwork.Systems;
 using Content.Shared.DeviceNetwork;
 using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom.Prototype;
+using Robust.Shared.Serialization;
 
 namespace Content.Server.DeviceNetwork.Components
 {
@@ -112,7 +113,7 @@ namespace Content.Server.DeviceNetwork.Components
         /// <summary>
         ///     A list of configurators that this device is on.
         /// </summary>
-        [DataField]
+        [NonSerialized]
         [Access(typeof(NetworkConfiguratorSystem))]
         public HashSet<EntityUid> Configurators = new();
     }


### PR DESCRIPTION
# Description
Why, just why? This field stores all network configurators that are currently being used to link the owner entity to other elements of a device network. This field has no use between map resets, but SS14 will attempt to serialize it anyway, which will sometimes result in `configurators: [ invalid ]` because the network configurator entity has been deleted.

# Changelog
No cl