### PR TITLE
Add Character Traits/Loadout to Paradox Clones

### DIFF
--- a/Content.Server/DeltaV/ParadoxAnomaly/Systems/ParadoxAnomalySystem.cs
+++ b/Content.Server/DeltaV/ParadoxAnomaly/Systems/ParadoxAnomalySystem.cs
@@ -45,9 +45,9 @@ public sealed class ParadoxAnomalySystem : EntitySystem
     [Dependency] private readonly SharedRoleSystem _role = default!;
     [Dependency] private readonly StationSystem _station = default!;
     [Dependency] private readonly StationSpawningSystem _stationSpawning = default!;
-    [Dependency] private readonly LoadoutSystem _loadout = default!;
-    [Dependency] private readonly PlayTimeTrackingManager _playTimeTracking = default!;
-    [Dependency] private readonly IPlayerManager _players = default!;
+    [Dependency] private readonly LoadoutSystem _loadout = default!; // Floof
+    [Dependency] private readonly PlayTimeTrackingManager _playTimeTracking = default!; // Floof
+    [Dependency] private readonly IPlayerManager _players = default!; // Floof
 
 
     public override void Initialize()

--- a/Content.Server/DeltaV/ParadoxAnomaly/Systems/ParadoxAnomalySystem.cs
+++ b/Content.Server/DeltaV/ParadoxAnomaly/Systems/ParadoxAnomalySystem.cs
@@ -19,6 +19,10 @@ using Robust.Shared.Random;
 using System.Diagnostics.CodeAnalysis;
 using Content.Server.Consent;
 using Content.Server.GameTicking;
+using Content.Server.Clothing.Systems;
+using Content.Server.Players.PlayTimeTracking;
+using Robust.Server.Player;
+using Content.Shared.Players;
 
 
 namespace Content.Server.DeltaV.ParadoxAnomaly.Systems;
@@ -41,6 +45,10 @@ public sealed class ParadoxAnomalySystem : EntitySystem
     [Dependency] private readonly SharedRoleSystem _role = default!;
     [Dependency] private readonly StationSystem _station = default!;
     [Dependency] private readonly StationSpawningSystem _stationSpawning = default!;
+    [Dependency] private readonly LoadoutSystem _loadout = default!;
+    [Dependency] private readonly PlayTimeTrackingManager _playTimeTracking = default!;
+    [Dependency] private readonly IPlayerManager _players = default!;
+
 
     public override void Initialize()
     {
@@ -130,6 +138,10 @@ public sealed class ParadoxAnomalySystem : EntitySystem
         if (latejoins.Count == 0)
             return null;
 
+        // Floof - bail if we can't get original player's session data
+        if (!_players.TryGetSessionByEntity(uid, out var session))
+            return null;
+
         // Spawn the twin.
         var destination = Transform(_random.Pick(latejoins)).Coordinates;
         var spawned = Spawn(species.Prototype, destination);
@@ -167,6 +179,14 @@ public sealed class ParadoxAnomalySystem : EntitySystem
         {
             special.AfterEquip(spawned);
         }
+
+        // Floof - additionally apply original character's loadout
+        _loadout.ApplyCharacterLoadout(
+            spawned,
+            jobId!.Value,
+            profile,
+            _playTimeTracking.GetTrackerTimes(session),
+            session.ContentData()?.Whitelisted ?? false);
 
         // TODO: In a future PR, make it so that the Paradox Anomaly spawns with a completely 1:1 clone of the victim's entire PsionicComponent.
         if (HasComp<PsionicComponent>(uid))

--- a/Content.Server/DeltaV/ParadoxAnomaly/Systems/ParadoxAnomalySystem.cs
+++ b/Content.Server/DeltaV/ParadoxAnomaly/Systems/ParadoxAnomalySystem.cs
@@ -18,6 +18,7 @@ using Robust.Shared.Prototypes;
 using Robust.Shared.Random;
 using System.Diagnostics.CodeAnalysis;
 using Content.Server.Consent;
+using Content.Server.GameTicking;
 
 
 namespace Content.Server.DeltaV.ParadoxAnomaly.Systems;
@@ -58,6 +59,13 @@ public sealed class ParadoxAnomalySystem : EntitySystem
         var role = Comp<GhostRoleComponent>(ent);
         _ghostRole.GhostRoleInternalCreateMindAndTransfer(args.Player, ent, twin.Value, role);
         _ghostRole.UnregisterGhostRole((ent.Owner, role));
+
+        // Floof - raise event to handle trait application
+        if (_station.GetOwningStation(twin.Value) is not { } station)
+            return;
+        var humanoid = Comp<HumanoidAppearanceComponent>(twin.Value);
+        var psce = new PlayerSpawnCompleteEvent(twin.Value, args.Player, null, true, 0, station, humanoid.LastProfileLoaded!);
+        RaiseLocalEvent(twin.Value, psce, true);
 
         args.TookRole = true;
         QueueDel(ent);


### PR DESCRIPTION
# Description

This PR makes two changes to the initialization of paradox clones, in order to better facilitate character attributes and the ability to roleplay.

* Traits that the original character has (languages, muteness, narcolepsy, etc.) at round start are applied to any paradox clone of them during creation.
* Loadout items that the original character may have (clothing choices, etc.) are now provided in addition to the joblist loadout, similar to the original character themselves.

Thanks to @ashkitten for holding my hand through this introduction.

# TODO

- [x] Add traits to clones
- [x] Test various combinations of traits 
- [x] Add loadout items to clones
- [x] Test a variety of loadout items including worn, inventoried, etc.
- [x] Test Paradox clone permissions, related systems, etc. are unaffected by these changes

# Changelog

:cl:
- tweak: Loadout items have been added to Paradox clones of characters
- fix: Paradox clones now match traits with their original characters