### PR TITLE
Cloning Issue

### DIFF
--- a/Resources/Prototypes/Research/experimental.yml
+++ b/Resources/Prototypes/Research/experimental.yml
@@ -167,6 +167,7 @@
     - CloningConsoleComputerCircuitboard
     - MedicalScannerMachineCircuitboard
     - MetempsychoticMachineCircuitboard
+    - CloningPodMachineCircuitboard
 
 - type: technology
   id: NightVisionTech


### PR DESCRIPTION
# Description

For whatever reason the default cloning pod which is supposed to be worse then the Metem was removed from researches. I don't know why, but I've heard several complaints that the Metem is worse then a RR and some stations start with it.

I don't know who did this or when, but the Metem is supposed to be an upgrade with a lower biomass usage that only works on psychics.

# Changelog

:cl:
- tweak: Tweaked cloning pod circuit back into research

