### PR TITLE
Adds Welding Gas Mask to CE's Loadout

### DIFF
--- a/Resources/Prototypes/CharacterItemGroups/Jobs/Engineering/chiefEngineer.yml
+++ b/Resources/Prototypes/CharacterItemGroups/Jobs/Engineering/chiefEngineer.yml
@@ -113,10 +113,12 @@
     - type: loadout
       id: LoadoutEngineeringChiefEngineerNeckEngineerMedal
 
-#- type: characterItemGroup
-#  id: LoadoutChiefEngineerMask
-#  maxItems: 1
-#  items:
+- type: characterItemGroup
+  id: LoadoutChiefEngineerMask
+  maxItems: 1
+  items:
+    - type: loadout
+      id: LoadoutClothingMaskWeldingGas
 
 - type: characterItemGroup
   id: LoadoutChiefEngineerOuter

--- a/Resources/Prototypes/Loadouts/Jobs/Engineering/chiefEngineer.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Engineering/chiefEngineer.yml
@@ -482,6 +482,18 @@
     - ClothingNeckEngineermedal
 
 # Mask
+- type: loadout
+  id: LoadoutChiefEngineerMask
+  category: JobsEngineeringChiefEngineer
+  cost: 1
+  items:
+    - ClothingMaskWeldingGas
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: LoadoutChiefEngineerMask
+    - !type:CharacterJobRequirement
+      jobs:
+        - ChiefEngineer
 
 # Outer
 - type: loadout


### PR DESCRIPTION
<!--
This is a semi-strict format, you can add/remove sections as needed but the order/format should be kept the same
Remove these comments before submitting
-->

# Adds the Welding gas mask to the CE's Loadout 

<!--
Explain this PR in as much detail as applicable

Some example prompts to consider:
How might this affect the game? The codebase?
What might be some alternatives to this?
How/Who does this benefit/hurt [the game/codebase]?
-->

Adds a QOL of life item for some species in the role of CE (and drip)

Requested by Mutton!


- [ ] Task
- [x] Completed Task

---

<!--
This is default collapsed, readers click to expand it and see all your media
The PR media section can get very large at times, so this is a good way to keep it clean
The title is written using HTML tags
The title must be within the <summary> tags or you won't see it
-->

<details><summary><h1>Media</h1></summary>
<p>

<img width="2209" height="660" alt="arg" src="https://github.com/user-attachments/assets/2205694e-ba4f-4588-8e43-32a8494fba4a" />

</p>

</details>

---

# Changelog

<!--
You can add an author after the `:cl:` to change the name that appears in the changelog (ex: `:cl: Death`)
Leaving it blank will default to your GitHub display name
This includes all available types for the changelog
-->

:cl: Karlm4x
- add: Added Welding Gas Mask to CE's loadout options
