### PR TITLE
Antag Advantage Removal

### DIFF
--- a/Resources/Prototypes/DeltaV/Roles/Jobs/Justice/clerk.yml
+++ b/Resources/Prototypes/DeltaV/Roles/Jobs/Justice/clerk.yml
@@ -3,7 +3,6 @@
   name: job-name-clerk
   description: job-description-clerk
   playTimeTracker: JobClerk
-  antagAdvantage: 2
   requirements:
     - !type:CharacterDepartmentTimeRequirement
       department: Security

--- a/Resources/Prototypes/Roles/Jobs/Cargo/cargo_technician.yml
+++ b/Resources/Prototypes/Roles/Jobs/Cargo/cargo_technician.yml
@@ -3,7 +3,6 @@
   name: job-name-cargotech
   description: job-description-cargotech
   playTimeTracker: JobCargoTechnician
-  antagAdvantage: 2 # DeltaV - Reduced TC: External Access
   startingGear: CargoTechGear
   icon: "JobIconCargoTechnician"
   supervisors: job-supervisors-qm

--- a/Resources/Prototypes/Roles/Jobs/Cargo/quartermaster.yml
+++ b/Resources/Prototypes/Roles/Jobs/Cargo/quartermaster.yml
@@ -3,7 +3,6 @@
   name: job-name-qm
   description: job-description-qm
   playTimeTracker: JobQuartermaster
-  antagAdvantage: 6 # DeltaV - Reduced TC: Head of Staff
   requirements:
   #  - !type:RoleTimeRequirement #DeltaV
   #    role: JobCargoTechnician

--- a/Resources/Prototypes/Roles/Jobs/Cargo/salvage_specialist.yml
+++ b/Resources/Prototypes/Roles/Jobs/Cargo/salvage_specialist.yml
@@ -3,7 +3,6 @@
   name: job-name-salvagespec
   description: job-description-salvagespec
   playTimeTracker: JobSalvageSpecialist
-  antagAdvantage: 3 # DeltaV - Reduced TC: External Access + Free hardsuit and weapons
   icon: "JobIconShaftMiner"
   startingGear: SalvageSpecialistGear
   supervisors: job-supervisors-qm

--- a/Resources/Prototypes/Roles/Jobs/Civilian/assistant.yml
+++ b/Resources/Prototypes/Roles/Jobs/Civilian/assistant.yml
@@ -3,7 +3,6 @@
   name: job-name-passenger
   description: job-description-passenger
   playTimeTracker: JobPassenger
-  antagAdvantage: -5 # Floof - No Access and a dream
   startingGear: PassengerGear
   icon: "JobIconPassenger"
   supervisors: job-supervisors-everyone

--- a/Resources/Prototypes/Roles/Jobs/Civilian/assistant.yml
+++ b/Resources/Prototypes/Roles/Jobs/Civilian/assistant.yml
@@ -3,6 +3,7 @@
   name: job-name-passenger
   description: job-description-passenger
   playTimeTracker: JobPassenger
+  antagAdvantage: -5 # Floof - No Access and a dream
   startingGear: PassengerGear
   icon: "JobIconPassenger"
   supervisors: job-supervisors-everyone

--- a/Resources/Prototypes/Roles/Jobs/Civilian/lawyer.yml
+++ b/Resources/Prototypes/Roles/Jobs/Civilian/lawyer.yml
@@ -3,7 +3,6 @@
   name: job-name-lawyer
   description: job-description-lawyer
   playTimeTracker: JobLawyer
-  antagAdvantage: 2 # DeltaV - Reduced TC: Security Radio and Access
   startingGear: LawyerGear
   icon: "JobIconLawyer"
   supervisors: job-supervisors-cj  # Delta V - Change supervisor to chief justice

--- a/Resources/Prototypes/Roles/Jobs/Civilian/service_worker.yml
+++ b/Resources/Prototypes/Roles/Jobs/Civilian/service_worker.yml
@@ -7,7 +7,6 @@
   icon: "JobIconServiceWorker"
   supervisors: job-supervisors-service
   canBeAntag: true # DeltaV - Can be antagonist
-  antagAdvantage: 1 # DeltaV - Reduced TC: Accesses
   access:
   - Service
   - Maintenance

--- a/Resources/Prototypes/Roles/Jobs/Command/head_of_personnel.yml
+++ b/Resources/Prototypes/Roles/Jobs/Command/head_of_personnel.yml
@@ -3,7 +3,6 @@
   name: job-name-hop
   description: job-description-hop
   playTimeTracker: JobHeadOfPersonnel
-  antagAdvantage: 6 # DeltaV - Reduced TC: Head of Staff
   requirements:
     - !type:CharacterDepartmentTimeRequirement # DeltaV - Civilian dept time requirement
       department: Civilian

--- a/Resources/Prototypes/Roles/Jobs/Engineering/atmospheric_technician.yml
+++ b/Resources/Prototypes/Roles/Jobs/Engineering/atmospheric_technician.yml
@@ -7,7 +7,6 @@
   - !type:CharacterDepartmentTimeRequirement
     department: Engineering
     min: 3600 # Floofstation - 1 hour
-  antagAdvantage: 5 # Floof - Reduced TC: External Access + Fireaxe + Free Hardsuit, but they cannot pump chemicals into the air supply en masse.
   startingGear: AtmosphericTechnicianGear
   icon: "JobIconAtmosphericTechnician"
   supervisors: job-supervisors-ce
@@ -28,3 +27,4 @@
   innerClothingSkirt: ClothingUniformJumpskirtAtmos
   satchel: ClothingBackpackSatchelEngineeringFilled
   duffelbag: ClothingBackpackDuffelEngineeringFilled
+

--- a/Resources/Prototypes/Roles/Jobs/Engineering/senior_engineer.yml
+++ b/Resources/Prototypes/Roles/Jobs/Engineering/senior_engineer.yml
@@ -8,7 +8,6 @@
     - !type:CharacterDepartmentTimeRequirement
       department: Engineering
       min: 144000 # Floofstation 40 hrs
-  antagAdvantage: 3 # Floof - Reduced TC: External Access + Engineering
   startingGear: SeniorEngineerGear
   icon: "JobIconSeniorEngineer"
   supervisors: job-supervisors-ce

--- a/Resources/Prototypes/Roles/Jobs/Engineering/station_engineer.yml
+++ b/Resources/Prototypes/Roles/Jobs/Engineering/station_engineer.yml
@@ -6,7 +6,6 @@
   requirements:
   - !type:CharacterOverallTimeRequirement
     min: 14400 # 4hr floof
-  antagAdvantage: 3 # DeltaV - Reduced TC: External Access + Engineering
   startingGear: StationEngineerGear
   icon: "JobIconStationEngineer"
   supervisors: job-supervisors-ce

--- a/Resources/Prototypes/Roles/Jobs/Engineering/technical_assistant.yml
+++ b/Resources/Prototypes/Roles/Jobs/Engineering/technical_assistant.yml
@@ -6,7 +6,6 @@
   requirements:
   - !type:CharacterOverallTimeRequirement
     min: 3600 # 1hr floof
-  antagAdvantage: 3 # DeltaV - Reduced TC: External Access + Engineering
   startingGear: TechnicalAssistantGear
   icon: "JobIconTechnicalAssistant"
   supervisors: job-supervisors-engineering

--- a/Resources/Prototypes/Roles/Jobs/Medical/chief_medical_officer.yml
+++ b/Resources/Prototypes/Roles/Jobs/Medical/chief_medical_officer.yml
@@ -5,7 +5,6 @@
   name: job-name-cmo
   description: job-description-cmo
   playTimeTracker: JobChiefMedicalOfficer
-  antagAdvantage: 6 # DeltaV - Reduced TC: Head of Staff
   requirements:
     - !type:CharacterDepartmentTimeRequirement
       department: Medical

--- a/Resources/Prototypes/Roles/Jobs/Medical/paramedic.yml
+++ b/Resources/Prototypes/Roles/Jobs/Medical/paramedic.yml
@@ -3,7 +3,6 @@
   name: job-name-paramedic
   description: job-description-paramedic
   playTimeTracker: JobParamedic
-  antagAdvantage: 2 # DeltaV - Reduced TC: External Access
   startingGear: ParamedicGear
   icon: "JobIconParamedic"
   supervisors: job-supervisors-cmo

--- a/Resources/Prototypes/Roles/Jobs/Science/research_director.yml
+++ b/Resources/Prototypes/Roles/Jobs/Science/research_director.yml
@@ -3,7 +3,6 @@
   name: job-name-rd
   description: job-description-rd
   playTimeTracker: JobResearchDirector
-  antagAdvantage: 6 # DeltaV - Reduced TC: Head of Staff
   requirements:
     - !type:CharacterDepartmentTimeRequirement
       department: Epistemics # DeltaV - Epistemics Department replacing Science

--- a/Resources/Prototypes/_Floof/Roles/Jobs/Logi/inventory_specialist.yml
+++ b/Resources/Prototypes/_Floof/Roles/Jobs/Logi/inventory_specialist.yml
@@ -8,7 +8,6 @@
     - !type:CharacterDepartmentTimeRequirement
       department: Logistics
       min: 57600 #16 hours
-  antagAdvantage: 2 # DeltaV - Reduced TC: External Access
   startingGear: InvSpecGear
   icon: "JobIconInventorySpecialist"
   supervisors: job-supervisors-qm


### PR DESCRIPTION
# Description
Follows Upstream and Removes Antag Advantage. All are equal, (except tiders who play like the dark souls wretch opening).

The change log says, "All men are created equal; it is our habits that make us different."

# Changelog
:cl:
- tweak: 人人生而平等, 正是我们的习惯让我们与众不同。(editor's note: this means all jobs will now receive the same amount of TC when chosen to be traitors)