### PR TITLE
Locker Rejig

### DIFF
--- a/Resources/Prototypes/Catalog/Fills/Lockers/misc.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/misc.yml
@@ -121,13 +121,16 @@
       - id: ClothingUniformJumpskirtOperative
     - id: ClothingBackpackDuffelSyndicate
     - id: CyberPen
-    - id: CigPackSyndicate
+    # - id: CigPackSyndicate # Floof - Taken out due to non-contraband status
     - id: ClothingBackpackDuffelSyndicatePyjamaBundle
+    - id: ClothingHandsGlovesCombat # Floof
     - id: ClothingBeltMilitaryWebbing
+    - id: ClothingBeltMercWebbing # Floof
     - id: ClothingShoesBootsCombatFilled
+    - id: ClothingShoesBootsMercFilled # Floof
     - id: ToolboxSyndicateFilled
-    - id: BalloonSyn
-    - id: WeaponSniperMosin
+    # - id: BalloonSyn
+    # - id: WeaponSniperMosin
       weight: 2
     - !type:EntSelector
       id: ClothingEyesNightVisionGogglesSyndie
@@ -160,11 +163,11 @@
     # Weapons
     - !type:NestedSelector
       tableId: MaintWeaponTable
-      prob: 0.075
+      prob: 0.10
     # Syndie Loot
     - !type:NestedSelector
       tableId: SyndieMaintLoot
-      prob: 0.05
+      prob: 0.075
     - !type:NestedSelector
       tableId: LewdMaintLoot # Floof - lewd loot
       prob: 0.3

--- a/Resources/Prototypes/Catalog/Fills/Lockers/misc.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/misc.yml
@@ -124,6 +124,7 @@
     # - id: CigPackSyndicate # Floof - Taken out due to non-contraband status
     - id: ClothingBackpackDuffelSyndicatePyjamaBundle
     - id: ClothingHandsGlovesCombat # Floof
+    - id: ClothingHandsMercGlovesCombat # Floof
     - id: ClothingBeltMilitaryWebbing
     - id: ClothingBeltMercWebbing # Floof
     - id: ClothingShoesBootsCombatFilled

--- a/Resources/Prototypes/Entities/Markers/Spawners/Random/maintenance.yml
+++ b/Resources/Prototypes/Entities/Markers/Spawners/Random/maintenance.yml
@@ -373,8 +373,6 @@
       - id: WeaponShotgunHandmade
       - id: WeaponShotgunImprovisedLoaded
       - id: WeaponSniperMosin
-      - id: TelescopicShield
-      - id: SmokeGrenade # Floof - Harmless distraction
     # Super Rare Group  
     - !type:GroupSelector # Floof - Super Rare ding ding ding you won the lottery
       weight: 1

--- a/Resources/Prototypes/Entities/Markers/Spawners/Random/maintenance.yml
+++ b/Resources/Prototypes/Entities/Markers/Spawners/Random/maintenance.yml
@@ -272,7 +272,7 @@
       - id: Bucket
       - id: RadioHandheld
       - id: AppraisalTool
-      - id: ModularReceiver
+      # - id: ModularReceiver
       - id: WeaponFlareGun
       - id: BarberScissors
       - !type:GroupSelector
@@ -293,7 +293,7 @@
       - id: ResearchDisk5000
       - id: PetCarrier
       - id: DrinkMopwataBottleRandom
-      - id: LidSalami
+      # - id: LidSalami
         weight: 0.05
 
 - type: entity
@@ -324,22 +324,22 @@
       - id: BaseBallBat
       - id: CombatKnife
       - id: Spear
-      - id: RifleStock
-      - id: ModularReceiver
-      - id: HydroponicsToolScythe
+      # - id: RifleStock # Floof - Commenting out somethings that are in this catagory that are kinda useless or don't fit
+      # - id: ModularReceiver
+      # - id: HydroponicsToolScythe
     # Rare Group
     - !type:GroupSelector
       weight: 5
       children:
-      - id: Lighter
-      - id: Matchbox
-      - id: ClothingEyesBlindfold
-      - id: ClothingMaskMuzzle
+      # - id: Lighter
+      # - id: Matchbox
+      # - id: ClothingEyesBlindfold
+      # - id: ClothingMaskMuzzle
       - id: ClothingMaskGasSecurity
-      - id: ShardGlass
-        weight: 2
-      - id: Syringe
-      - id: Mousetrap
+      # - id: ShardGlass
+      #  weight: 2
+      # - id: Syringe
+      # - id: Mousetrap
       - !type:GroupSelector
         weight: 2
         children:

--- a/Resources/Prototypes/Entities/Markers/Spawners/Random/maintenance.yml
+++ b/Resources/Prototypes/Entities/Markers/Spawners/Random/maintenance.yml
@@ -11,6 +11,7 @@
         children:
         - id: Lighter
         - id: CigCartonBlue
+        - id: CigPackSyndicate
       # Gar glasses
       - !type:GroupSelector
         children:
@@ -251,7 +252,7 @@
         tableId: SprayPaintTable
         weight: 3
         rolls: !type:RangeNumberSelector
-          range: 1, 3
+          range: 3, 5
       # Uncommon Group
     - !type:GroupSelector
       weight: 23
@@ -293,8 +294,9 @@
       - id: ResearchDisk5000
       - id: PetCarrier
       - id: DrinkMopwataBottleRandom
-      # - id: LidSalami
-        weight: 0.05
+      - id: RandomArtifactSpawner # Floof - helps epi a little
+      # - id: LidSalami # Floof - Commented out due actually garbage
+      #  weight: 0.05
 
 - type: entity
   name: Maint Loot Spawner
@@ -318,40 +320,68 @@
     children:
     # Common Group
     - !type:GroupSelector
-      weight: 95
+      weight: 80
       children:
       - id: Machete
       - id: BaseBallBat
       - id: CombatKnife
       - id: Spear
-      # - id: RifleStock # Floof - Commenting out somethings that are in this catagory that are kinda useless or don't fit
-      # - id: ModularReceiver
+      - id: KukriKnife
+      - id: ThrowingKnife
+      - id: ClothingBeltEnergySheathFilledToy # Floof - Makes security believe there's syndies
+      - id: ToySword # Floof - Just a little bit of psychological torture
+      - id: DBToySword # Floof - for those seccies who use toy swords as meta knoweldge for knowing there's syndies in the round
+      # - id: RifleStock # Floof - Commented out due to lack of impact
+      # - id: ModularReceiver # Floof - Commented out due to lack of impact
       # - id: HydroponicsToolScythe
-    # Rare Group
+    # Uncommon Group
     - !type:GroupSelector
-      weight: 5
+      weight: 15
       children:
-      # - id: Lighter
-      # - id: Matchbox
-      # - id: ClothingEyesBlindfold
-      # - id: ClothingMaskMuzzle
+      # - id: Lighter # Floof - Commented out due wrong catagory
+      # - id: Matchbox # Floof - Commented out due wrong catagory
+      # - id: ClothingEyesBlindfold # Floof - Commented out due wrong catagory
+      # - id: ClothingMaskMuzzle # Floof - Commented out due wrong catagory
       - id: ClothingMaskGasSecurity
-      # - id: ShardGlass
+      - id: ClothingMaskGasMerc
+      - id: ClothingMaskGasExplorer
+      # - id: ShardGlass # Floof - actually just rubbish
       #  weight: 2
-      # - id: Syringe
-      # - id: Mousetrap
-      - !type:GroupSelector
-        weight: 2
-        children:
-        - id: Brutepack1
-        - id: Ointment1
-        - id: Gauze1
+      # - id: Syringe # Floof - Commented out due wrong catagory
+      # - id: Mousetrap # Floof - Commented out due wrong catagory
+      #- !type:GroupSelector
+      #  weight: 5
+      #  children:
+      #  - id: Brutepack1 # Floof - Commented out due wrong catagory
+      #  - id: Ointment1 # Floof - Commented out due wrong catagory
+      #  - id: Gauze1 # Floof - Commented out due wrong catagory
       - id: Bola
       - id: SurvivalKnife
       - id: ScalpelShiv
       - id: Shiv
       - id: SawImprov
       - id: HydroponicsToolMiniHoe
+      - id: Stunprod # Floof
+      - id: Sledgehammer # Floof
+      - id: WoodenBuckler # Floof
+    # Rare Group 
+    - !type:GroupSelector # Floof - Rare single shot guns
+      weight: 4
+      children:
+      - id: Musket
+      - id: WeaponPistolFlintlock
+      - id: WeaponShotgunHandmade
+      - id: WeaponShotgunImprovisedLoaded
+      - id: WeaponSniperMosin
+      - id: TelescopicShield
+      - id: SmokeGrenade # Floof - Harmless distraction
+    # Super Rare Group  
+    - !type:GroupSelector # Floof - Super Rare ding ding ding you won the lottery
+      weight: 1
+      children:
+      - id: WeaponLaserSvalinn
+      - id: WeaponDisabler # Floof - Seccie lost it
+      - id: WeaponSniperGrand # Floof - Same status as a Mosin
 
 - type: entity
   name: Maint Loot Spawner


### PR DESCRIPTION
# Description

Increases the variety of contraband inside maint locker fills while commenting out some to clean the pool of things that don't belong or otherwise never used. 

Noticeable adds include random artifact, toy swords, single shot guns and more work for security.

Due to how the loot table is done, Mosins are rarer now. (and everything in the same tier and rarer)

Why? I felt it was overdue a look, and honestly the weapons roll getting taken by a glass shard or a blindfold is a bit shit.

One of the things that got suggested to me was having a 0.1% chance that gas mask could be voice mask. (Not implemented)
Other thoughts include the syndie insuls which shock you and the weird psionic ones that give you noosphere zap.



# Changelog

:cl:
- tweak: chaos

