### PR TITLE
Addbody Command Toolshed

### DIFF
--- a/Content.Server/Body/Commands/AddHandCommand.cs
+++ b/Content.Server/Body/Commands/AddHandCommand.cs
@@ -118,6 +118,8 @@ namespace Content.Server.Body.Commands
                 var text = $"You have no body{(_random.Prob(0.2f) ? " and you must scream." : ".")}";
 
                 shell.WriteLine(text);
+                // Floof
+                shell.WriteLine($"Add one with the {(args.Length == 0 ? "self" : "ent " + entity)} addbody:default command.");
                 return;
             }
 
@@ -128,6 +130,13 @@ namespace Content.Server.Body.Commands
             }
 
             var bodySystem = _entManager.System<BodySystem>();
+
+            // Floof - ensure the entity has a body
+            if (!_entManager.HasComponent<BodyComponent>(entity))
+            {
+                shell.WriteLine($"Specified entity has no body!.");
+                return;
+            }
 
             var attachAt = bodySystem.GetBodyChildrenOfType(entity, BodyPartType.Arm, body).FirstOrDefault();
             if (attachAt == default)

--- a/Content.Server/_Floof/Body/Commands/AddBodyCommand.cs
+++ b/Content.Server/_Floof/Body/Commands/AddBodyCommand.cs
@@ -1,0 +1,79 @@
+using Content.Server.Administration;
+using Content.Server.Body.Systems;
+using Content.Shared.Administration;
+using Content.Shared.Body.Components;
+using Content.Shared.Body.Prototypes;
+using Content.Shared.Body.Systems;
+using Content.Shared.Hands.Components;
+using Content.Shared.Interaction.Components;
+using Robust.Shared.Prototypes;
+using Robust.Shared.Toolshed;
+
+
+namespace Content.Server._Floof.Body.Commands;
+
+[ToolshedCommand, AdminCommand(AdminFlags.Admin)]
+sealed class AddBodyCommand : ToolshedCommand
+{
+    [ValidatePrototypeId<EntityPrototype>]
+    public const string DefaultBodyPrototype = "Adminbus";
+
+    [CommandImplementation("default")]
+    public EntityUid AddDefault(
+        [CommandInvocationContext] IInvocationContext ctx,
+        [PipedArgument] EntityUid input)
+    {
+        return AddPrototype(ctx, input, DefaultBodyPrototype);
+    }
+
+    [CommandImplementation("prototype")]
+    public EntityUid AddPrototype(
+        [CommandInvocationContext] IInvocationContext ctx,
+        [PipedArgument] EntityUid input,
+        [CommandArgument] ProtoId<BodyPrototype> proto)
+    {
+        if (HasComp<BodyComponent>(input))
+        {
+            ctx.WriteLine($"Warning: entity {input} already has a body. Refusing to add another.");
+            return input;
+        }
+
+        EnsureComp<HandsComponent>(input);
+        EnsureComp<ComplexInteractionComponent>(input); // required to pick up items
+        EntityManager.AddComponent(input, new BodyComponent
+        {
+            Prototype = proto
+        });
+
+        return input;
+    }
+
+    [CommandImplementation("set_required_legs")]
+    public EntityUid SetRequiredLegs(
+        [CommandInvocationContext] IInvocationContext ctx,
+        [PipedArgument] EntityUid input,
+        [CommandArgument] int required)
+    {
+        if (TryComp<BodyComponent>(input, out var body))
+        {
+            body.RequiredLegs = required;
+        }
+        return input;
+    }
+
+    [CommandImplementation("remove")]
+    public EntityUid RemoveBody(
+        [CommandInvocationContext] IInvocationContext ctx,
+        [PipedArgument] EntityUid input)
+    {
+        if (TryComp<BodyComponent>(input, out var body))
+        {
+            // Yes we have to do this because otherwise the system won't delete them
+            foreach (var part in EntityManager.System<BodySystem>().GetBodyChildren(input, body))
+                EntityManager.QueueDeleteEntity(part.Id);
+
+            RemComp<BodyComponent>(input);
+        }
+        return input;
+    }
+}

--- a/Content.Server/_Floof/Body/Commands/BodyCommand.cs
+++ b/Content.Server/_Floof/Body/Commands/BodyCommand.cs
@@ -13,10 +13,9 @@ using Robust.Shared.Toolshed;
 namespace Content.Server._Floof.Body.Commands;
 
 [ToolshedCommand, AdminCommand(AdminFlags.Admin)]
-sealed class AddBodyCommand : ToolshedCommand
+sealed class BodyCommand : ToolshedCommand
 {
-    [ValidatePrototypeId<EntityPrototype>]
-    public const string DefaultBodyPrototype = "Adminbus";
+    public static readonly ProtoId<BodyPrototype> DefaultBodyPrototype = "Adminbus";
 
     [CommandImplementation("default")]
     public EntityUid AddDefault(

--- a/Content.Shared/Body/Components/BodyComponent.cs
+++ b/Content.Shared/Body/Components/BodyComponent.cs
@@ -8,7 +8,7 @@ using Robust.Shared.Prototypes;
 namespace Content.Shared.Body.Components;
 
 [RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
-[Access(typeof(SharedBodySystem))]
+[Access(typeof(SharedBodySystem), Other = AccessPermissions.ReadWrite)] // Floof - stop limiting access ffs
 public sealed partial class BodyComponent : Component
 {
     /// <summary>

--- a/Resources/Locale/en-US/_Floof/body/commands.ftl
+++ b/Resources/Locale/en-US/_Floof/body/commands.ftl
@@ -1,0 +1,4 @@
+command-description-addbody-default = Add the default body to the piped entity. Example usage: `self addbody:default`
+command-description-addbody-prototype = Add a body to the piped entity. Example usage: `self addbody:prototype Human`
+command-description-addbody-set_required_legs = Set how many legs the piped entity needs to be able to stand/walk. Example usage: `self addbody:set-required-legs 2`
+command-description-addbody-remove = Remove a body from the piped entity. Example usage: `self addbody:remove`

--- a/Resources/Locale/en-US/_Floof/body/commands.ftl
+++ b/Resources/Locale/en-US/_Floof/body/commands.ftl
@@ -1,4 +1,4 @@
-command-description-addbody-default = Add the default body to the piped entity. Example usage: `self addbody:default`
-command-description-addbody-prototype = Add a body to the piped entity. Example usage: `self addbody:prototype Human`
-command-description-addbody-set_required_legs = Set how many legs the piped entity needs to be able to stand/walk. Example usage: `self addbody:set-required-legs 2`
-command-description-addbody-remove = Remove a body from the piped entity. Example usage: `self addbody:remove`
+command-description-body-default = Add the default body to the piped entity. Example usage: `self body:default`
+command-description-body-prototype = Add a body to the piped entity. Example usage: `self body:prototype Human`
+command-description-body-set_required_legs = Set how many legs the piped entity needs to be able to stand/walk. Example usage: `self body:set-required-legs 2`
+command-description-body-remove = Remove a body from the piped entity. Example usage: `self body:remove`

--- a/Resources/Prototypes/_Floof/Body/Prototypes/adminbus.yml
+++ b/Resources/Prototypes/_Floof/Body/Prototypes/adminbus.yml
@@ -1,0 +1,35 @@
+# No head and arms, hands are attached directly to the torso
+- type: body
+  id: Adminbus
+  name: pseudo-body
+  root: torso
+  slots:
+    torso:
+      part: TorsoHuman
+      connections:
+      - right hand
+      - left hand
+      - right leg
+      - left leg
+      organs:
+        heart: OrganHumanHeart
+        lungs: OrganHumanLungs
+        stomach: OrganHumanStomach
+        liver: OrganHumanLiver
+        kidneys: OrganHumanKidneys
+    right hand:
+      part: RightHandHuman
+    left hand:
+      part: LeftHandHuman
+    right leg:
+      part: RightLegHuman
+      connections:
+      - right foot
+    left leg:
+      part: LeftLegHuman
+      connections:
+      - left foot
+    right foot:
+      part: RightFootHuman
+    left foot:
+      part: LeftFootHuman


### PR DESCRIPTION
# Description
Adds toolshed commands to add/remove bodies to/from entities. This allows to create e.g. a weh plushie with hands, as the `addhand` command requires the modified entity to have a body.

These commands do NOT set anything up than the very basics necessary to do admin shenanigans (Body, Hands, ComplexInteractions). If you want more, e.g. combat mode, alerts, mob state, you have to add that yourself.

- addbody:default - adds a default Adminbus body to the piped entity. The body features some hands and legs.
- addbody:prototype - adds a body prototyped specified in the argument.
- addbody:remove - removes the body from an entity, deleting all related body parts.
- addbody:set_required_legs - sets how many legs an entity needs to walk. I dunno why that isn't a part of the BodyPrototype but at this point I don't care.


<details><summary><h1>Media</h1></summary>
<p>


https://github.com/user-attachments/assets/57d2d0b7-a949-4f9b-a2d8-8e62b44a2141



</p>
</details>


# Changelog
:cl:
ADMIN:
- add: Added a set of commands to help add bodies (and hands!) to non-mob entities. See `list addbody` or Floof-Station#1278 for more info.