### PR TITLE
Downstream Merge: Constructible Holopads and Lathes

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
@@ -492,6 +492,8 @@
     - DeepFryerMachineCircuitboard #Nyano - Summary: adds deep fryer circuit board
     - SpaceHeaterMachineCircuitBoard
     - StationAnchorCircuitboard
+    - FaxMachineCircuitboard # Vulp
+    - HolopadMachineCircuitboard # Vulp
     dynamicRecipes:
       - ThermomachineFreezerMachineCircuitBoard
       - HellfireFreezerMachineCircuitBoard

--- a/Resources/Prototypes/_Vulp/Entities/Objects/Devices/Circuitboards/communication.yml
+++ b/Resources/Prototypes/_Vulp/Entities/Objects/Devices/Circuitboards/communication.yml
@@ -1,0 +1,14 @@
+- type: entity
+  id: FaxMachineCircuitboard
+  parent: BaseMachineCircuitboard
+  name: fax machine board
+  description: A machine printed circuit board for a long-range fax machine.
+  components:
+  - type: MachineBoard
+    prototype: FaxMachineConstructible
+    requirements:
+      Manipulator: 2
+    materialRequirements:
+      Steel: 2
+      Glass: 2
+      Cable: 2

--- a/Resources/Prototypes/_Vulp/Entities/Structures/Machines/communication.yml
+++ b/Resources/Prototypes/_Vulp/Entities/Structures/Machines/communication.yml
@@ -1,0 +1,15 @@
+- type: entity
+  parent: [FaxMachineBase, ConstructibleMachine]
+  id: FaxMachineConstructible
+  suffix: Constructed
+  components:
+  - type: Machine
+    board: FaxMachineCircuitboard
+  - type: ContainerContainer # Just because the entity manager won't merge those properly
+    containers:
+      Paper: !type:ContainerSlot
+        ent: null
+      machine_board: !type:Container
+        ents: []
+      machine_parts: !type:Container
+        ents: []

--- a/Resources/Prototypes/_Vulp/Recipes/Lathes/communication.yml
+++ b/Resources/Prototypes/_Vulp/Recipes/Lathes/communication.yml
@@ -1,0 +1,18 @@
+- type: latheRecipe
+  id: HolopadMachineCircuitboard
+  result: HolopadMachineCircuitboard
+  completetime: 4
+  materials:
+    Steel: 300
+    Glass: 900
+    Gold: 100
+    Bluespace: 100
+
+- type: latheRecipe
+  id: FaxMachineCircuitboard
+  result: FaxMachineCircuitboard
+  completetime: 4
+  materials:
+    Steel: 300
+    Glass: 900
+    Gold: 100


### PR DESCRIPTION
Downstream PR: https://github.com/vulpstation/vulpstation/pull/28. Ported from Vulpstation

-----

# Description
Title, tested in-game

# Changelog
:cl:
- add: Faxes and holopads now have their respective circuit boards available in the circuit imprinter and can be constructed.