### PR TITLE
Syndicate Uplink Buff

### DIFF
--- a/Content.IntegrationTests/Tests/StoreTests.cs
+++ b/Content.IntegrationTests/Tests/StoreTests.cs
@@ -79,11 +79,11 @@ public sealed class StoreTests
             var discountComponent = entManager.GetComponent<StoreDiscountComponent>(pda);
             Assert.That(
                 discountComponent.Discounts,
-                Has.Exactly(3).Items,
-                $"After applying discount total discounted items count was expected to be '3' "
+                Has.Exactly(5).Items,
+                $"After applying discount total discounted items count was expected to be '5' "
                 + $"but was actually {discountComponent.Discounts.Count}- this can be due to discount "
                 + $"categories settings (maxItems, weight) not being realistically set, or default "
-                + $"discounted count being changed from '3' in StoreDiscountSystem.InitializeDiscounts."
+                + $"discounted count being changed from '5' in StoreDiscountSystem.InitializeDiscounts."
             );
             var discountedListingItems = storeComponent.FullListingsCatalog
                                                        .Where(x => x.IsCostModified)

--- a/Content.Server/StoreDiscount/Systems/StoreDiscountSystem.cs
+++ b/Content.Server/StoreDiscount/Systems/StoreDiscountSystem.cs
@@ -71,7 +71,7 @@ public sealed class StoreDiscountSystem : EntitySystem
 
     private IReadOnlyList<StoreDiscountData> InitializeDiscounts(
         IReadOnlyCollection<ListingDataWithCostModifiers> listings,
-        int totalAvailableDiscounts = 3
+        int totalAvailableDiscounts = 5
     )
     {
         // Get list of categories with cumulative weights.

--- a/Resources/Locale/en-US/store/uplink-catalog.ftl
+++ b/Resources/Locale/en-US/store/uplink-catalog.ftl
@@ -139,8 +139,8 @@ uplink-stealth-box-desc = A box outfitted with stealth technology, sneak around 
 uplink-headset-name = Syndicate Over-ear Headset
 uplink-headset-desc = A headset that allows you to communicate with other syndicate operatives. Has 4 slots for encryption keys.
 
-uplink-encryption-key-name = Syndicate Encryption Keys
-uplink-encryption-key-desc = Two encryption keys for access to the secret frequency of our special agents. Give the spare to a friend, but make sure it doesn't fall into enemy hands.
+uplink-encryption-key-name = Syndicate Encryption Key
+uplink-encryption-key-desc = An encryption key for access to the secret frequency of our special agents. Make sure it doesn't fall into enemy hands.
 
 uplink-binary-translator-key-name = Binary Translator Key
 uplink-binary-translator-key-desc = Lets you tap into the silicons' binary channel. Don't talk on it though, at least not without a voice mask.

--- a/Resources/Prototypes/Catalog/uplink_catalog.yml
+++ b/Resources/Prototypes/Catalog/uplink_catalog.yml
@@ -8,7 +8,7 @@
   productEntity: WeaponPistolViper
   discountCategory: rareDiscounts
   discountDownTo:
-    Telecrystal: 2
+    Telecrystal: 1
   cost:
     Telecrystal: 3
   categories:
@@ -21,9 +21,9 @@
   productEntity: WeaponRevolverPythonAP
   discountCategory: usualDiscounts
   discountDownTo:
-    Telecrystal: 4
+    Telecrystal: 1
   cost:
-    Telecrystal: 8 # Originally was 13 TC but was not used due to high cost
+    Telecrystal: 5 # Originally was 13 TC but was not used due to high cost
   categories:
   - UplinkWeaponry
 
@@ -35,9 +35,9 @@
   productEntity: WeaponPistolCobra
   discountCategory: rareDiscounts
   discountDownTo:
-    Telecrystal: 2
+    Telecrystal: 1
   cost:
-    Telecrystal: 4
+    Telecrystal: 3
   categories:
   - UplinkWeaponry
 
@@ -47,6 +47,9 @@
   name: uplink-rifle-mosin-name
   description: uplink-rifle-mosin-desc
   productEntity: WeaponSniperMosin
+  discountCategory: rareDiscounts
+  discountDownTo:
+    Telecrystal: 0
   cost:
     Telecrystal: 1
   categories:
@@ -59,7 +62,7 @@
   icon: { sprite: /Textures/Objects/Weapons/Melee/e_sword.rsi, state: icon }
   discountCategory: veryRareDiscounts
   discountDownTo:
-    Telecrystal: 4
+    Telecrystal: 2
   productEntity: EnergySword
   cost:
     Telecrystal: 8
@@ -88,9 +91,9 @@
   productEntity: ThrowingKnivesKit
   discountCategory: rareDiscounts
   discountDownTo:
-    Telecrystal: 3
+    Telecrystal: 2
   cost:
-    Telecrystal: 6
+    Telecrystal: 5
   categories:
     - UplinkWeaponry
 
@@ -102,7 +105,7 @@
   productEntity: ClothingHandsGlovesNorthStar
   discountCategory: veryRareDiscounts
   discountDownTo:
-    Telecrystal: 4
+    Telecrystal: 2
   cost:
     Telecrystal: 8
   categories:
@@ -115,7 +118,7 @@
   productEntity: ToolboxElectricalTurretFilled
   discountCategory: usualDiscounts
   discountDownTo:
-    Telecrystal: 3
+    Telecrystal: 2
   cost:
     Telecrystal: 6
   categories:
@@ -153,9 +156,9 @@
   productEntity: BriefcaseSyndieSniperBundleFilled
   discountCategory: usualDiscounts
   discountDownTo:
-    Telecrystal: 6
+    Telecrystal: 2
   cost:
-    Telecrystal: 12
+    Telecrystal: 8
   categories:
   - UplinkWeaponry
   
@@ -167,9 +170,9 @@
   productEntity: ClothingBackpackDuffelSyndicateFilledSMG
   discountCategory: veryRareDiscounts
   discountDownTo:
-    Telecrystal: 10
+    Telecrystal: 8
   cost:
-    Telecrystal: 17
+    Telecrystal: 16
   categories:
   - UplinkWeaponry
 
@@ -181,9 +184,9 @@
   productEntity: ClothingBackpackDuffelSyndicateFilledShotgun
   discountCategory: veryRareDiscounts
   discountDownTo:
-    Telecrystal: 12
+    Telecrystal: 8
   cost:
-    Telecrystal: 20
+    Telecrystal: 18
   categories:
   - UplinkWeaponry
 
@@ -195,9 +198,9 @@
   productEntity: ClothingBackpackDuffelSyndicateFilledGrenadeLauncher
   discountCategory: veryRareDiscounts
   discountDownTo:
-    Telecrystal: 20
+    Telecrystal: 18
   cost:
-    Telecrystal: 25
+    Telecrystal: 24
   categories:
   - UplinkWeaponry
 
@@ -209,7 +212,7 @@
   productEntity: ClothingBackpackDuffelSyndicateFilledLMG
   discountCategory: veryRareDiscounts
   discountDownTo:
-    Telecrystal: 24
+    Telecrystal: 20
   cost:
     Telecrystal: 30
   categories:
@@ -257,7 +260,7 @@
   productEntity: SyndieMiniBomb
   discountCategory: veryRareDiscounts
   discountDownTo:
-    Telecrystal: 3
+    Telecrystal: 2
   cost:
     Telecrystal: 6
   categories:
@@ -270,7 +273,7 @@
   productEntity: SupermatterGrenade
   discountCategory: usualDiscounts
   discountDownTo:
-    Telecrystal: 3
+    Telecrystal: 2
   cost:
     Telecrystal: 6
   categories:
@@ -327,9 +330,9 @@
   productEntity: ClothingBeltMilitaryWebbingGrenadeFilled
   discountCategory: veryRareDiscounts
   discountDownTo:
-    Telecrystal: 6
+    Telecrystal: 4
   cost:
-    Telecrystal: 12
+    Telecrystal: 10
   categories:
   - UplinkExplosives
   conditions:
@@ -345,9 +348,9 @@
   productEntity: ClothingBackpackDuffelSyndicateC4tBundle
   discountCategory: veryRareDiscounts
   discountDownTo:
-    Telecrystal: 8
+    Telecrystal: 4
   cost:
-    Telecrystal: 12 #you're buying bulk so its a 25% discount, so no additional random discount over it
+    Telecrystal: 10 #you're buying bulk so its a 25% discount, so no additional random discount over it
   categories:
   - UplinkExplosives
 
@@ -360,7 +363,7 @@
   discountDownTo:
     Telecrystal: 1
   cost:
-    Telecrystal: 5 #floof change
+    Telecrystal: 4 #floof change
   categories:
   - UplinkExplosives
 
@@ -372,7 +375,7 @@
   productEntity: PenExplodingBox
   discountCategory: usualDiscounts
   discountDownTo:
-    Telecrystal: 2
+    Telecrystal: 1
   cost:
     Telecrystal: 4
   categories:
@@ -418,7 +421,7 @@
   productEntity: ClusterGrenade
   discountCategory: usualDiscounts
   discountDownTo:
-    Telecrystal: 5
+    Telecrystal: 4
   cost:
     Telecrystal: 8
   categories:
@@ -540,7 +543,7 @@
   description: uplink-ammo-bundle-desc
   productEntity: ClothingBackpackDuffelSyndicateAmmoFilled
   cost:
-    Telecrystal: 15
+    Telecrystal: 12
   categories:
   - UplinkAmmo
   conditions:
@@ -563,7 +566,7 @@
   productEntity: HypopenBox
   discountCategory: rareDiscounts
   discountDownTo:
-    Telecrystal: 4
+    Telecrystal: 3
   cost:
     Telecrystal: 6
   categories:
@@ -591,9 +594,9 @@
   productEntity: ChemicalSynthesisKit
   discountCategory: usualDiscounts
   discountDownTo:
-    Telecrystal: 3
+    Telecrystal: 1
   cost:
-    Telecrystal: 4
+    Telecrystal: 3
   categories:
   - UplinkChemicals
 
@@ -625,9 +628,9 @@
   productEntity: NocturineChemistryBottle
   discountCategory: usualDiscounts
   discountDownTo:
-    Telecrystal: 3
+    Telecrystal: 2
   cost:
-    Telecrystal: 6
+    Telecrystal: 5
   categories:
   - UplinkChemicals
 
@@ -640,7 +643,7 @@
   discountDownTo:
     Telecrystal: 2
   cost:
-    Telecrystal: 5
+    Telecrystal: 4
   categories:
   - UplinkChemicals
 
@@ -677,9 +680,9 @@
   productEntity: StimkitFilled
   discountCategory: rareDiscounts
   discountDownTo:
-    Telecrystal: 8
+    Telecrystal: 5
   cost:
-    Telecrystal: 12
+    Telecrystal: 10
   categories:
   - UplinkChemicals
 
@@ -690,9 +693,9 @@
   productEntity: CigPackSyndicate
   discountCategory: rareDiscounts
   discountDownTo:
-    Telecrystal: 1
+    Telecrystal: 0
   cost:
-    Telecrystal: 2
+    Telecrystal: 1
   categories:
   - UplinkPointless
 
@@ -729,7 +732,7 @@
   discountDownTo:
     Telecrystal: 1
   cost:
-    Telecrystal: 3
+    Telecrystal: 2
   categories:
   - UplinkDeception
 
@@ -742,7 +745,7 @@
   discountDownTo:
     Telecrystal: 2
   cost:
-    Telecrystal: 5
+    Telecrystal: 4
   categories:
   - UplinkDeception
 
@@ -753,9 +756,9 @@
   productEntity: ChameleonProjector
   discountCategory: rareDiscounts
   discountDownTo:
-    Telecrystal: 4
+    Telecrystal: 2
   cost:
-    Telecrystal: 7
+    Telecrystal: 4
   categories:
   - UplinkDeception
 
@@ -765,13 +768,11 @@
   description: uplink-encryption-key-desc
   icon: { sprite: /Textures/Objects/Devices/encryption_keys.rsi, state: synd_label }
   productEntity: BoxEncryptionKeySyndie # Two for the price of one
-  discountCategory: usualDiscounts
-  discountDownTo:
-    Telecrystal: 1
   cost:
-    Telecrystal: 2
+    Telecrystal: 0
   categories:
   - UplinkDeception
+  saleLimit: 1
 
 - type: listing
   id: UplinkCyberpen
@@ -798,11 +799,8 @@
   name: uplink-ultrabright-lantern-name
   description: uplink-ultrabright-lantern-desc
   productEntity: LanternFlash
-  discountCategory: usualDiscounts
-  discountDownTo:
-    Telecrystal: 1
   cost:
-    Telecrystal: 2
+    Telecrystal: 1
   categories:
   - UplinkDeception
 
@@ -813,9 +811,9 @@
   productEntity: BriefcaseSyndieLobbyingBundleFilled
   discountCategory: usualDiscounts
   discountDownTo:
-    Telecrystal: 2
+    Telecrystal: 1
   cost:
-    Telecrystal: 4
+    Telecrystal: 3
   categories:
     - UplinkDeception
 
@@ -835,9 +833,6 @@
   description: uplink-decoy-kit-desc
   icon: { sprite: /Textures/Objects/Tools/Decoys/operative_decoy.rsi, state: folded }
   productEntity: ClothingBackpackDuffelSyndicateDecoyKitFilled
-  discountCategory: usualDiscounts
-  discountDownTo:
-    Telecrystal: 3
   cost:
     Telecrystal: 1
   categories:
@@ -852,7 +847,7 @@
   discountDownTo:
     Telecrystal: 1
   cost:
-    Telecrystal: 4
+    Telecrystal: 3
   categories:
   - UplinkDeception
 
@@ -865,7 +860,7 @@
   productEntity: Emag
   discountCategory: veryRareDiscounts
   discountDownTo:
-    Telecrystal: 5
+    Telecrystal: 4
   cost:
     Telecrystal: 8
   categories:
@@ -891,9 +886,9 @@
   productEntity: BorgModuleSyndicateWeapon
   discountCategory: usualDiscounts
   discountDownTo:
-    Telecrystal: 3
+    Telecrystal: 2
   cost:
-    Telecrystal: 5
+    Telecrystal: 4
   categories:
   - UplinkDisruption
 
@@ -941,9 +936,9 @@
   productEntity: ToolboxSyndicateFilled
   discountCategory: rareDiscounts
   discountDownTo:
-    Telecrystal: 1
+    Telecrystal: 0
   cost:
-    Telecrystal: 2
+    Telecrystal: 1
   categories:
   - UplinkDisruption
 
@@ -967,9 +962,9 @@
   productEntity: ClothingBackpackDuffelSyndicateFilledMedical
   discountCategory: usualDiscounts
   discountDownTo:
-    Telecrystal: 2
+    Telecrystal: 1
   cost:
-    Telecrystal: 4
+    Telecrystal: 2
   categories:
   - UplinkDisruption
 
@@ -980,9 +975,9 @@
   productEntity: PowerSink
   discountCategory: usualDiscounts
   discountDownTo:
-    Telecrystal: 4
+    Telecrystal: 2
   cost:
-    Telecrystal: 8
+    Telecrystal: 6
   categories:
   - UplinkDisruption
   conditions:
@@ -996,6 +991,9 @@
   name: uplink-super-surplus-bundle-name
   description: uplink-super-surplus-bundle-desc
   productEntity: CrateSyndicateSuperSurplusBundle
+  discountCategory: usualDiscounts
+  discountDownTo:
+    Telecrystal: 20
   cost:
     Telecrystal: 40
   categories:
@@ -1019,9 +1017,9 @@
   productEntity: BoxHoloparasite
   discountCategory: usualDiscounts
   discountDownTo:
-    Telecrystal: 8
+    Telecrystal: 6
   cost:
-    Telecrystal: 14
+    Telecrystal: 12
   categories:
   - UplinkAllies
   conditions:
@@ -1038,9 +1036,9 @@
   icon: { sprite: Objects/Devices/communication.rsi, state: old-radio-urist }
   discountCategory: usualDiscounts
   discountDownTo:
-    Telecrystal: 7
+    Telecrystal: 6
   cost:
-    Telecrystal: 16
+    Telecrystal: 12
   categories:
   - UplinkAllies
   conditions:
@@ -1071,15 +1069,13 @@
   description: uplink-reinforcement-radio-cyborg-assault-desc
   productEntity: ReinforcementRadioSyndicateCyborgAssault
   icon: { sprite: Objects/Devices/communication.rsi, state: old-radio-borg-assault }
+  discountCategory: usualDiscounts
+  discountDownTo:
+    Telecrystal: 10
   cost:
-    Telecrystal: 65
+    Telecrystal: 40
   categories:
     - UplinkAllies
-  conditions:
-    - !type:StoreWhitelistCondition
-      whitelist:
-        tags:
-          - NukeOpsUplink
 
 - type: listing
   id: UplinkReinforcementRadioSyndicateAncestor
@@ -1156,7 +1152,7 @@
   productEntity: StorageImplanter
   discountCategory: rareDiscounts
   discountDownTo:
-    Telecrystal: 4
+    Telecrystal: 2
   cost:
     Telecrystal: 8
   categories:
@@ -1175,9 +1171,9 @@
   productEntity: FreedomImplanter
   discountCategory: veryRareDiscounts
   discountDownTo:
-    Telecrystal: 3
+    Telecrystal: 2
   cost:
-    Telecrystal: 5
+    Telecrystal: 4
   categories:
     - UplinkImplants
 
@@ -1205,7 +1201,7 @@
   discountDownTo:
     Telecrystal: 2
   cost:
-    Telecrystal: 5
+    Telecrystal: 4
   categories:
     - UplinkImplants
 
@@ -1237,7 +1233,7 @@
   discountDownTo:
     Telecrystal: 1
   cost:
-    Telecrystal: 7 #Floof change
+    Telecrystal: 6 #Floof change
   categories:
     - UplinkImplants
 
@@ -1268,7 +1264,7 @@
   icon: { sprite: /Textures/Actions/Implants/implants.rsi, state: explosive }
   productEntity: MacroBombImplanter
   cost:
-    Telecrystal: 13
+    Telecrystal: 12
   categories:
     - UplinkImplants
   conditions:
@@ -1305,9 +1301,9 @@
   productEntity: UplinkImplanter
   discountCategory: usualDiscounts
   discountDownTo:
-    Telecrystal: 1
+    Telecrystal: 0
   cost:
-    Telecrystal: 2
+    Telecrystal: 1
   categories:
   - UplinkImplants
   conditions:
@@ -1359,7 +1355,7 @@
   discountDownTo:
     Telecrystal: 1
   cost:
-    Telecrystal: 6
+    Telecrystal: 3
   categories:
   - UplinkWearables
 
@@ -1418,18 +1414,18 @@
   categories:
   - UplinkWearables
 
-- type: listing
-  id: UplinkClothingShoesBootsMagSyndie
-  name: uplink-clothing-shoes-boots-mag-syndie-name
-  description: uplink-clothing-shoes-boots-mag-syndie-desc
-  productEntity: ClothingShoesBootsMagSyndie
-  discountCategory: usualDiscounts
-  discountDownTo:
-    Telecrystal: 2
-  cost:
-    Telecrystal: 4
-  categories:
-  - UplinkWearables
+#- type: listing # Just not working at the moment
+#  id: UplinkClothingShoesBootsMagSyndie
+#  name: uplink-clothing-shoes-boots-mag-syndie-name
+#  description: uplink-clothing-shoes-boots-mag-syndie-desc
+#  productEntity: ClothingShoesBootsMagSyndie
+#  discountCategory: usualDiscounts
+#  discountDownTo:
+#    Telecrystal: 2
+#  cost:
+#    Telecrystal: 4
+#  categories:
+#  - UplinkWearables
 
 - type: listing
   id: UplinkEVASyndie
@@ -1439,9 +1435,9 @@
   productEntity: ClothingBackpackDuffelSyndicateEVABundle
   discountCategory: rareDiscounts
   discountDownTo:
-    Telecrystal: 1
+    Telecrystal: 0
   cost:
-    Telecrystal: 2
+    Telecrystal: 1
   categories:
   - UplinkWearables
 
@@ -1467,9 +1463,9 @@
   productEntity: ClothingBackpackDuffelSyndicateHardsuitBundle
   discountCategory: veryRareDiscounts
   discountDownTo:
-    Telecrystal: 4
+    Telecrystal: 2
   cost:
-    Telecrystal: 10
+    Telecrystal: 8
   categories:
   - UplinkWearables
 
@@ -1479,7 +1475,7 @@
   description: uplink-clothing-conducting-gloves-desc
   productEntity: ClothingHandsGlovesConducting
   cost:
-    Telecrystal: 2
+    Telecrystal: 1
   categories:
   - UplinkWearables
   conditions:
@@ -1500,9 +1496,9 @@
   productEntity: ClothingBackpackDuffelSyndicateEliteHardsuitBundle
   discountCategory: rareDiscounts
   discountDownTo:
-    Telecrystal: 5 # Floof - M3739 - FinancialCrisis - Was originally 7.
+    Telecrystal: 4 # Floof - M3739 - FinancialCrisis - Was originally 7.
   cost:
-    Telecrystal: 11 # Floof - M3739 - FinancialCrisis - Was originally 1. Even Cybersun Industries suffers from "minor inconveniences."
+    Telecrystal: 10 # Floof - M3739 - FinancialCrisis - Was originally 1. Even Cybersun Industries suffers from "minor inconveniences."
   categories:
   - UplinkWearables
 
@@ -1514,7 +1510,7 @@
   productEntity: CrateCybersunJuggernautBundle
   discountCategory: veryRareDiscounts
   discountDownTo:
-    Telecrystal: 8
+    Telecrystal: 5
   cost:
     Telecrystal: 12
   categories:
@@ -1526,7 +1522,7 @@
   description: uplink-clothing-eyes-hud-syndicate-desc
   productEntity: ClothingEyesHudSyndicate
   cost:
-    Telecrystal: 2
+    Telecrystal: 1
   categories:
     - UplinkWearables
   conditions:
@@ -1620,9 +1616,9 @@
   productEntity: GatfruitSeeds
   discountCategory: usualDiscounts
   discountDownTo:
-    Telecrystal: 3
+    Telecrystal: 1
   cost:
-    Telecrystal: 6
+    Telecrystal: 3
   categories:
   - UplinkJob
   conditions:
@@ -1637,9 +1633,9 @@
   productEntity: ClothingHandsGlovesBoxingRigged
   discountCategory: usualDiscounts
   discountDownTo:
-    Telecrystal: 3
+    Telecrystal: 1
   cost:
-    Telecrystal: 6
+    Telecrystal: 3
   categories:
     - UplinkJob
   conditions:
@@ -1692,7 +1688,7 @@
   productEntity: HolyHandGrenade
   discountCategory: rareDiscounts
   discountDownTo:
-    Telecrystal: 14
+    Telecrystal: 10
   cost:
     Telecrystal: 20
   categories:
@@ -1709,9 +1705,9 @@
   productEntity: RevolverCapGunFake
   discountCategory: usualDiscounts
   discountDownTo:
-    Telecrystal: 5
+    Telecrystal: 4
   cost:
-    Telecrystal: 9
+    Telecrystal: 8
   categories:
   - UplinkJob
   conditions:
@@ -1763,9 +1759,9 @@
   productEntity: BoxHoloclown
   discountCategory: rareDiscounts
   discountDownTo:
-    Telecrystal: 6
+    Telecrystal: 4
   cost:
-    Telecrystal: 12
+    Telecrystal: 10
   categories:
   - UplinkJob
   conditions:
@@ -1863,7 +1859,7 @@
   discountDownTo:
     Telecrystal: 2
   cost:
-    Telecrystal: 5
+    Telecrystal: 4
   categories:
   - UplinkJob
   conditions:
@@ -1874,6 +1870,7 @@
     blacklist:
       components:
       - SurplusBundle
+      
 #- type: listing
 #  id: UplinkSingarityBeacon
 #  name: uplink-singularity-beacon-name
@@ -1945,7 +1942,7 @@
   description: uplink-backpack-syndicate-desc
   productEntity: ClothingBackpackSyndicate
   cost:
-    Telecrystal: 2
+    Telecrystal: 1
   categories:
     - UplinkPointless
 
@@ -1967,7 +1964,7 @@
   description: uplink-revolver-cap-gun-desc
   productEntity: RevolverCapGun
   cost:
-    Telecrystal: 4
+    Telecrystal: 1
   categories:
   - UplinkPointless
 
@@ -1977,7 +1974,7 @@
   description: uplink-syndicate-stamp-desc
   productEntity: RubberStampSyndicate
   cost:
-    Telecrystal: 2
+    Telecrystal: 1
   categories:
   - UplinkPointless
 
@@ -2017,7 +2014,7 @@
   description: uplink-costume-pyjama-desc
   productEntity: ClothingBackpackDuffelSyndicatePyjamaBundle
   cost:
-    Telecrystal: 4
+    Telecrystal: 2
   categories:
   - UplinkPointless
 
@@ -2027,7 +2024,7 @@
   description: uplink-costume-clown-desc
   productEntity: ClothingBackpackDuffelSyndicateCostumeClown
   cost:
-    Telecrystal: 2
+    Telecrystal: 1
   categories:
   - UplinkPointless
 
@@ -2067,7 +2064,7 @@
   description: uplink-balloon-desc
   productEntity: BalloonSyn
   cost:
-    Telecrystal: 20
+    Telecrystal: 1
   categories:
   - UplinkPointless
 

--- a/Resources/Prototypes/Catalog/uplink_catalog.yml
+++ b/Resources/Prototypes/Catalog/uplink_catalog.yml
@@ -772,6 +772,7 @@
     Telecrystal: 0
   categories:
   - UplinkDeception
+  conditions:
   - !type:ListingLimitedStockCondition
     stock: 1
 

--- a/Resources/Prototypes/Catalog/uplink_catalog.yml
+++ b/Resources/Prototypes/Catalog/uplink_catalog.yml
@@ -767,12 +767,13 @@
   name: uplink-encryption-key-name
   description: uplink-encryption-key-desc
   icon: { sprite: /Textures/Objects/Devices/encryption_keys.rsi, state: synd_label }
-  productEntity: BoxEncryptionKeySyndie # Two for the price of one
+  productEntity: EncryptionKeySyndie
   cost:
     Telecrystal: 0
   categories:
   - UplinkDeception
-  saleLimit: 1
+  - !type:ListingLimitedStockCondition
+    stock: 1
 
 - type: listing
   id: UplinkCyberpen

--- a/Resources/Prototypes/EstacaoPirata/Catalog/uplink_catalog.yml
+++ b/Resources/Prototypes/EstacaoPirata/Catalog/uplink_catalog.yml
@@ -4,6 +4,6 @@
   description: uplink-syndicate-deck-desc
   productEntity: CardBoxSyndicate
   cost:
-    Telecrystal: 4 # Frontier: 1<4 (less spam please)
+    Telecrystal: 1 # Frontier: 1<4 (less spam please)
   categories:
   - UplinkPointless

--- a/Resources/Prototypes/_Floof/Catalog/uplink_catalog.yml
+++ b/Resources/Prototypes/_Floof/Catalog/uplink_catalog.yml
@@ -18,6 +18,9 @@
   description: uplink-EnergySabre-desc
   icon: { sprite: /Textures/_Floof/Objects/Weapons/Melee/e_sabre.rsi, state: icon }
   productEntity: ClothingBeltEnergySheathFilled
+  discountCategory: usualDiscounts
+  discountDownTo:
+    Telecrystal: 2
   cost:
     Telecrystal: 8
   categories:
@@ -30,8 +33,11 @@
   description: uplink-energy-halberd-desc
   icon: { sprite: _Floof/Objects/Weapons/Melee/e_halberd.rsi, state: icon }
   productEntity: WeaponEnergyHalberd
+  discountCategory: usualDiscounts
+  discountDownTo:
+    Telecrystal: 4
   cost:
-    Telecrystal: 10
+    Telecrystal: 8
   categories:
   - UplinkWeaponry
 #  saleLimit: 1 # Floofstation - used to exist, but now it doesn't. Oh, well.
@@ -57,7 +63,7 @@
   productEntity: BriefcaseSyndieTypewriterBundleFilled
   discountCategory: usualDiscounts
   discountDownTo:
-    Telecrystal: 8
+    Telecrystal: 6
   cost:
     Telecrystal: 12
   categories:


### PR DESCRIPTION
# Description

Under the request of the Head Committee, Syndicate Uplink items have been made cheaper.
Please discuss if needs be but remember this is supposed to be a huge buff to Traitors, balance if over tuned.

# Changelog
:cl:
- tweak: Several syndicate items now cost less TC.