### PR TITLE
Fix Subtles Not Displaying over Ones Head

### DIFF
--- a/Content.Client/UserInterface/Systems/Chat/ChatUIController.cs
+++ b/Content.Client/UserInterface/Systems/Chat/ChatUIController.cs
@@ -932,10 +932,12 @@ public sealed class ChatUIController : UIController
                 AddSpeechBubble(msg, SpeechBubble.SpeechType.Say);
                 break;
 
+            case ChatChannel.Subtle: // Floofstation
             case ChatChannel.Emotes:
                 AddSpeechBubble(msg, SpeechBubble.SpeechType.Emote);
                 break;
 
+            case ChatChannel.SubtleOOC: // Floofstation
             case ChatChannel.LOOC:
                 if (_config.GetCVar(CCVars.LoocAboveHeadShow))
                     AddSpeechBubble(msg, SpeechBubble.SpeechType.Looc);


### PR DESCRIPTION
# Description
I have no good words for this.
This is a cherry-pick of https://github.com/Vulpstation/Vulpstation/pull/56/commits/64cc0c7dae3911513e6cc564df389ad17c7d4e72

Why did the original author not do this? Why did they mark up the message instead of applying a popup style? Why are subtle OOC messages sent through the IC subtle function? So many questions, so little answers.

# Changelog
:cl:
- fix: Subtles and subtle OOC messages should now correctly display over the speaker's head.