### PR TITLE
Adds a Obligatory Bodybag to Medicine Lockers

### DIFF
--- a/Resources/Prototypes/Catalog/Fills/Lockers/medical.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/medical.yml
@@ -15,6 +15,7 @@
       - id: Bloodpack
         amount: 2
       - id: Gauze
+      - id: BodyBagFolded
 
 - type: entity
   id: LockerWallMedicalFilled
@@ -34,6 +35,7 @@
       - id: Bloodpack
         amount: 2
       - id: Gauze
+      - id: BodyBagFolded
 
 
 - type: entity
@@ -192,6 +194,8 @@
         prob: 0.3
       - id: LunchboxMedicalFilledRandom # Delta-V Lunchboxes!
         prob: 0.3 
+      - id: BodyBagFolded
+        amount: 2
 
 - type: entity
   id: LockerParamedicFilledHardsuit #Delta V - Paramedic locker with suit
@@ -216,3 +220,5 @@
         prob: 0.3
       - id: LunchboxMedicalFilledRandom # Delta-V Lunchboxes!
         prob: 0.3 
+      - id: BodyBagFolded
+        amount: 2

--- a/Resources/Prototypes/Catalog/Fills/Lockers/medical.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/medical.yml
@@ -15,7 +15,7 @@
       - id: Bloodpack
         amount: 2
       - id: Gauze
-      - id: BodyBagFolded
+      - id: BodyBagFolded # Floofstation
 
 - type: entity
   id: LockerWallMedicalFilled
@@ -35,8 +35,7 @@
       - id: Bloodpack
         amount: 2
       - id: Gauze
-      - id: BodyBagFolded
-
+      - id: BodyBagFolded # Floofstation
 
 - type: entity
   id: LockerMedicalFilled
@@ -194,7 +193,7 @@
         prob: 0.3
       - id: LunchboxMedicalFilledRandom # Delta-V Lunchboxes!
         prob: 0.3 
-      - id: BodyBagFolded
+      - id: BodyBagFolded  # Floofstation
         amount: 2
 
 - type: entity
@@ -220,5 +219,5 @@
         prob: 0.3
       - id: LunchboxMedicalFilledRandom # Delta-V Lunchboxes!
         prob: 0.3 
-      - id: BodyBagFolded
+      - id: BodyBagFolded  # Floofstation
         amount: 2


### PR DESCRIPTION
# Description
Adds a obligatory bodybag to medicine lockers. Just good to have on hand, don't need a medfab to print, no need to pray for a bodybag box which is premapped.

# Changelog
:cl:
- add: Added +1 Body Bag to Medicine Lockers