### PR TITLE
Suffer Maxxing

### DIFF
--- a/Resources/Locale/en-US/_Floof/traits/traits.ftl
+++ b/Resources/Locale/en-US/_Floof/traits/traits.ftl
@@ -88,3 +88,5 @@ trait-name-TraitorTeachTarget = Marked for Death
 trait-description-TraitorTeachTarget = Someone or something wants you taught a lesson. Traitors can recieve orders to kill you.
 # Target Consent Traits: End
 
+trait-name-TraitDeathAcidifier = Death Acidifer
+trait-description-TraitDeathAcidifier = For one reason or another, you acidify on death or have a death acidifer implant, possibly due to current or previous work.

--- a/Resources/Prototypes/Traits/physical.yml
+++ b/Resources/Prototypes/Traits/physical.yml
@@ -758,6 +758,8 @@
           damageContainers:
           - Biological
           - BiologicalMetaphysical # Floof - M3739 - #1006
+          - Inorganic
+          - Silicon
         - type: ShowHealthBars
           damageContainers:
           - Biological

--- a/Resources/Prototypes/Traits/physical.yml
+++ b/Resources/Prototypes/Traits/physical.yml
@@ -66,7 +66,7 @@
       inverted: true
       traits: # Floof - M3739 - #690
         - GlassJaw
-        - Redshirt
+        - 
   functions:
     - !type:TraitReplaceComponent
       components:
@@ -91,7 +91,7 @@
       inverted: true
       traits: # Floof - M3739 - #690
         - Tenacity
-        - Redshirt
+        - 
   functions:
     - !type:TraitReplaceComponent
       components:
@@ -790,7 +790,7 @@
     - !type:TraitReplaceComponent
       components:
         - type: DeadModifier
-          deadThresholdModifier: -100
+          deadThresholdModifier: -99 # We find out if you have a crit status again for the crit traits.
 
 - type: trait
   id: BrittleBoneDisease

--- a/Resources/Prototypes/Traits/physical.yml
+++ b/Resources/Prototypes/Traits/physical.yml
@@ -66,7 +66,7 @@
       inverted: true
       traits: # Floof - M3739 - #690
         - GlassJaw
-        - 
+        - BrittleBoneDisease
   functions:
     - !type:TraitReplaceComponent
       components:

--- a/Resources/Prototypes/Traits/physical.yml
+++ b/Resources/Prototypes/Traits/physical.yml
@@ -790,7 +790,7 @@
     - !type:TraitReplaceComponent
       components:
         - type: DeadModifier
-          deadThresholdModifier: -99 # We find out if you have a crit status again for the crit traits.
+          deadThresholdModifier: -95 # We find out if you have a crit status again for the crit traits.
 
 - type: trait
   id: BrittleBoneDisease

--- a/Resources/Prototypes/Traits/physical.yml
+++ b/Resources/Prototypes/Traits/physical.yml
@@ -66,7 +66,6 @@
       inverted: true
       traits: # Floof - M3739 - #690
         - GlassJaw
-        - BrittleBoneDisease
         - Redshirt
   functions:
     - !type:TraitReplaceComponent
@@ -92,7 +91,6 @@
       inverted: true
       traits: # Floof - M3739 - #690
         - Tenacity
-        - BrittleBoneDisease
         - Redshirt
   functions:
     - !type:TraitReplaceComponent
@@ -786,10 +784,6 @@
       traits: # Floof - M3739 - #690 - As it stands, this trait COMPLETELY REMOVES the crit status altogether. Traits that alter crit thresholds will have no effect as a result.
         - WillToLive
         - WillToDie
-        - GlassJaw
-        - Tenacity
-        - BrittleBoneDisease
-
   functions:
     - !type:TraitReplaceComponent
       components:
@@ -815,7 +809,6 @@
       traits: # Floof - M3739 - #690
         - GlassJaw
         - Tenacity
-        - Redshirt
   functions:
     - !type:TraitReplaceComponent
       components:

--- a/Resources/Prototypes/Traits/physical.yml
+++ b/Resources/Prototypes/Traits/physical.yml
@@ -91,7 +91,7 @@
       inverted: true
       traits: # Floof - M3739 - #690
         - Tenacity
-        - 
+        - BrittleBoneDisease
   functions:
     - !type:TraitReplaceComponent
       components:

--- a/Resources/Prototypes/_Floof/Traits/physical.yml
+++ b/Resources/Prototypes/_Floof/Traits/physical.yml
@@ -301,5 +301,6 @@
     - Borg
     - MedicalBorg
   functions:
-  - !type:AddImplantSpecial
-    implants: [ DeathAcidifierImplant ]
+    - type: AutoImplant
+      implants:
+      - DeathAcidifierImplant

--- a/Resources/Prototypes/_Floof/Traits/physical.yml
+++ b/Resources/Prototypes/_Floof/Traits/physical.yml
@@ -301,5 +301,5 @@
     - Borg
     - MedicalBorg
   functions:
-  - !type:AddImplant
+  - !type:TraitAddImplant
     implants: [ DeathAcidifierImplant ]

--- a/Resources/Prototypes/_Floof/Traits/physical.yml
+++ b/Resources/Prototypes/_Floof/Traits/physical.yml
@@ -301,6 +301,5 @@
     - Borg
     - MedicalBorg
   functions:
-    - type: AutoImplant
-      implants:
-      - DeathAcidifierImplant
+  - !type:AddImplant
+    implants: [ DeathAcidifierImplant ]

--- a/Resources/Prototypes/_Floof/Traits/physical.yml
+++ b/Resources/Prototypes/_Floof/Traits/physical.yml
@@ -290,3 +290,16 @@
   - !type:TraitModifySilicon
     batteryDrainModifier: -0.25 # Floof - M3739 - #1209 - Roughly 32 minutes on a medium capacity power cell.
     
+- type: trait
+  id: TraitDeathAcidifier
+  category: Physical
+  points: -8
+  requirements:
+  - !type:CharacterJobRequirement
+    inverted: true
+    jobs:
+    - Borg
+    - MedicalBorg
+  functions:
+  - !type:AddImplantSpecial
+    implants: [ DeathAcidifierImplant ]


### PR DESCRIPTION
# Description

We love suffering.
Therefore, I've made Brittle Bones and Redshirt un-mutually exclusive. (Looking at you Kip Yip)
And I've made a brand new, Death Acidifier trait, which starts you with a death acidifer (inside you). For when you want to be TRULY unrevivable, or roleplay a former nukie or whatever you desire. (Flick would take this)
I wanted to make a BSO Linelife variant but we're lacking that code.

# TODO

- [ ] Check if Death Acidifer Trait is working

# Changelog

:cl:
- add: Added Death Acidifier Trait
- tweak: You can now take Brittle Bones and Red Shirt together again.

