### PR TITLE
Fix Pronoun Usage in Wave Interaction

### DIFF
--- a/Resources/Locale/en-US/interaction/verbs/noop.ftl
+++ b/Resources/Locale/en-US/interaction/verbs/noop.ftl
@@ -48,9 +48,9 @@ interaction-WaveAt-success-self-popup = You wave {$hasUsed ->
 }
 interaction-WaveAt-success-target-popup = {THE($user)} waves {$hasUsed ->
     [false] at you.
-    *[true] {POSS-PRONOUN($user)} {$used} at you.
+    *[true] {POSS-ADJ($user)} {$used} at you.
 }
 interaction-WaveAt-success-others-popup = {THE($user)} waves {$hasUsed ->
     [false] at {THE($target)}.
-    *[true] {POSS-PRONOUN($user)} {$used} at {THE($target)}.
+    *[true] {POSS-ADJ($user)} {$used} at {THE($target)}.
 }


### PR DESCRIPTION
# Changelog

:cl:
- fix: Fixed an issue where the game would incorrectly state that someone "Waves theirs item" at you.
