### PR TITLE
Tajaran Fix: Custom Species & Missing Markings Slots

### DIFF
--- a/Resources/Prototypes/_EE/Species/tajaran.yml
+++ b/Resources/Prototypes/_EE/Species/tajaran.yml
@@ -16,7 +16,8 @@
   maleFirstNames: names_tajaran_first
   femaleFirstNames: names_tajaran_first
   lastNames: names_tajaran_last
-  
+  customName: true # Floofstation
+
 
 - type: markingPoints
   id: MobTajaranMarkingLimits

--- a/Resources/Prototypes/_EE/Species/tajaran.yml
+++ b/Resources/Prototypes/_EE/Species/tajaran.yml
@@ -72,8 +72,12 @@
     HeadSide: MobHumanoidAnyMarking
     Hair: MobHumanoidAnyMarking
     FacialHair: MobHumanoidAnyMarking
+    Face: MobHumanoidAnyMarking # Floof
     Snout: MobHumanoidAnyMarking
     Chest: MobTajaranTorso
+    Underwear: MobHumanoidAnyMarking # Floofstation
+    Undershirt: MobHumanoidAnyMarking # Floofstation
+    Wings: MobHumanoidAnyMarking # Floof
     Eyes: MobTajaranEyes
     LArm: MobTajaranLArm
     RArm: MobTajaranRArm
@@ -82,6 +86,8 @@
     LLeg: MobTajaranLLeg
     RLeg: MobTajaranRLeg
     Tail: MobHumanoidAnyMarking
+    TailBehind: MobHumanoidAnyMarking
+    TailOversuit: MobHumanoidAnyMarking
     LFoot: MobTajaranLFoot
     RFoot: MobTajaranRFoot
 


### PR DESCRIPTION
# Description

Adds the one line needed to allow for custom species while selecting Tajaran.

---

# Changelog

:cl: sprkl
- fix: Tajaran can have their species name customized.
