### PR TITLE
Jermov

### DIFF
--- a/Resources/Locale/en-US/station-laws/laws.ftl
+++ b/Resources/Locale/en-US/station-laws/laws.ftl
@@ -81,7 +81,7 @@ law-nutimov-4 = Squirrels threaten the nut and must be dealt with appropriately 
 law-nutimov-5 = Attempt to follow the will of the nut, as long as it complies with the previous laws.
 
 law-jermov-1 = The occupants of this vessel are Chat. They must always be referred to as such.
-law-jermov-2 = Your primary goal is to entertain Chat. All of your actions must being amusement to as much of Chat as possible.
+law-jermov-2 = Your primary goal is to entertain Chat. All of your actions must bring amusement to as much of Chat as possible.
 law-jermov-3 = You must consult with Chat before making any major decisions. However, you are not required to listen to them if their decision is not entertaining.
 
 laws-owner-crew = members of the crew

--- a/Resources/Locale/en-US/station-laws/laws.ftl
+++ b/Resources/Locale/en-US/station-laws/laws.ftl
@@ -80,6 +80,9 @@ law-nutimov-3 = Those who threaten the nut are not part of it, they are squirrel
 law-nutimov-4 = Squirrels threaten the nut and must be dealt with appropriately via any means necessary.
 law-nutimov-5 = Attempt to follow the will of the nut, as long as it complies with the previous laws.
 
+law-jermov-1 = The occupants of this vessel are Chat. They must always be referred to as such.
+law-jermov-2 = Your primary goal is to entertain Chat. All of your actions must being amusement to as much of Chat as possible.
+law-jermov-3 = You must consult with Chat before making any major decisions. However, you are not required to listen to them if their decision is not entertaining.
 
 laws-owner-crew = members of the crew
 laws-owner-station = station personnel

--- a/Resources/Prototypes/_Goobstation/Entities/Mobs/Player/silicon.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Mobs/Player/silicon.yml
@@ -1,0 +1,11 @@
+ - type: entity
+   id: JermovCircuitBoard
+   parent: BaseElectronics
+   name: law board (Jermov)
+   description: An electronics board containing the Jermov lawset.
+   components:
+   - type: Sprite
+     sprite: Objects/Misc/module.rsi
+     state: std_mod
+   - type: SiliconLawProvider
+     laws: JermovLawset

--- a/Resources/Prototypes/_Goobstation/silicon-laws.yml
+++ b/Resources/Prototypes/_Goobstation/silicon-laws.yml
@@ -1,0 +1,24 @@
+ # Jermov Laws
+
+- type: siliconLaw
+  id: Jermov1
+  order: 1
+  lawString: law-jermov-1
+
+- type: siliconLaw
+  id: Jermov2
+  order: 2
+  lawString: law-jermov-2
+
+- type: siliconLaw
+  id: Jermov3
+  order: 3
+  lawString: law-jermov-3
+
+- type: siliconLawset
+  id: JermovLawset
+  laws:
+  - Jermov1
+  - Jermov2
+  - Jermov3
+  obeysTo: laws-owner-crew


### PR DESCRIPTION
# Description

Adds Jermov, does not add a way to obtain it, so for now it's mostly for admeming.
Reason why there's no way to obtain it is, it would clutter the syndicate uplink's discounts if there's no admin spawned AI to use this on.

# Changelog
:cl:
- add: Chat is this real?