### PR TITLE
Task Acumen II (Admin Updates No. 1)

### DIFF
--- a/Content.Client/Administration/UI/Notes/AdminNotesLinePopup.xaml
+++ b/Content.Client/Administration/UI/Notes/AdminNotesLinePopup.xaml
@@ -1,10 +1,10 @@
 <Popup xmlns="https://spacestation14.io"
        xmlns:gfx="clr-namespace:Robust.Client.Graphics;assembly=Robust.Client">
-    <PanelContainer StyleClasses="BackgroundDark">
+    <PanelContainer>
         <PanelContainer.PanelOverride>
-            <gfx:StyleBoxFlat BorderThickness="1" BorderColor="#18181B"/>
+            <gfx:StyleBoxFlat BorderThickness="2" BorderColor="#18181B" BackgroundColor="#25252a"/>
         </PanelContainer.PanelOverride>
-        <BoxContainer Orientation="Vertical">
+        <BoxContainer Orientation="Vertical" Margin="4 4 4 4">
             <Label Name="PlayerNameLabel"/>
             <Label Name="IdLabel"/>
             <Label Name="TypeLabel"/>

--- a/Content.Server/Administration/BanPanelEui.cs
+++ b/Content.Server/Administration/BanPanelEui.cs
@@ -131,13 +131,12 @@ public sealed class BanPanelEui : BaseEui
         }
 
         if (erase &&
-            targetUid != null &&
-            _playerManager.TryGetSessionById(targetUid.Value, out var targetPlayer))
+            targetUid != null)
         {
             try
             {
                 if (_entities.TrySystem(out AdminSystem? adminSystem))
-                    adminSystem.Erase(targetPlayer);
+                    adminSystem.Erase(targetUid.Value);
             }
             catch (Exception e)
             {

--- a/Content.Server/Administration/BanPanelEui.cs
+++ b/Content.Server/Administration/BanPanelEui.cs
@@ -7,8 +7,9 @@ using Content.Server.EUI;
 using Content.Shared.Administration;
 using Content.Shared.Database;
 using Content.Shared.Eui;
-using Robust.Server.Player;
+using Content.Shared.Roles;
 using Robust.Shared.Network;
+using Robust.Shared.Prototypes;
 
 namespace Content.Server.Administration;
 
@@ -18,9 +19,9 @@ public sealed class BanPanelEui : BaseEui
     [Dependency] private readonly IEntityManager _entities = default!;
     [Dependency] private readonly ILogManager _log = default!;
     [Dependency] private readonly IPlayerLocator _playerLocator = default!;
-    [Dependency] private readonly IPlayerManager _playerManager = default!;
     [Dependency] private readonly IChatManager _chat = default!;
     [Dependency] private readonly IAdminManager _admins = default!;
+    [Dependency] private readonly IPrototypeManager _prototypeManager = default!;
 
     private readonly ISawmill _sawmill;
 
@@ -123,7 +124,14 @@ public sealed class BanPanelEui : BaseEui
             var now = DateTimeOffset.UtcNow;
             foreach (var role in roles)
             {
-                _banManager.CreateRoleBan(targetUid, target, Player.UserId, addressRange, targetHWid, role, minutes, severity, reason, now);
+                if (_prototypeManager.HasIndex<JobPrototype>(role))
+                {
+                    _banManager.CreateRoleBan(targetUid, target, Player.UserId, addressRange, targetHWid, role, minutes, severity, reason, now);
+                }
+                else
+                {
+                    _sawmill.Warning($"{Player.Name} ({Player.UserId}) tried to issue a job ban with an invalid job: {role}");
+                }
             }
 
             Close();

--- a/Content.Server/Administration/Commands/EraseCommand.cs
+++ b/Content.Server/Administration/Commands/EraseCommand.cs
@@ -1,0 +1,47 @@
+using System.Linq;
+using Content.Server.Administration.Systems;
+using Content.Shared.Administration;
+using Robust.Server.Player;
+using Robust.Shared.Console;
+
+namespace Content.Server.Administration.Commands;
+
+[AdminCommand(AdminFlags.Admin)]
+public sealed class EraseCommand : LocalizedEntityCommands
+{
+    [Dependency] private readonly IPlayerLocator _locator = default!;
+    [Dependency] private readonly IPlayerManager _players = default!;
+    [Dependency] private readonly AdminSystem _admin = default!;
+
+    public override string Command => "erase";
+
+    public override async void Execute(IConsoleShell shell, string argStr, string[] args)
+    {
+        if (args.Length != 1)
+        {
+            shell.WriteError(Loc.GetString("cmd-erase-invalid-args"));
+            shell.WriteLine(Help);
+            return;
+        }
+
+        var located = await _locator.LookupIdByNameOrIdAsync(args[0]);
+
+        if (located == null)
+        {
+            shell.WriteError(Loc.GetString("cmd-erase-player-not-found"));
+            return;
+        }
+
+        _admin.Erase(located.UserId);
+    }
+
+    public override CompletionResult GetCompletion(IConsoleShell shell, string[] args)
+    {
+        if (args.Length != 1)
+            return CompletionResult.Empty;
+
+        var options = _players.Sessions.OrderBy(c => c.Name).Select(c => c.Name).ToArray();
+
+        return CompletionResult.FromHintOptions(options, Loc.GetString("cmd-erase-player-completion"));
+    }
+}

--- a/Content.Server/Administration/Systems/AdminSystem.cs
+++ b/Content.Server/Administration/Systems/AdminSystem.cs
@@ -16,7 +16,9 @@ using Content.Shared.GameTicking;
 using Content.Shared.Hands.Components;
 using Content.Shared.IdentityManagement;
 using Content.Shared.Inventory;
+using Content.Shared.Mind;
 using Content.Shared.PDA;
+using Content.Shared.Players;
 using Content.Shared.Players.PlayTimeTracking;
 using Content.Shared.Popups;
 using Content.Shared.Roles;
@@ -383,35 +385,37 @@ namespace Content.Server.Administration.Systems
         ///     chat messages and showing a popup to other players.
         ///     Their items are dropped on the ground.
         /// </summary>
-        public void Erase(ICommonSession player)
+        public void Erase(NetUserId uid)
         {
-            var entity = player.AttachedEntity;
-            _chat.DeleteMessagesBy(player);
+            _chat.DeleteMessagesBy(uid);
 
-            if (entity != null && !TerminatingOrDeleted(entity.Value))
+            if (!_minds.TryGetMind(uid, out var mindId, out var mind) || mind.OwnedEntity == null || TerminatingOrDeleted(mind.OwnedEntity.Value))
+                return;
+
+            var entity = mind.OwnedEntity.Value;
+
+            if (TryComp(entity, out TransformComponent? transform))
             {
-                if (TryComp(entity.Value, out TransformComponent? transform))
-                {
-                    var coordinates = _transform.GetMoverCoordinates(entity.Value, transform);
-                    var name = Identity.Entity(entity.Value, EntityManager);
-                    _popup.PopupCoordinates(Loc.GetString("admin-erase-popup", ("user", name)), coordinates, PopupType.LargeCaution);
-                    var filter = Filter.Pvs(coordinates, 1, EntityManager, _playerManager);
-                    var audioParams = new AudioParams().WithVolume(3);
-                    _audio.PlayStatic("/Audio/DeltaV/Misc/reducedtoatmos.ogg", filter, coordinates, true, audioParams);
-                }
+                var coordinates = _transform.GetMoverCoordinates(entity, transform);
+                var name = Identity.Entity(entity, EntityManager);
+                _popup.PopupCoordinates(Loc.GetString("admin-erase-popup", ("user", name)), coordinates, PopupType.LargeCaution);
+                var filter = Filter.Pvs(coordinates, 1, EntityManager, _playerManager);
+                var audioParams = new AudioParams().WithVolume(3);
+                _audio.PlayStatic("/Audio/Effects/pop_high.ogg", filter, coordinates, true, audioParams);
+            }
 
-                foreach (var item in _inventory.GetHandOrInventoryEntities(entity.Value))
+            foreach (var item in _inventory.GetHandOrInventoryEntities(entity))
+            {
+                if (TryComp(item, out PdaComponent? pda) &&
+                    TryComp(pda.ContainedId, out StationRecordKeyStorageComponent? keyStorage) &&
+                    keyStorage.Key is { } key &&
+                    _stationRecords.TryGetRecord(key, out GeneralStationRecord? record))
                 {
-                    if (TryComp(item, out PdaComponent? pda) &&
-                        TryComp(pda.ContainedId, out StationRecordKeyStorageComponent? keyStorage) &&
-                        keyStorage.Key is { } key &&
-                        _stationRecords.TryGetRecord(key, out GeneralStationRecord? record))
+                    if (TryComp(entity, out DnaComponent? dna) &&
+                        dna.DNA != record.DNA)
                     {
-                        if (TryComp(entity, out DnaComponent? dna) &&
-                            dna.DNA != record.DNA)
-                        {
-                            continue;
-                        }
+                        continue;
+                    }
 
                         if (TryComp(entity, out FingerprintComponent? fingerPrint) &&
                             fingerPrint.Fingerprint != record.Fingerprint)
@@ -424,28 +428,32 @@ namespace Content.Server.Administration.Systems
                     }
                 }
 
-                if (_inventory.TryGetContainerSlotEnumerator(entity.Value, out var enumerator))
+            if (_inventory.TryGetContainerSlotEnumerator(entity, out var enumerator))
+            {
+                while (enumerator.NextItem(out var item, out var slot))
                 {
-                    while (enumerator.NextItem(out var item, out var slot))
-                    {
-                        if (_inventory.TryUnequip(entity.Value, entity.Value, slot.Name, true, true))
-                            _physics.ApplyAngularImpulse(item, ThrowingSystem.ThrowAngularImpulse);
-                    }
-                }
-
-                if (TryComp(entity.Value, out HandsComponent? hands))
-                {
-                    foreach (var hand in _hands.EnumerateHands(entity.Value, hands))
-                    {
-                        _hands.TryDrop(entity.Value, hand, checkActionBlocker: false, doDropInteraction: false, handsComp: hands);
-                    }
+                    if (_inventory.TryUnequip(entity, entity, slot.Name, true, true))
+                        _physics.ApplyAngularImpulse(item, ThrowingSystem.ThrowAngularImpulse);
                 }
             }
 
-            _minds.WipeMind(player);
+            if (TryComp(entity, out HandsComponent? hands))
+            {
+                foreach (var hand in _hands.EnumerateHands(entity, hands))
+                {
+                    _hands.TryDrop(entity, hand, checkActionBlocker: false, doDropInteraction: false, handsComp: hands);
+                }
+            }
+
+            _minds.WipeMind(mindId, mind);
             QueueDel(entity);
 
-            _gameTicker.SpawnObserver(player);
+            if (_playerManager.TryGetSessionById(uid, out var session))
+                _gameTicker.SpawnObserver(session);
         }
+
+    private void OnSessionPlayTimeUpdated(ICommonSession session)
+    {
+        UpdatePlayerList(session);
     }
 }

--- a/Content.Server/Administration/Systems/AdminSystem.cs
+++ b/Content.Server/Administration/Systems/AdminSystem.cs
@@ -77,8 +77,7 @@ namespace Content.Server.Administration.Systems
             Subs.CVar(_config, CCVars.PanicBunkerEnabled, OnPanicBunkerChanged, true);
             Subs.CVar(_config, CCVars.PanicBunkerDisableWithAdmins, OnPanicBunkerDisableWithAdminsChanged, true);
             Subs.CVar(_config, CCVars.PanicBunkerEnableWithoutAdmins, OnPanicBunkerEnableWithoutAdminsChanged, true);
-            Subs.CVar(
-                _config, CCVars.PanicBunkerCountDeadminnedAdmins, OnPanicBunkerCountDeadminnedAdminsChanged, true);
+            Subs.CVar(_config, CCVars.PanicBunkerCountDeadminnedAdmins, OnPanicBunkerCountDeadminnedAdminsChanged, true);
             Subs.CVar(_config, CCVars.PanicBunkerShowReason, OnShowReasonChanged, true);
             Subs.CVar(_config, CCVars.PanicBunkerMinAccountAge, OnPanicBunkerMinAccountAgeChanged, true);
             Subs.CVar(_config, CCVars.PanicBunkerMinOverallHours, OnPanicBunkerMinOverallHoursChanged, true);

--- a/Content.Server/Administration/Systems/AdminSystem.cs
+++ b/Content.Server/Administration/Systems/AdminSystem.cs
@@ -77,7 +77,8 @@ namespace Content.Server.Administration.Systems
             Subs.CVar(_config, CCVars.PanicBunkerEnabled, OnPanicBunkerChanged, true);
             Subs.CVar(_config, CCVars.PanicBunkerDisableWithAdmins, OnPanicBunkerDisableWithAdminsChanged, true);
             Subs.CVar(_config, CCVars.PanicBunkerEnableWithoutAdmins, OnPanicBunkerEnableWithoutAdminsChanged, true);
-            Subs.CVar(_config, CCVars.PanicBunkerCountDeadminnedAdmins, OnPanicBunkerCountDeadminnedAdminsChanged, true);
+            Subs.CVar(
+                _config, CCVars.PanicBunkerCountDeadminnedAdmins, OnPanicBunkerCountDeadminnedAdminsChanged, true);
             Subs.CVar(_config, CCVars.PanicBunkerShowReason, OnShowReasonChanged, true);
             Subs.CVar(_config, CCVars.PanicBunkerMinAccountAge, OnPanicBunkerMinAccountAgeChanged, true);
             Subs.CVar(_config, CCVars.PanicBunkerMinOverallHours, OnPanicBunkerMinOverallHoursChanged, true);
@@ -249,17 +250,20 @@ namespace Content.Server.Administration.Systems
                 overallPlaytime = playTime;
             }
 
-            return new PlayerInfo(name, entityName, identityName, startingRole, antag, GetNetEntity(session?.AttachedEntity), data.UserId,
+            return new PlayerInfo(
+                name, entityName, identityName, startingRole, antag, GetNetEntity(session?.AttachedEntity), data.UserId,
                 connected, _roundActivePlayers.Contains(data.UserId), overallPlaytime);
         }
 
         private void OnPanicBunkerChanged(bool enabled)
         {
             PanicBunker.Enabled = enabled;
-            _chat.SendAdminAlert(Loc.GetString(enabled
-                ? "admin-ui-panic-bunker-enabled-admin-alert"
-                : "admin-ui-panic-bunker-disabled-admin-alert"
-            ));
+            _chat.SendAdminAlert(
+                Loc.GetString(
+                    enabled
+                        ? "admin-ui-panic-bunker-enabled-admin-alert"
+                        : "admin-ui-panic-bunker-disabled-admin-alert"
+                ));
 
             SendPanicBunkerStatusAll();
         }
@@ -267,10 +271,12 @@ namespace Content.Server.Administration.Systems
         private void OnBabyJailChanged(bool enabled)
         {
             BabyJail.Enabled = enabled;
-            _chat.SendAdminAlert(Loc.GetString(enabled
-                ? "admin-ui-baby-jail-enabled-admin-alert"
-                : "admin-ui-baby-jail-disabled-admin-alert"
-            ));
+            _chat.SendAdminAlert(
+                Loc.GetString(
+                    enabled
+                        ? "admin-ui-baby-jail-enabled-admin-alert"
+                        : "admin-ui-baby-jail-disabled-admin-alert"
+                ));
 
             SendBabyJailStatusAll();
         }
@@ -389,7 +395,8 @@ namespace Content.Server.Administration.Systems
         {
             _chat.DeleteMessagesBy(uid);
 
-            if (!_minds.TryGetMind(uid, out var mindId, out var mind) || mind.OwnedEntity == null || TerminatingOrDeleted(mind.OwnedEntity.Value))
+            if (!_minds.TryGetMind(uid, out var mindId, out var mind) || mind.OwnedEntity == null ||
+                TerminatingOrDeleted(mind.OwnedEntity.Value))
                 return;
 
             var entity = mind.OwnedEntity.Value;
@@ -398,7 +405,8 @@ namespace Content.Server.Administration.Systems
             {
                 var coordinates = _transform.GetMoverCoordinates(entity, transform);
                 var name = Identity.Entity(entity, EntityManager);
-                _popup.PopupCoordinates(Loc.GetString("admin-erase-popup", ("user", name)), coordinates, PopupType.LargeCaution);
+                _popup.PopupCoordinates(
+                    Loc.GetString("admin-erase-popup", ("user", name)), coordinates, PopupType.LargeCaution);
                 var filter = Filter.Pvs(coordinates, 1, EntityManager, _playerManager);
                 var audioParams = new AudioParams().WithVolume(3);
                 _audio.PlayStatic("/Audio/Effects/pop_high.ogg", filter, coordinates, true, audioParams);
@@ -417,16 +425,16 @@ namespace Content.Server.Administration.Systems
                         continue;
                     }
 
-                        if (TryComp(entity, out FingerprintComponent? fingerPrint) &&
-                            fingerPrint.Fingerprint != record.Fingerprint)
-                        {
-                            continue;
-                        }
-
-                        _stationRecords.RemoveRecord(key);
-                        Del(item);
+                    if (TryComp(entity, out FingerprintComponent? fingerPrint) &&
+                        fingerPrint.Fingerprint != record.Fingerprint)
+                    {
+                        continue;
                     }
+
+                    _stationRecords.RemoveRecord(key);
+                    Del(item);
                 }
+            }
 
             if (_inventory.TryGetContainerSlotEnumerator(entity, out var enumerator))
             {
@@ -452,8 +460,9 @@ namespace Content.Server.Administration.Systems
                 _gameTicker.SpawnObserver(session);
         }
 
-    private void OnSessionPlayTimeUpdated(ICommonSession session)
-    {
-        UpdatePlayerList(session);
+        private void OnSessionPlayTimeUpdated(ICommonSession session)
+        {
+            UpdatePlayerList(session);
+        }
     }
 }

--- a/Content.Server/Administration/Systems/AdminVerbSystem.cs
+++ b/Content.Server/Administration/Systems/AdminVerbSystem.cs
@@ -34,11 +34,11 @@ using Robust.Shared.Timing;
 using Robust.Shared.Toolshed;
 using Robust.Shared.Utility;
 using System.Linq;
-using System.Numerics;
 using Content.Server.Silicons.Laws;
 using Content.Shared.Silicons.Laws;
 using Content.Shared.Silicons.Laws.Components;
 using Robust.Server.Player;
+using Content.Shared.Mind;
 using Robust.Shared.Physics.Components;
 using static Content.Shared.Configurable.ConfigurationComponent;
 
@@ -137,87 +137,6 @@ namespace Content.Server.Administration.Systems
                     prayerVerb.Impact = LogImpact.Low;
                     args.Verbs.Add(prayerVerb);
 
-                    // Freeze
-                    var frozen = TryComp<AdminFrozenComponent>(args.Target, out var frozenComp);
-                    var frozenAndMuted = frozenComp?.Muted ?? false;
-
-                    if (!frozen)
-                    {
-                        args.Verbs.Add(new Verb
-                        {
-                            Priority = -1, // This is just so it doesn't change position in the menu between freeze/unfreeze.
-                            Text = Loc.GetString("admin-verbs-freeze"),
-                            Category = VerbCategory.Admin,
-                            Icon = new SpriteSpecifier.Texture(new ("/Textures/Interface/VerbIcons/snow.svg.192dpi.png")),
-                            Act = () =>
-                            {
-                                EnsureComp<AdminFrozenComponent>(args.Target);
-                            },
-                            Impact = LogImpact.Medium,
-                        });
-                    }
-
-                    if (!frozenAndMuted)
-                    {
-                        // allow you to additionally mute someone when they are already frozen
-                        args.Verbs.Add(new Verb
-                        {
-                            Priority = -1, // This is just so it doesn't change position in the menu between freeze/unfreeze.
-                            Text = Loc.GetString("admin-verbs-freeze-and-mute"),
-                            Category = VerbCategory.Admin,
-                            Icon = new SpriteSpecifier.Texture(new ("/Textures/Interface/VerbIcons/snow.svg.192dpi.png")),
-                            Act = () =>
-                            {
-                                _freeze.FreezeAndMute(args.Target);
-                            },
-                            Impact = LogImpact.Medium,
-                        });
-                    }
-
-                    if (frozen)
-                    {
-                        args.Verbs.Add(new Verb
-                        {
-                            Priority = -1, // This is just so it doesn't change position in the menu between freeze/unfreeze.
-                            Text = Loc.GetString("admin-verbs-unfreeze"),
-                            Category = VerbCategory.Admin,
-                            Icon = new SpriteSpecifier.Texture(new ("/Textures/Interface/VerbIcons/snow.svg.192dpi.png")),
-                            Act = () =>
-                            {
-                                RemComp<AdminFrozenComponent>(args.Target);
-                            },
-                            Impact = LogImpact.Medium,
-                        });
-                    }
-
-                    // Erase
-                    args.Verbs.Add(new Verb
-                    {
-                        Text = Loc.GetString("admin-verbs-erase"),
-                        Message = Loc.GetString("admin-verbs-erase-description"),
-                        Category = VerbCategory.Admin,
-                        Icon = new SpriteSpecifier.Texture(new("/Textures/Interface/VerbIcons/delete_transparent.svg.192dpi.png")),
-                        Act = () =>
-                        {
-                            _adminSystem.Erase(targetActor.PlayerSession);
-                        },
-                        Impact = LogImpact.Extreme,
-                        ConfirmationPopup = true
-                    });
-
-                // Respawn
-                    args.Verbs.Add(new Verb()
-                    {
-                        Text = Loc.GetString("admin-player-actions-respawn"),
-                        Category = VerbCategory.Admin,
-                        Act = () =>
-                        {
-                            _console.ExecuteCommand(player, $"respawn {targetActor.PlayerSession.Name}");
-                        },
-                        ConfirmationPopup = true,
-                        // No logimpact as the command does it internally.
-                    });
-
                     // Spawn - Like respawn but on the spot.
                     args.Verbs.Add(new Verb()
                     {
@@ -239,7 +158,7 @@ namespace Content.Server.Administration.Systems
 
                             if (targetMind != null)
                             {
-                                _mindSystem.TransferTo(targetMind.Value, mobUid);
+                                _mindSystem.TransferTo(targetMind.Value, mobUid, true);
                             }
                         },
                         ConfirmationPopup = true,
@@ -277,6 +196,92 @@ namespace Content.Server.Administration.Systems
                         Impact = LogImpact.Low
                     });
                 }
+
+                if (_mindSystem.TryGetMind(args.Target, out _, out var mind) && mind.UserId != null)
+                {
+                    // Erase
+                    args.Verbs.Add(new Verb
+                    {
+                        Text = Loc.GetString("admin-verbs-erase"),
+                        Message = Loc.GetString("admin-verbs-erase-description"),
+                        Category = VerbCategory.Admin,
+                        Icon = new SpriteSpecifier.Texture(
+                            new("/Textures/Interface/VerbIcons/delete_transparent.svg.192dpi.png")),
+                        Act = () =>
+                        {
+                            _adminSystem.Erase(mind.UserId.Value);
+                        },
+                        Impact = LogImpact.Extreme,
+                        ConfirmationPopup = true
+                    });
+
+                    // Respawn
+                    args.Verbs.Add(new Verb
+                    {
+                        Text = Loc.GetString("admin-player-actions-respawn"),
+                        Category = VerbCategory.Admin,
+                        Act = () =>
+                        {
+                            _console.ExecuteCommand(player, $"respawn \"{mind.UserId}\"");
+                        },
+                        ConfirmationPopup = true,
+                        // No logimpact as the command does it internally.
+                    });
+                }
+
+                // Freeze
+                var frozen = TryComp<AdminFrozenComponent>(args.Target, out var frozenComp);
+                var frozenAndMuted = frozenComp?.Muted ?? false;
+
+                if (!frozen)
+                {
+                    args.Verbs.Add(new Verb
+                    {
+                        Priority = -1, // This is just so it doesn't change position in the menu between freeze/unfreeze.
+                        Text = Loc.GetString("admin-verbs-freeze"),
+                        Category = VerbCategory.Admin,
+                        Icon = new SpriteSpecifier.Texture(new ("/Textures/Interface/VerbIcons/snow.svg.192dpi.png")),
+                        Act = () =>
+                        {
+                            EnsureComp<AdminFrozenComponent>(args.Target);
+                        },
+                        Impact = LogImpact.Medium,
+                    });
+                }
+
+                if (!frozenAndMuted)
+                {
+                    // allow you to additionally mute someone when they are already frozen
+                    args.Verbs.Add(new Verb
+                    {
+                        Priority = -1, // This is just so it doesn't change position in the menu between freeze/unfreeze.
+                        Text = Loc.GetString("admin-verbs-freeze-and-mute"),
+                        Category = VerbCategory.Admin,
+                        Icon = new SpriteSpecifier.Texture(new ("/Textures/Interface/VerbIcons/snow.svg.192dpi.png")),
+                        Act = () =>
+                        {
+                            _freeze.FreezeAndMute(args.Target);
+                        },
+                        Impact = LogImpact.Medium,
+                    });
+                }
+
+                if (frozen)
+                {
+                    args.Verbs.Add(new Verb
+                    {
+                        Priority = -1, // This is just so it doesn't change position in the menu between freeze/unfreeze.
+                        Text = Loc.GetString("admin-verbs-unfreeze"),
+                        Category = VerbCategory.Admin,
+                        Icon = new SpriteSpecifier.Texture(new ("/Textures/Interface/VerbIcons/snow.svg.192dpi.png")),
+                        Act = () =>
+                        {
+                            RemComp<AdminFrozenComponent>(args.Target);
+                        },
+                        Impact = LogImpact.Medium,
+                    });
+                }
+
 
                 // Admin Logs
                 if (_adminManager.HasAdminFlag(player, AdminFlags.Logs))

--- a/Content.Server/Chat/Managers/ChatManager.cs
+++ b/Content.Server/Chat/Managers/ChatManager.cs
@@ -82,9 +82,9 @@ namespace Content.Server.Chat.Managers
             DispatchServerAnnouncement(Loc.GetString(val ? "chat-manager-admin-ooc-chat-enabled-message" : "chat-manager-admin-ooc-chat-disabled-message"));
         }
 
-        public void DeleteMessagesBy(ICommonSession player)
+        public void DeleteMessagesBy(NetUserId uid)
         {
-            if (!_players.TryGetValue(player.UserId, out var user))
+            if (!_players.TryGetValue(uid, out var user))
                 return;
 
             var msg = new MsgDeleteChatMessagesBy { Key = user.Key, Entities = user.Entities };

--- a/Content.Server/Chat/Managers/IChatManager.cs
+++ b/Content.Server/Chat/Managers/IChatManager.cs
@@ -36,7 +36,7 @@ namespace Content.Server.Chat.Managers
 
         bool MessageCharacterLimit(ICommonSession player, string message);
 
-        void DeleteMessagesBy(ICommonSession player);
+        void DeleteMessagesBy(NetUserId uid);
 
         [return: NotNullIfNotNull(nameof(author))]
         ChatUser? EnsurePlayer(NetUserId? author);

--- a/Content.Server/GameTicking/Commands/RespawnCommand.cs
+++ b/Content.Server/GameTicking/Commands/RespawnCommand.cs
@@ -1,4 +1,6 @@
-using Content.Shared.Mind;
+using System.Linq;
+using Content.Server.Administration;
+using Content.Server.Mind;
 using Content.Shared.Players;
 using Robust.Server.Player;
 using Robust.Shared.Console;
@@ -6,57 +8,72 @@ using Robust.Shared.Network;
 
 namespace Content.Server.GameTicking.Commands
 {
-    sealed class RespawnCommand : IConsoleCommand
+    sealed class RespawnCommand : LocalizedEntityCommands
     {
-        public string Command => "respawn";
-        public string Description => "Respawns a player, kicking them back to the lobby.";
-        public string Help => "respawn [player]";
+        [Dependency] private readonly IPlayerManager _player = default!;
+        [Dependency] private readonly IPlayerLocator _locator = default!;
+        [Dependency] private readonly GameTicker _gameTicker = default!;
+        [Dependency] private readonly MindSystem _mind = default!;
 
-        public void Execute(IConsoleShell shell, string argStr, string[] args)
+        public override string Command => "respawn";
+
+        public override async void Execute(IConsoleShell shell, string argStr, string[] args)
         {
             var player = shell.Player;
             if (args.Length > 1)
             {
-                shell.WriteLine("Must provide <= 1 argument.");
+                shell.WriteError(Loc.GetString("cmd-respawn-invalid-args"));
                 return;
             }
-
-            var playerMgr = IoCManager.Resolve<IPlayerManager>();
-            var sysMan = IoCManager.Resolve<IEntitySystemManager>();
-            var ticker = sysMan.GetEntitySystem<GameTicker>();
-            var mind = sysMan.GetEntitySystem<SharedMindSystem>();
 
             NetUserId userId;
             if (args.Length == 0)
             {
                 if (player == null)
                 {
-                    shell.WriteLine("If not a player, an argument must be given.");
+                    shell.WriteError(Loc.GetString("cmd-respawn-no-player"));
                     return;
                 }
 
                 userId = player.UserId;
             }
-            else if (!playerMgr.TryGetUserId(args[0], out userId))
+            else
             {
-                shell.WriteLine("Unknown player");
-                return;
-            }
+                var located = await _locator.LookupIdByNameOrIdAsync(args[0]);
 
-            if (!playerMgr.TryGetSessionById(userId, out var targetPlayer))
-            {
-                if (!playerMgr.TryGetPlayerData(userId, out var data))
+                if (located == null)
                 {
-                    shell.WriteLine("Unknown player");
+                    shell.WriteError(Loc.GetString("cmd-respawn-unknown-player"));
                     return;
                 }
 
-                mind.WipeMind(data.ContentData()?.Mind);
-                shell.WriteLine("Player is not currently online, but they will respawn if they come back online");
+                userId = located.UserId;
+            }
+
+            if (!_player.TryGetSessionById(userId, out var targetPlayer))
+            {
+                if (!_player.TryGetPlayerData(userId, out var data))
+                {
+                    shell.WriteError(Loc.GetString("cmd-respawn-unknown-player"));
+                    return;
+                }
+
+                _mind.WipeMind(data.ContentData()?.Mind);
+                shell.WriteError(Loc.GetString("cmd-respawn-player-not-online"));
                 return;
             }
 
-            ticker.Respawn(targetPlayer);
+            _gameTicker.Respawn(targetPlayer);
+        }
+
+      public override CompletionResult GetCompletion(IConsoleShell shell, string[] args)
+        {
+            if (args.Length != 1)
+                return CompletionResult.Empty;
+
+            var options = _player.Sessions.OrderBy(c => c.Name).Select(c => c.Name).ToArray();
+
+            return CompletionResult.FromHintOptions(options, Loc.GetString("cmd-respawn-player-completion"));
         }
     }
 }

--- a/Content.Server/Ghost/GhostSystem.cs
+++ b/Content.Server/Ghost/GhostSystem.cs
@@ -194,7 +194,10 @@ namespace Content.Server.Ghost
             component.TimeOfDeath = time;
 
             _actions.AddAction(uid, ref component.BooActionEntity, component.BooAction);
-            _actions.AddAction(uid, ref component.ToggleGhostHearingActionEntity, component.ToggleGhostHearingAction);
+            if (HasComp<GhostHearingComponent>(uid)) // Floof - M3739 - TaskAcumen-II | Restrict normal ghosts from hearing everything
+            {
+                _actions.AddAction(uid, ref component.ToggleGhostHearingActionEntity, component.ToggleGhostHearingAction);
+            }
             _actions.AddAction(uid, ref component.ToggleLightingActionEntity, component.ToggleLightingAction);
             _actions.AddAction(uid, ref component.ToggleFoVActionEntity, component.ToggleFoVAction);
             _actions.AddAction(uid, ref component.ToggleGhostsActionEntity, component.ToggleGhostsAction);

--- a/Content.Server/Ghost/GhostSystem.cs
+++ b/Content.Server/Ghost/GhostSystem.cs
@@ -194,7 +194,7 @@ namespace Content.Server.Ghost
             component.TimeOfDeath = time;
 
             _actions.AddAction(uid, ref component.BooActionEntity, component.BooAction);
-            if (HasComp<GhostHearingComponent>(uid)) // Floof - M3739 - TaskAcumen-II | Restrict normal ghosts from hearing everything
+            if (HasComp<GhostHearingComponent>(uid)) // Floof - M3739 - #1300 | Restrict normal ghosts from hearing everything
             {
                 _actions.AddAction(uid, ref component.ToggleGhostHearingActionEntity, component.ToggleGhostHearingAction);
             }

--- a/Content.Server/Traits/TraitSystem.cs
+++ b/Content.Server/Traits/TraitSystem.cs
@@ -116,15 +116,15 @@ public sealed class TraitSystem : EntitySystem
             return;
 
         // For maximum comedic effect, this is plenty of time for the cheater to get on station and start interacting with people.
-        var timeToDestroy = _random.NextFloat(120, 360);
+        /*var timeToDestroy = _random.NextFloat(120, 360);
 
-        Timer.Spawn(TimeSpan.FromSeconds(timeToDestroy), () => VaporizeCheater(targetPlayer));
+        Timer.Spawn(TimeSpan.FromSeconds(timeToDestroy), () => VaporizeCheater(targetPlayer));*/
     }
 
     /// <summary>
     ///     https://www.youtube.com/watch?v=X2QMN0a_TrA
     /// </summary>
-    private void VaporizeCheater (Robust.Shared.Player.ICommonSession targetPlayer)
+    /*private void VaporizeCheater (Robust.Shared.Player.ICommonSession targetPlayer)
     {
         _adminSystem.Erase(targetPlayer);
 
@@ -136,5 +136,6 @@ public sealed class TraitSystem : EntitySystem
             EntityUid.Invalid,
             false,
             targetPlayer.Channel);
-    }
+    }*/
+    // Floof - M3739 - TaskAcumen-II | I don't feel like modernizing this bit to use TargetUID due to changes to Erase.
 }

--- a/Content.Server/Traits/TraitSystem.cs
+++ b/Content.Server/Traits/TraitSystem.cs
@@ -136,6 +136,5 @@ public sealed class TraitSystem : EntitySystem
             EntityUid.Invalid,
             false,
             targetPlayer.Channel);
-    }*/
-    // Floof - M3739 - TaskAcumen-II | I don't feel like modernizing this bit to use TargetUID due to changes to Erase.
+    }
 }

--- a/Content.Server/Traits/TraitSystem.cs
+++ b/Content.Server/Traits/TraitSystem.cs
@@ -116,17 +116,19 @@ public sealed class TraitSystem : EntitySystem
             return;
 
         // For maximum comedic effect, this is plenty of time for the cheater to get on station and start interacting with people.
-        /*var timeToDestroy = _random.NextFloat(120, 360);
-
-        Timer.Spawn(TimeSpan.FromSeconds(timeToDestroy), () => VaporizeCheater(targetPlayer));*/
+        var timeToDestroy = _random.NextFloat(120, 360);
+        
+        Timer.Spawn(TimeSpan.FromSeconds(timeToDestroy), () => VaporizeCheater(targetPlayer));
     }
 
     /// <summary>
     ///     https://www.youtube.com/watch?v=X2QMN0a_TrA
     /// </summary>
-    /*private void VaporizeCheater (Robust.Shared.Player.ICommonSession targetPlayer)
+    private void VaporizeCheater (Robust.Shared.Player.ICommonSession targetPlayer)
     {
-        _adminSystem.Erase(targetPlayer);
+        // Floof - M3739 | Get NetUserID of the targetPlayer.
+        var targetUser = targetPlayer.UserId; 
+        _adminSystem.Erase(targetUser);
 
         var feedbackMessage = $"[font size=24][color=#ff0000]{"You have spawned in with an illegal trait point total. If this was a result of cheats, then your nonexistence is a skill issue. Otherwise, feel free to click 'Return To Lobby', and fix your trait selections."}[/color][/font]";
         _chatManager.ChatMessageToOne(

--- a/Resources/Locale/en-US/administration/commands/erase.ftl
+++ b/Resources/Locale/en-US/administration/commands/erase.ftl
@@ -1,0 +1,7 @@
+# erase
+cmd-erase-desc = Erase a player's entity if it exists and all their chat messages
+cmd-erase-help = erase <Username of User Id>
+cmd-erase-invalid-args = Invalid number of arguments
+cmd-erase-player-not-found = Player not found
+
+cmd-erase-player-completion = <Username>

--- a/Resources/Locale/en-US/administration/commands/respawn.ftl
+++ b/Resources/Locale/en-US/administration/commands/respawn.ftl
@@ -1,0 +1,9 @@
+cmd-respawn-desc = Respawns a player, kicking them back to the lobby.
+cmd-respawn-help = respawn [player or UserId]
+
+cmd-respawn-invalid-args = Must provide <= 1 argument.
+cmd-respawn-no-player = If not a player, an argument must be given.
+cmd-respawn-unknown-player = Unknown player
+cmd-respawn-player-not-online = Player is not currently online, but they will respawn if they come back online
+
+cmd-respawn-player-completion = <Username>

--- a/Resources/Prototypes/Entities/Mobs/Player/observer.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/observer.yml
@@ -58,7 +58,7 @@
   - type: Examiner
     skipChecks: true
   - type: Ghost
-  - type: GhostHearing
+#  - type: GhostHearing | Floof - M3739 - TaskAcumen-II | Restrict normal ghosts from hearing everything
   - type: IntrinsicRadioReceiver
   - type: ActiveRadio
     receiveAllChannels: true

--- a/Resources/Prototypes/Entities/Mobs/Player/observer.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/observer.yml
@@ -58,7 +58,7 @@
   - type: Examiner
     skipChecks: true
   - type: Ghost
-#  - type: GhostHearing | Floof - M3739 - TaskAcumen-II | Restrict normal ghosts from hearing everything
+#  - type: GhostHearing | Floof - M3739 - #1300 | Restrict normal ghosts from hearing everything
   - type: IntrinsicRadioReceiver
   - type: ActiveRadio
     receiveAllChannels: true


### PR DESCRIPTION
<!--
This is a semi-strict format, you can add/remove sections as needed but the order/format should be kept the same
Remove these comments before submitting
-->

# Description

<!--
Explain this PR in as much detail as applicable

Some example prompts to consider:
How might this affect the game? The codebase?
What might be some alternatives to this?
How/Who does this benefit/hurt [the game/codebase]?
-->

On today's episode of wrestling my mind to do what I need to do:

This PR aims to address concerns and requests in the administrative sense, primarily concerning ghost hearing, and a bug regarding the note line popup.

This is achieved by cherry-picking Wizden 29909 for the bug fix, and by removing the `GhostHearing` component, along with a check to see if the component exists before adding the action associated with it.

Wizden 30433 and 35422 was cherry-picked as well in preparation for the much later goal of porting the Antag Ban PR from Wizden. This also changes the erase and respawn verbs to be used on offline players, and sanitizes the admin UI input so it doesn't crash the debug environment. This can be removed upon request.

---

<!--
This is default collapsed, readers click to expand it and see all your media
The PR media section can get very large at times, so this is a good way to keep it clean
The title is written using HTML tags
The title must be within the <summary> tags or you won't see it
-->

<details><summary><h1>Media</h1></summary>
<p>

<img width="531" height="451" alt="image" src="https://github.com/user-attachments/assets/f810d28d-1209-4699-888c-6257059b003e" />
<img width="609" height="280" alt="image" src="https://github.com/user-attachments/assets/3c48f4ad-2d41-4d75-904b-1c8295615ad0" />

Attempting to perform a job ban for Antags, which currently do not work, will instead throw the following error instead of crashing the debug server:
<img width="1037" height="259" alt="image" src="https://github.com/user-attachments/assets/d519d380-55a8-4507-a0b1-3274fa6b325b" />

</p>
</details>

---

# Changelog

<!--
You can add an author after the `:cl:` to change the name that appears in the changelog (ex: `:cl: Death`)
Leaving it blank will default to your GitHub display name
This includes all available types for the changelog
-->

:cl:
ADMIN:

- fix: Respawn verb is now available on players even after they have disconnected.
- fix: Erase command is now available on players even after they have disconnected.
- add: You can now erase people with the erase command
- tweak: Respawn command now also accepts user ids

