### PR TITLE
Fixes Assay Feedback Text for Various Abilities

### DIFF
--- a/Resources/Locale/en-US/psionics/psionic-powers.ftl
+++ b/Resources/Locale/en-US/psionics/psionic-powers.ftl
@@ -10,7 +10,7 @@ dispel-power-metapsionic-feedback = {CAPITALIZE($entity)} is a mighty stone, sta
 # Mass Sleep
 mass-sleep-power-description = Put targets in a small area to sleep.
 mass-sleep-initialization-feedback = Reaching out to the minds around me, I have located the words that can send others to the realm of dreams.
-mass-sleep-metapsionic-feedback = {CAPITALIZE($entity)} bears the indelible mark of a dream thief.
+mass-sleep-power-metapsionic-feedback = {CAPITALIZE($entity)} bears the indelible mark of a dream thief.
 
 # Mind Swap
 mind-swap-power-description = Swap minds with the target. Either can change back after 20 seconds.
@@ -58,7 +58,7 @@ healing-word-power-initialization-feedback =
     At the beginning of time, a word was spoken that brought life into the Spheres.
     Though it taxes my mind to know it, this Secret is known to me now.
     I need only speak it.
-healing-word-power-metapsionic-feedback = {CAPITALIZE($entity)} bears the Lesser Secret of Life.
+healing-word-power-feedback = {CAPITALIZE($entity)} bears the Lesser Secret of Life.
 healing-word-begin = {CAPITALIZE($entity)} mutters a word that brings both joy and pain alike to those who hear it.
 
 # Revivify
@@ -69,7 +69,7 @@ revivify-power-initialization-feedback =
     For a moment, my soul journeys across time and space to the beginning of it all, there I hear it.
     The Secret of Life in its fullness. I feel my entire existence burning out from within, merely by knowing it.
     Power flows through me as a mighty river, begging to be released with a simple spoken word.
-revivify-power-metapsionic-feedback = {CAPITALIZE($entity)} bears the Greater Secret of Life.
+revivify-power-feedback = {CAPITALIZE($entity)} bears the Greater Secret of Life.
 revivify-begin = {CAPITALIZE($entity)} enunciates a word of such divine power, that those who hear it weep from joy.
 
 # Telegnosis
@@ -96,19 +96,21 @@ xenoglossy-power-initialization-feedback =
     I feel an empathy with all creation, so that I may understand them and be understood.
     The barrier between thought and expressions is permeable to me.
 
-psionic-language-power-metapsionic-feedback = The noösphere flows freely through {CAPITALIZE($entity)}, who seems to digest it and pass it back out undisturbed.
+psionic-language-power-feedback = The noösphere flows freely through {CAPITALIZE($entity)}, who seems to digest it and pass it back out undisturbed.
 
 # Psychognomy
 psychognomy-power-description = You have some vague sense of the form of the source of telepathic messages.
 psychognomy-power-initialization-feedback =
     I have pierced the veil, and I know I'm not alone. More concerning, the piercing I made seems to be still indefinitely permeable.
     When energy passes through the perforations in the noösphere, I get a faint glimpse of the material origin.
+psionic-psychognomy-power-feedback = {CAPITALIZE($entity)} can partially trace a telepathic message's origin.
 
 # Telepathy
 telepathy-power-description = You are capable of both sending and receiving telepathic messages.
 telepathy-power-initialization-feedback =
     The voices I've heard all my life begin to clear, yet they do not leave me. Before, they were as incoherent whispers,
     now my senses broaden, I come to a realization that they are part of a communal shared hallucination. Behind every voice is a glimmering sentience.
+psionic-telepathy-power-feedback = {CAPITALIZE($entity)} is capable of understanding and communicating without words or actions
 
 # Shadeskip
 action-name-shadeskip = Shadeskip
@@ -141,7 +143,7 @@ pyrokinetic-flare-power-initialization-feedback =
     My gaze is briefly filled with a flash of immense light and head, and for a single moment I can see a glimpse of a realm
     of fire and pain, of hunger and suffering. Just as soon as I glimpse it, the vision fades. But the memory of that flash lingers within my mind.
     I can recall it still, a glimpse of the fires of Gehenna.
-pyrokinetic-flare-power-metapsionic-feedback = Guh these don't even matter because nobody can read this line in-game and I don't know when I'm ever bringing back Narrow Pulse
+pyrokinetic-flare-power-metapsionic-feedback = {CAPITALIZE($entity)} can use a spark of fire to blind enemies
 
 # Summon Imp
 action-name-summon-imp = Summon Imp

--- a/Resources/Prototypes/Psionics/psionics.yml
+++ b/Resources/Prototypes/Psionics/psionics.yml
@@ -312,13 +312,13 @@
     - !type:PsionicFeedbackSelfChat
       feedbackMessage: psychognomy-power-initialization-feedback
     - !type:AddPsionicAssayFeedback
-      assayFeedback: psionic-language-power-feedback
+      assayFeedback: psionic-psychognomy-power-feedback
   removalFunctions:
     - !type:RemovePsionicPowerComponents
       components:
         - type: Psychognomist
     - !type:RemoveAssayFeedback
-      assayFeedback: psionic-language-power-feedback
+      assayFeedback: psionic-psychognomy-power-feedback
   powerSlotCost: 0
 
 - type: psionicPower
@@ -334,7 +334,7 @@
     - !type:PsionicFeedbackSelfChat
       feedbackMessage: telepathy-power-initialization-feedback
     - !type:AddPsionicAssayFeedback
-      assayFeedback: psionic-language-power-feedback
+      assayFeedback: psionic-telepathy-power-feedback
     - !type:PsionicAddAvailablePowers
       powerPrototype: XenoglossyPower
       weight: 0.75
@@ -346,7 +346,7 @@
       components:
         - type: Telepathy
     - !type:RemoveAssayFeedback
-      assayFeedback: psionic-language-power-feedback
+      assayFeedback: psionic-telepathy-power-feedback
     - !type:PsionicRemoveAvailablePowers
       powerPrototype: XenoglossyPower
     - !type:PsionicRemoveAvailablePowers


### PR DESCRIPTION
# Description
Problem: Assay ability for some abilities returns the internal feedback variable instead of an actual description.
Reason: Mismatched/non-existent locale entries or duplicate labels

This change fixes this problem.
I also did not write a bug report because I found the problem and a solution relatively quickly after

# Changelog

:cl:
- fix: Fixed mass sleep, healing word, and revivify assay feedback.
- fix: Fixed all three language abilities (telepathy, xenoglossy and psychognomy)
- add: Wrote psychognomy and telepathy descriptions as they didnt exist.
- tweak: Changed pyrokinetic flare description from placeholder text to a real description
