### PR TITLE
Raise Max Allowed Basic Languages

### DIFF
--- a/Resources/Prototypes/CharacterItemGroups/Generic/languageGroups.yml
+++ b/Resources/Prototypes/CharacterItemGroups/Generic/languageGroups.yml
@@ -1,6 +1,6 @@
 - type: characterItemGroup
   id: TraitsLanguagesBasic
-  maxItems: 1
+  maxItems: 2
   items:
     - type: trait
       id: SignLanguage


### PR DESCRIPTION
# Description

In light of the new Tajaran race, which adds two new languages, and the animal languages of which there are five, I strongly believe that the number of allowed basic language traits should be raised to AT LEAST two, enabling greater multilingual roleplay.

This is especially vital for characters that were already planned to be Tajaran, but had a different language picked out as their alternate while waiting, and now have to choose between maintaining ability to communicate with their existing friends or taking on their originally planned languages.

---

# Changelog

:cl:
- tweak: You can now choose up to two additional languages in character creation.