### PR TITLE
Minor QoL Patch

### DIFF
--- a/Resources/Prototypes/Catalog/Cargo/cargo_atmospherics.yml
+++ b/Resources/Prototypes/Catalog/Cargo/cargo_atmospherics.yml
@@ -78,17 +78,17 @@
   category: cargoproduct-category-name-atmospherics
   group: market
 
-#- type: cargoProduct
-#  name: "water vapor canister"
-#  id: AtmosphericsWaterVapor
-#  description: "Water vapor canister"
-#  icon:
-#    sprite: Structures/Storage/canister.rsi
-#    state: water_vapor
-#  product: WaterVaporCanister
-#  cost: 2600
-#  category: cargoproduct-category-name-atmospherics
-#  group: market
+- type: cargoProduct
+  name: "water vapor canister"
+  id: AtmosphericsWaterVapor
+  description: "Water vapor canister"
+  icon:
+    sprite: Structures/Storage/canister.rsi
+    state: water_vapor
+  product: WaterVaporCanister
+  cost: 2600
+  category: cargoproduct-category-name-atmospherics
+  group: market
 
 - type: cargoProduct
   id: AtmosphericsPlasma

--- a/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
@@ -858,7 +858,7 @@
   - type: Butcherable
     spawned:
     - id: FoodMeat
-      amount: 5
+      amount: 8
   - type: Grammar
     attributes:
       gender: female # Here because of UdderComponent
@@ -3564,7 +3564,7 @@
         Base: dead
   - type: Butcherable
     spawned:
-    - id: FoodMeat
+    - id: FoodMeatBacon
       amount: 6
   - type: Grammar
     attributes:

--- a/Resources/Prototypes/Entities/Objects/Specific/rehydrateable.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/rehydrateable.yml
@@ -66,6 +66,24 @@
   - type: Rehydratable
     possibleSpawns:
     - MobCow
+    
+- type: entity # Floofstation
+  parent: MonkeyCube
+  id: PigCube
+  name: pig cube
+  components:
+  - type: Rehydratable
+    possibleSpawns:
+    - MobPig
+
+- type: entity # Floofstation
+  parent: MonkeyCube
+  id: ChickenCube
+  name: chicken cube
+  components:
+  - type: Rehydratable
+    possibleSpawns:
+    - MobChicken
 
 - type: entity
   parent: MonkeyCube

--- a/Resources/Prototypes/Entities/Objects/Specific/rehydrateable.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/rehydrateable.yml
@@ -67,24 +67,6 @@
     possibleSpawns:
     - MobCow
     
-- type: entity # Floofstation
-  parent: MonkeyCube
-  id: PigCube
-  name: pig cube
-  components:
-  - type: Rehydratable
-    possibleSpawns:
-    - MobPig
-
-- type: entity # Floofstation
-  parent: MonkeyCube
-  id: ChickenCube
-  name: chicken cube
-  components:
-  - type: Rehydratable
-    possibleSpawns:
-    - MobChicken
-
 - type: entity
   parent: MonkeyCube
   id: GoatCube

--- a/Resources/Prototypes/Entities/Objects/Specific/rehydrateable.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/rehydrateable.yml
@@ -66,7 +66,7 @@
   - type: Rehydratable
     possibleSpawns:
     - MobCow
-    
+
 - type: entity
   parent: MonkeyCube
   id: GoatCube

--- a/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
@@ -769,6 +769,8 @@
     - MothroachCube
     - MouseCube
     - CockroachCube
+    - PigCube # Floofstation
+    - ChickenCube # Floofstation
   - type: EmagLatheRecipes
     emagStaticRecipes:
     - AbominationCube

--- a/Resources/Prototypes/Recipes/Lathes/rehydrateable.yml
+++ b/Resources/Prototypes/Recipes/Lathes/rehydrateable.yml
@@ -21,20 +21,6 @@
   materials:
     Biomass: 120
 
-- type: latheRecipe # Floofstation
-  id: PigCube
-  result: PigCube
-  completetime: 30
-  materials:
-    Biomass: 80
-
-- type: latheRecipe # Floofstation
-  id: ChickenCube
-  result: ChickenCube
-  completetime: 15
-  materials:
-    Biomass: 12
-
 - type: latheRecipe
   id: GoatCube
   result: GoatCube

--- a/Resources/Prototypes/Recipes/Lathes/rehydrateable.yml
+++ b/Resources/Prototypes/Recipes/Lathes/rehydrateable.yml
@@ -21,6 +21,20 @@
   materials:
     Biomass: 120
 
+- type: latheRecipe # Floofstation
+  id: PigCube
+  result: PigCube
+  completetime: 30
+  materials:
+    Biomass: 80
+
+- type: latheRecipe # Floofstation
+  id: ChickenCube
+  result: ChickenCube
+  completetime: 15
+  materials:
+    Biomass: 12
+
 - type: latheRecipe
   id: GoatCube
   result: GoatCube
@@ -47,7 +61,7 @@
   result: CockroachCube
   completetime: 15
   materials:
-    Biomass: 16
+    Biomass: 10
 
 - type: latheRecipe
   id: SpaceCarpCube

--- a/Resources/Prototypes/Recipes/Lathes/tools.yml
+++ b/Resources/Prototypes/Recipes/Lathes/tools.yml
@@ -42,7 +42,7 @@
   id: CableStack
   result: CableApcStack1
   category: Parts
-  completetime: 2
+  completetime: 0
   materials:
     Steel: 30
 
@@ -50,7 +50,7 @@
   id: CableMVStack
   result: CableMVStack1
   category: Parts
-  completetime: 2
+  completetime: 0
   materials:
     Steel: 30
 
@@ -58,7 +58,7 @@
   id: CableHVStack
   result: CableHVStack1
   category: Parts
-  completetime: 2
+  completetime: 0
   materials:
     Steel: 30
 

--- a/Resources/Prototypes/Recipes/Lathes/tools.yml
+++ b/Resources/Prototypes/Recipes/Lathes/tools.yml
@@ -42,7 +42,7 @@
   id: CableStack
   result: CableApcStack1
   category: Parts
-  completetime: 0
+  completetime: 0.2
   materials:
     Steel: 30
 
@@ -50,7 +50,7 @@
   id: CableMVStack
   result: CableMVStack1
   category: Parts
-  completetime: 0
+  completetime: 0.2
   materials:
     Steel: 30
 
@@ -58,7 +58,7 @@
   id: CableHVStack
   result: CableHVStack1
   category: Parts
-  completetime: 0
+  completetime: 0.2
   materials:
     Steel: 30
 

--- a/Resources/Prototypes/_Floof/Entities/Objects/Specific/Rehydrateable.yml
+++ b/Resources/Prototypes/_Floof/Entities/Objects/Specific/Rehydrateable.yml
@@ -257,3 +257,21 @@
   - type: Rehydratable
     possibleSpawns:
     - MobXenoCCNeutralRavager
+
+- type: entity # Floofstation
+  parent: MonkeyCube
+  id: PigCube
+  name: pig cube
+  components:
+  - type: Rehydratable
+    possibleSpawns:
+    - MobPig
+
+- type: entity # Floofstation
+  parent: MonkeyCube
+  id: ChickenCube
+  name: chicken cube
+  components:
+  - type: Rehydratable
+    possibleSpawns:
+    - MobChicken

--- a/Resources/Prototypes/_Floof/Recipes/Lathes/rehydrateable.yml
+++ b/Resources/Prototypes/_Floof/Recipes/Lathes/rehydrateable.yml
@@ -1,0 +1,13 @@
+- type: latheRecipe # Floofstation
+  id: PigCube
+  result: PigCube
+  completetime: 30
+  materials:
+    Biomass: 80
+
+- type: latheRecipe # Floofstation
+  id: ChickenCube
+  result: ChickenCube
+  completetime: 15
+  materials:
+    Biomass: 12


### PR DESCRIPTION
![MinorQoLPR](https://github.com/user-attachments/assets/ecd7f3b8-d726-48d2-bec2-bb43a4a40922)

# Description

Makes Wires instant build, waiting 2 seconds for every single wire was unacceptably long, even processing ORE is faster.
Re-enabled Water Vapor Canisters to be bought from Logistics.
Adds Pig and Chicken Cubes and the method to print them from a biofab.
Fixes Pigs to give bacon.


# Changelog
:cl:
- tweak: Tweaked wires to build almost instantly
- tweak: Re-enabled Water Vapor Canisters from Logistics
- fix: Pigs give bacon now. Weird they didn't before.
- add: Added Pig and Chicken Cubes.

