### PR TITLE
Fix Slime Person Tags

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/Species/slime.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/slime.yml
@@ -132,6 +132,9 @@
   - type: Tag #floof
     tags:
     - SlimeEmotes
+    - CanPilot # Floof - M3739 - TaskAdjust-V | Fix Tags
+    - FootstepSound
+    - DoorBumpOpener
 
 - type: entity
   parent: MobHumanDummy

--- a/Resources/Prototypes/Entities/Mobs/Species/slime.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/slime.yml
@@ -132,7 +132,7 @@
   - type: Tag #floof
     tags:
     - SlimeEmotes
-    - CanPilot # Floof - M3739 - TaskAdjust-V | Fix Tags
+    - CanPilot # Floof - M3739 - 1307 | Fix Tags
     - FootstepSound
     - DoorBumpOpener
 


### PR DESCRIPTION
<!--
This is a semi-strict format, you can add/remove sections as needed but the order/format should be kept the same
Remove these comments before submitting
-->

# Description

<!--
Explain this PR in as much detail as applicable

Some example prompts to consider:
How might this affect the game? The codebase?
What might be some alternatives to this?
How/Who does this benefit/hurt [the game/codebase]?
-->

This PR aims to give Slime People back their tags which was overwritten by a recent PR dealing with them.

---

# Changelog

<!--
You can add an author after the `:cl:` to change the name that appears in the changelog (ex: `:cl: Death`)
Leaving it blank will default to your GitHub display name
This includes all available types for the changelog
-->

:cl:
- fix: Slime people are once again, certified to pilot, and registered by door sensors.