### PR TITLE
Partial Reversion of #1221

### DIFF
--- a/Content.Server/Chat/Systems/ChatSystem.cs
+++ b/Content.Server/Chat/Systems/ChatSystem.cs
@@ -1010,8 +1010,6 @@ public sealed partial class ChatSystem : SharedChatSystem
             newMessage = SanitizeMessageCapital(newMessage);
         if (capitalizeTheWordI)
             newMessage = SanitizeMessageCapitalizeTheWordI(newMessage, "i");
-        if (numbersAsWords) // Floof
-            newMessage = SanitizeMessageNumbersAsWords(newMessage);
         if (punctuate)
             newMessage = SanitizeMessagePeriod(newMessage);
 

--- a/Content.Shared/Chat/SharedChatSystem.cs
+++ b/Content.Shared/Chat/SharedChatSystem.cs
@@ -1,6 +1,5 @@
 using System.Collections.Frozen;
 using System.Text.RegularExpressions;
-using Content.Shared.Localizations;
 using Content.Shared.Popups;
 using Content.Shared.Radio;
 using Content.Shared.Speech;
@@ -194,16 +193,6 @@ public abstract class SharedChatSystem : EntitySystem
         }
 
         return message;
-    }
-
-    private static readonly Regex NumberRegex = new(@"-?\d+(\.\d+)?");
-    // Floof
-    public string SanitizeMessageNumbersAsWords(string message)
-    {
-        if (string.IsNullOrEmpty(message))
-            return message;
-
-        return NumberRegex.Replace(message, match => ContentLocalizationManager.FormatNumberWords(match.Value));
     }
 
     public static string SanitizeAnnouncement(string message, int maxLength = 0, int maxNewlines = 2)

--- a/Content.Shared/Localizations/ContentLocalizationManager.cs
+++ b/Content.Shared/Localizations/ContentLocalizationManager.cs
@@ -230,7 +230,6 @@ namespace Content.Shared.Localizations
 
             return new LocValueString(res);
         }
-        
         // Floof
         private static readonly string[] ZeroToNineteen =
         [

--- a/Content.Shared/Localizations/ContentLocalizationManager.cs
+++ b/Content.Shared/Localizations/ContentLocalizationManager.cs
@@ -47,6 +47,7 @@ namespace Content.Shared.Localizations
 
             _loc.AddFunction(cultureEn, "MAKEPLURAL", FormatMakePlural);
             _loc.AddFunction(cultureEn, "MANY", FormatMany);
+            _loc.AddFunction(cultureEn, "NUMBER-WORDS", FormatNumberWords); // Floof
         }
 
         private ILocValue FormatMany(LocArgs args)
@@ -229,5 +230,97 @@ namespace Content.Shared.Localizations
 
             return new LocValueString(res);
         }
+        
+        // Floof
+        private static readonly string[] ZeroToNineteen =
+        [
+            "zero", "one", "two", "three", "four", "five", "six", "seven", "eight", "nine",
+            "ten", "eleven", "twelve", "thirteen", "fourteen", "fifteen", "sixteen", "seventeen", "eighteen", "nineteen"
+        ];
+
+        private static readonly string[] TwentyToNinety =
+        [
+            "twenty", "thirty", "forty", "fifty", "sixty", "seventy", "eighty", "ninety"
+        ];
+
+        // each is 10^x starting with x=3 and incrementing by 3
+        private static readonly string[] LargeNumberNames =
+        [
+            "thousand",
+            "million",
+            "billion",
+            "trillion",
+            "quadrillion",
+            "quintillion",
+            "sextillion",
+            "septillion",
+            "octillion",
+            "nonillion",
+            "decillion",
+            "undecillion",
+            "duodecillion",
+            "tredecillion",
+            "quattuordecillion",
+            "quindecillion",
+            "sexdecillion",
+            "septendecillion",
+            "octodecillion",
+            "novemdecillion",
+            "vigintillion"
+        ];
+
+        // HEAVILY adapted from https://stackoverflow.com/a/18493408
+        // rewritten entirely with string handling functions because BigInteger isn't allowed in sandbox...
+        private static string IntToEnglishText(string n, bool isFirst = false)
+        {
+            n = n.TrimStart('0');
+            string result;
+            if(isFirst && n == "")
+                result = "zero";
+            else if(n.StartsWith("-"))
+                result = "negative " + IntToEnglishText(n[1..]);
+            else if(n == "")
+                result = "";
+            else if(n.Length == 1)
+                result = ZeroToNineteen[int.Parse(n)] + " ";
+            else if(n.Length == 2 && n.StartsWith('1'))
+                result = ZeroToNineteen[int.Parse(n)] + (isFirst ? null : " ");
+            else if(n.Length == 2)
+                result = TwentyToNinety[int.Parse(n) / 10 - 2] + (n[1] != '0' ? "-" + IntToEnglishText(n[1].ToString()) : null);
+            else if(n.Length == 3)
+                result = IntToEnglishText(n[0].ToString()) + "hundred " + (n[1..3] != "00" ? "and " + IntToEnglishText(n[1..3]) : null);
+            else if (n.Length <= 6 + 3 * LargeNumberNames.Length)
+            {
+                var divRem = Math.DivRem(n.Length, 3);
+                if (divRem.Remainder == 0)
+                {
+                    divRem.Remainder = 3;
+                    divRem.Quotient -= 1;
+                }
+                result = IntToEnglishText(n[..divRem.Remainder]) + LargeNumberNames[divRem.Quotient - 1] + ", " +
+                    IntToEnglishText(n[divRem.Remainder..]);
+            }
+            else
+                result = n; // if it's bigger than 999 vigintillion, just fucking bail
+            if(isFirst)
+                result = result.Trim();
+            return result;
+        }
+
+        public static string FormatNumberWords(string number)
+        {
+            var parts = number.Split(".");
+            var result = IntToEnglishText(parts[0], true);
+            if (parts.TryGetValue(1, out var fractional))
+            {
+                result += " point";
+                foreach (var digit in fractional)
+                    result += " " + ZeroToNineteen[int.Parse(digit.ToString())];
+            }
+            return result;
+        }
+
+        private static ILocValue FormatNumberWords(LocArgs args) =>
+            new LocValueString(FormatNumberWords(args.Args[0].Value!.ToString()!));
     }
 }

--- a/Content.Shared/Localizations/ContentLocalizationManager.cs
+++ b/Content.Shared/Localizations/ContentLocalizationManager.cs
@@ -47,7 +47,6 @@ namespace Content.Shared.Localizations
 
             _loc.AddFunction(cultureEn, "MAKEPLURAL", FormatMakePlural);
             _loc.AddFunction(cultureEn, "MANY", FormatMany);
-            _loc.AddFunction(cultureEn, "NUMBER-WORDS", FormatNumberWords); // Floof
         }
 
         private ILocValue FormatMany(LocArgs args)
@@ -230,97 +229,5 @@ namespace Content.Shared.Localizations
 
             return new LocValueString(res);
         }
-
-        // Floof
-        private static readonly string[] ZeroToNineteen =
-        [
-            "zero", "one", "two", "three", "four", "five", "six", "seven", "eight", "nine",
-            "ten", "eleven", "twelve", "thirteen", "fourteen", "fifteen", "sixteen", "seventeen", "eighteen", "nineteen"
-        ];
-
-        private static readonly string[] TwentyToNinety =
-        [
-            "twenty", "thirty", "forty", "fifty", "sixty", "seventy", "eighty", "ninety"
-        ];
-
-        // each is 10^x starting with x=3 and incrementing by 3
-        private static readonly string[] LargeNumberNames =
-        [
-            "thousand",
-            "million",
-            "billion",
-            "trillion",
-            "quadrillion",
-            "quintillion",
-            "sextillion",
-            "septillion",
-            "octillion",
-            "nonillion",
-            "decillion",
-            "undecillion",
-            "duodecillion",
-            "tredecillion",
-            "quattuordecillion",
-            "quindecillion",
-            "sexdecillion",
-            "septendecillion",
-            "octodecillion",
-            "novemdecillion",
-            "vigintillion"
-        ];
-
-        // HEAVILY adapted from https://stackoverflow.com/a/18493408
-        // rewritten entirely with string handling functions because BigInteger isn't allowed in sandbox...
-        private static string IntToEnglishText(string n, bool isFirst = false)
-        {
-            n = n.TrimStart('0');
-            string result;
-            if(isFirst && n == "")
-                result = "zero";
-            else if(n.StartsWith("-"))
-                result = "negative " + IntToEnglishText(n[1..]);
-            else if(n == "")
-                result = "";
-            else if(n.Length == 1)
-                result = ZeroToNineteen[int.Parse(n)] + " ";
-            else if(n.Length == 2 && n.StartsWith('1'))
-                result = ZeroToNineteen[int.Parse(n)] + (isFirst ? null : " ");
-            else if(n.Length == 2)
-                result = TwentyToNinety[int.Parse(n) / 10 - 2] + (n[1] != '0' ? "-" + IntToEnglishText(n[1].ToString()) : null);
-            else if(n.Length == 3)
-                result = IntToEnglishText(n[0].ToString()) + "hundred " + (n[1..3] != "00" ? "and " + IntToEnglishText(n[1..3]) : null);
-            else if (n.Length <= 6 + 3 * LargeNumberNames.Length)
-            {
-                var divRem = Math.DivRem(n.Length, 3);
-                if (divRem.Remainder == 0)
-                {
-                    divRem.Remainder = 3;
-                    divRem.Quotient -= 1;
-                }
-                result = IntToEnglishText(n[..divRem.Remainder]) + LargeNumberNames[divRem.Quotient - 1] + ", " +
-                    IntToEnglishText(n[divRem.Remainder..]);
-            }
-            else
-                result = n; // if it's bigger than 999 vigintillion, just fucking bail
-            if(isFirst)
-                result = result.Trim();
-            return result;
-        }
-
-        public static string FormatNumberWords(string number)
-        {
-            var parts = number.Split(".");
-            var result = IntToEnglishText(parts[0], true);
-            if (parts.TryGetValue(1, out var fractional))
-            {
-                result += " point";
-                foreach (var digit in fractional)
-                    result += " " + ZeroToNineteen[int.Parse(digit.ToString())];
-            }
-            return result;
-        }
-
-        private static ILocValue FormatNumberWords(LocArgs args) =>
-            new LocValueString(FormatNumberWords(args.Args[0].Value!.ToString()!));
     }
 }

--- a/Resources/Changelog/Floof.yml
+++ b/Resources/Changelog/Floof.yml
@@ -7350,8 +7350,6 @@ Entries:
   changes:
     - type: Add
       message: People you're carrying will now show up in your examine popup.
-    - type: Add
-      message: Literal numbers in speech are now translated to words.
   id: 774
   time: '2025-08-10T00:37:45.0000000+00:00'
   url: https://github.com/Floof-Station/Floof-Station/pull/1221


### PR DESCRIPTION
<!--
This is a semi-strict format, you can add/remove sections as needed but the order/format should be kept the same
Remove these comments before submitting
-->

# Description

<!--
Explain this PR in as much detail as applicable

Some example prompts to consider:
How might this affect the game? The codebase?
What might be some alternatives to this?
How/Who does this benefit/hurt [the game/codebase]?
-->

This PR is a partial reversion of #1221, more specifically the `numbersAsWords` half of that PR. Various unintended effects led to a undue decease in the usability and functionality of systems relying on chat.

The changelog has also been revised to reflect this.

In hindsight, this was an oversight in the review and testing procedures, one I am to rectify for future operations, and one I take full responsibility for. Consider this my mistake.

---

<!--
This is default collapsed, readers click to expand it and see all your media
The PR media section can get very large at times, so this is a good way to keep it clean
The title is written using HTML tags
The title must be within the <summary> tags or you won't see it
-->

<details><summary><h1>Media</h1></summary>
<p>

<img width="428" height="339" alt="image" src="https://github.com/user-attachments/assets/afe00122-decf-4fec-9a26-18e4bfbfc03e" />

</p>
</details>

---

# Changelog

No CL.