### PR TITLE
Canister+

### DIFF
--- a/Resources/Prototypes/_Floof/Catalog/Cargo/cargo_atmospherics.yml
+++ b/Resources/Prototypes/_Floof/Catalog/Cargo/cargo_atmospherics.yml
@@ -27,3 +27,23 @@
   cost: 20000
   category: cargoproduct-category-name-atmospherics
   group: market
+
+- type: cargoProduct
+  id: AtmosphericsLargeStorage
+  icon:
+    sprite: Structures/Storage/canister.rsi
+    state: yellow
+  product: LargeStorageCanister
+  cost: 2100
+  category: cargoproduct-category-name-atmospherics
+  group: market
+
+- type: cargoProduct
+  id: AtmosphericsSuperLargeStorage
+  icon:
+    sprite: Structures/Storage/canister.rsi
+    state: yellow
+  product: SuperLargeStorageCanister
+  cost: 6000
+  category: cargoproduct-category-name-atmospherics
+  group: market 

--- a/Resources/Prototypes/_Floof/Entities/Structures/Storage/Canisters/gas_canisters.yml
+++ b/Resources/Prototypes/_Floof/Entities/Structures/Storage/Canisters/gas_canisters.yml
@@ -65,3 +65,43 @@
           - 0 # Ammonia
           - 5610.51315 # N2O
         temperature: 72
+
+- type: entity
+  parent: StorageCanister
+  id: LargeStorageCanister
+  name: large storage canister
+  components:
+    - type: GasCanister
+      gasMixture:
+        volume: 2000
+        moles: # List of gasses for easy reference
+          - 0 # oxygen
+          - 0 # nitrogen
+          - 0 # CO2
+          - 0 # Plasma
+          - 0 # Tritium
+          - 0 # Water vapor
+          - 0 # Ammonia
+          - 0 # N2O
+          - 0 # Frezon
+        temperature: 293.15
+
+- type: entity
+  parent: StorageCanister
+  id: SuperLargeStorageCanister
+  name: super large storage canister
+  components:
+    - type: GasCanister
+      gasMixture:
+        volume: 5000
+        moles: # List of gasses for easy reference
+          - 0 # oxygen
+          - 0 # nitrogen
+          - 0 # CO2
+          - 0 # Plasma
+          - 0 # Tritium
+          - 0 # Water vapor
+          - 0 # Ammonia
+          - 0 # N2O
+          - 0 # Frezon
+        temperature: 293.15

--- a/Resources/Prototypes/_Floof/Entities/Structures/Storage/Canisters/gas_canisters.yml
+++ b/Resources/Prototypes/_Floof/Entities/Structures/Storage/Canisters/gas_canisters.yml
@@ -94,14 +94,5 @@
     - type: GasCanister
       gasMixture:
         volume: 5000
-        moles: # List of gasses for easy reference
-          - 0 # oxygen
-          - 0 # nitrogen
-          - 0 # CO2
-          - 0 # Plasma
-          - 0 # Tritium
-          - 0 # Water vapor
-          - 0 # Ammonia
-          - 0 # N2O
-          - 0 # Frezon
+        moles: []
         temperature: 293.15

--- a/Resources/Prototypes/_Floof/Entities/Structures/Storage/Canisters/gas_canisters.yml
+++ b/Resources/Prototypes/_Floof/Entities/Structures/Storage/Canisters/gas_canisters.yml
@@ -74,16 +74,7 @@
     - type: GasCanister
       gasMixture:
         volume: 2000
-        moles: # List of gasses for easy reference
-          - 0 # oxygen
-          - 0 # nitrogen
-          - 0 # CO2
-          - 0 # Plasma
-          - 0 # Tritium
-          - 0 # Water vapor
-          - 0 # Ammonia
-          - 0 # N2O
-          - 0 # Frezon
+        moles: []
         temperature: 293.15
 
 - type: entity


### PR DESCRIPTION
# Description
Adds a double capacity Storage Canister and a super 5 times capacity storage canister to purchase.

Why?
Honestly, I kinda want to see if an atmos tech can completely fill the super one with Frezon and see the price.
# Changelog
:cl:
- add: Added larger storage canisters.
