### PR TITLE
Halved Ratking Spawn Rate

### DIFF
--- a/Resources/Prototypes/GameRules/events.yml
+++ b/Resources/Prototypes/GameRules/events.yml
@@ -270,7 +270,7 @@
 #      prob: 0.001
     specialEntries:
     - id: SpawnPointGhostRatKing
-      prob: 0.001
+      prob: 0.0005
 
 - type: entity
   id: CockroachMigration


### PR DESCRIPTION
# Description

Halved Ratking Spawn Rate, due to it being PER VENT it resulted in bad luck rounds where there's like 4 rat kings in the ghost roles list.

# Changelog

:cl:
- tweak: Halved Ratking Spawn Rate
