### PR TITLE
Fix Internals on Pets

### DIFF
--- a/Content.Server/Body/Systems/InternalsSystem.cs
+++ b/Content.Server/Body/Systems/InternalsSystem.cs
@@ -266,7 +266,9 @@ public sealed class InternalsSystem : EntitySystem
         // 3. in-hand tanks
         // 4. pocket/belt tanks
 
-        if (!Resolve(user, ref user.Comp1, ref user.Comp2, ref user.Comp3))
+        // Floofstation - do not require the entity to have hands
+        user.Comp1 ??= CompOrNull<HandsComponent>(user);
+        if (!Resolve(user, ref user.Comp2, ref user.Comp3))
             return null;
 
         if (_inventory.TryGetSlotEntity(user, "back", out var backEntity, user.Comp2, user.Comp3) &&
@@ -282,6 +284,10 @@ public sealed class InternalsSystem : EntitySystem
         {
             return (entity.Value, gasTank);
         }
+
+        // Floofstation - see above
+        if (user.Comp1 is null)
+            return null;
 
         foreach (var item in _inventory.GetHandOrInventoryEntities((user.Owner, user.Comp1, user.Comp2)))
         {


### PR DESCRIPTION
# Description
For some reason the internals system would always attempt to resolve the HandsComponent on the entity whose internals are being toggled, which would always fail on animals.

<img width="1271" height="709" alt="image" src="https://github.com/user-attachments/assets/69abeed8-0508-4df4-8759-89ff9f3c3c2b" />

<img width="1268" height="712" alt="image" src="https://github.com/user-attachments/assets/ba665404-a699-45ab-bdc3-b362f6450014" />


# Changelog
:cl:
- fix: Animals such as foxes should once again be able to wear internals.
