### PR TITLE
Made Station Pets Not See Red when Moffroach Exists Within a 1km Radius

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
@@ -579,7 +579,7 @@
   - type: CanEscapeInventory
   - type: NpcFactionMember
     factions:
-    - Mouse
+    - Critter
   - type: Body
     prototype: Mothroach
   - type: TypingIndicator
@@ -3487,6 +3487,9 @@
     bloodMaxVolume: 60
   - type: CanEscapeInventory
     baseResistTime: 3
+  - type: NpcFactionMember
+    factions:
+      - Critter
   - type: MobPrice
     price: 60
   - type: NonSpreaderZombie

--- a/Resources/Prototypes/Entities/Mobs/NPCs/space.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/space.yml
@@ -404,7 +404,7 @@
     size: Tiny
   - type: NpcFactionMember
     factions:
-      - Mouse
+      - Critter
   - type: HTN
     rootTask:
       task: MouseCompound

--- a/Resources/Prototypes/_Floof/Entities/Mobs/NPCs/pets.yml
+++ b/Resources/Prototypes/_Floof/Entities/Mobs/NPCs/pets.yml
@@ -50,6 +50,9 @@
     noMovementLayers:
       movement:
         state: midwife
+  - type: NpcFactionMember
+    factions:
+      - Mouse
   - type: DamageStateVisuals
     states:
       Alive:

--- a/Resources/Prototypes/_Floof/Entities/Mobs/NPCs/pets.yml
+++ b/Resources/Prototypes/_Floof/Entities/Mobs/NPCs/pets.yml
@@ -52,7 +52,7 @@
         state: midwife
   - type: NpcFactionMember
     factions:
-      - Mouse
+      - Critter
   - type: DamageStateVisuals
     states:
       Alive:

--- a/Resources/Prototypes/ai_factions.yml
+++ b/Resources/Prototypes/ai_factions.yml
@@ -31,9 +31,13 @@
   id: PetsNT
   hostile:
   - SimpleHostile
+  - Mouse
   - Zombie
   - Xeno
   - Gorilla # Floof
+
+- type: npcFaction
+  id: Critter
 
 - type: npcFaction
   id: SimpleHostile

--- a/Resources/Prototypes/ai_factions.yml
+++ b/Resources/Prototypes/ai_factions.yml
@@ -30,7 +30,6 @@
 - type: npcFaction
   id: PetsNT
   hostile:
-  - Mouse
   - SimpleHostile
   - Zombie
   - Xeno

--- a/Resources/Prototypes/ai_factions.yml
+++ b/Resources/Prototypes/ai_factions.yml
@@ -30,8 +30,8 @@
 - type: npcFaction
   id: PetsNT
   hostile:
-  - SimpleHostile
   - Mouse
+  - SimpleHostile
   - Zombie
   - Xeno
   - Gorilla # Floof


### PR DESCRIPTION
<!--
This is a semi-strict format, you can add/remove sections as needed but the order/format should be kept the same
Remove these comments before submitting
-->

# Description

<!--
Explain this PR in as much detail as applicable

Some example prompts to consider:
How might this affect the game? The codebase?
What might be some alternatives to this?
How/Who does this benefit/hurt [the game/codebase]?
-->

Modified faction settings so that station pets like Runtime no longer kill passive mobs on sight. Edit: After some feedback, Runtime still is the mouse hunter she always meant to be. Dream big kids

---

# TODO

<!--
A list of everything you have to do before this PR is "complete"
You probably won't have to complete everything before merging but it's good to leave future references
-->

- [x] Removed "mouse" faction from hostile list
- [x] Added "mouse" faction to pet spider 

---

# Changelog

<!--
You can add an author after the `:cl:` to change the name that appears in the changelog (ex: `:cl: Death`)
Leaving it blank will default to your GitHub display name
This includes all available types for the changelog
-->

:cl:
- tweak: Station Pets will no longer go Doomguy on small critters
