### PR TITLE
Marked Traits Update: No Free Points

### DIFF
--- a/Resources/Prototypes/_Floof/Traits/marked.yml
+++ b/Resources/Prototypes/_Floof/Traits/marked.yml
@@ -1,7 +1,7 @@
 - type: trait
   id: TraitorKillTarget
   category: Marked
-  points: 2
+  points: 0
   slots: 0
   functions:
   - !type:TraitAddComponent
@@ -12,7 +12,7 @@
 - type: trait
   id: TraitorTeachTarget
   category: Marked
-  points: 1
+  points: 0
   slots: 0
   functions:
   - !type:TraitAddComponent


### PR DESCRIPTION
# Description

These traits do not take trait slots, were intended for just opting into wanted gameplay, and should not incentivize being taken by people that just want points but not the consequences.

So this removes the points, and bad incentive, for taking these traits.

---

# Changelog

:cl: Sprkl
- tweak: Marked traits no longer give trait points.
