### PR TITLE
Fix StandingState Mispredicts

### DIFF
--- a/Content.Client/Standing/LayingDownSystem.cs
+++ b/Content.Client/Standing/LayingDownSystem.cs
@@ -36,6 +36,9 @@ public sealed class LayingDownSystem : SharedLayingDownSystem
             sprite.DrawDepth = standing.CurrentState is StandingState.Lying && layingDown.IsCrawlingUnder
                 ? layingDown.CrawlingUnderDrawDepth
                 : layingDown.NormalDrawDepth;
+
+            // Floofstation - the rotation of an entity can change without it moving
+            OnMovementInput(uid, layingDown, new MoveEvent());
         }
 
         query.Dispose();

--- a/Content.Shared/Standing/SharedLayingDownSystem.cs
+++ b/Content.Shared/Standing/SharedLayingDownSystem.cs
@@ -114,8 +114,10 @@ public abstract class SharedLayingDownSystem : EntitySystem
             || _mobState.IsIncapacitated(uid)
             || !_standing.Stand(uid))
             component.CurrentState = StandingState.Lying;
+        else // Floofstation - put the below into else
+            component.CurrentState = StandingState.Standing;
 
-        component.CurrentState = StandingState.Standing;
+        Dirty(uid, component); // Floofstation
     }
 
     private void OnRefreshMovementSpeed(EntityUid uid, LayingDownComponent component, RefreshMovementSpeedModifiersEvent args)

--- a/Content.Shared/Standing/StandingStateSystem.cs
+++ b/Content.Shared/Standing/StandingStateSystem.cs
@@ -97,7 +97,7 @@ public sealed class StandingStateSystem : EntitySystem
 
         Climb(uid);
 
-        return true;
+        return standingState.CurrentState is StandingState.Lying; // Floofstation - this CAN be false if climb fails
     }
 
     public bool Stand(EntityUid uid,
@@ -146,7 +146,7 @@ public sealed class StandingStateSystem : EntitySystem
 
         Climb(uid);
 
-        return true;
+        return standingState.CurrentState is StandingState.Standing; // Floofstation - this CAN be false if climb fails
     }
 
     private void Climb(EntityUid uid)


### PR DESCRIPTION
# Description
Just glancing at this code makes me want to weep. Every minute I spend working on it is agonizing torture. I yearn for the day Wizden or anyone else writes their own implementation that we can use instead.

I fixed some parts of it. This should hopefully fix that annoying broken standing state where one is standing, but the game renders them as laying down for everyone. Also fixes the bug where the horizontal orientation (facing east/west) of a person was only updated when they moved.


<details><summary><h1>Media</h1></summary>
<p>


https://github.com/user-attachments/assets/ce97e387-62d6-4088-909d-e94ca0d3f398



</p>
</details>

# Changelog
:cl:
- fix: HOPEFULLY fixed the annoying bug that caused broken standing state.
- fix: Entities leaving your PVS should no longer have their sprite rotation reset to "facing west".