### PR TITLE
Add Multilingual Traits

### DIFF
--- a/Resources/Locale/en-US/_Floof/traits/language-traits.ftl
+++ b/Resources/Locale/en-US/_Floof/traits/language-traits.ftl
@@ -104,3 +104,12 @@ trait-description-NaturalKagebun =
         To the uninitiated, it is a chorus of sounds ranging from eerie whispers to ritualistic chanting.
         To those who speak it, it is a living tongue that links them to the spirit world and their ancient pacts.
         Through some adaptation, augmentation or clever workaround, you speak this instead of your species's usual natural language.
+
+trait-name-Bilingual = Bilingual
+trait-description-Bilingual = By upbringing or by immersion, you've picked up more languages than most. You're able to speak two languages in addition to your native tongue.
+
+trait-name-Trilingual = Trilingual
+trait-description-Trilingual = You're well-traveled or had a very diverse upbringing. You're able to speak three languages in addition to your native tongue.
+
+trait-name-Quadrilingual = Quadrilingual
+trait-description-Quadrilingual = You've been to more places than you can count, and picked up more than a few languages along the way. You're able to speak four languages in addition to your native tongue.

--- a/Resources/Prototypes/CharacterItemGroups/Generic/languageGroups.yml
+++ b/Resources/Prototypes/CharacterItemGroups/Generic/languageGroups.yml
@@ -1,6 +1,6 @@
 - type: characterItemGroup
   id: TraitsLanguagesBasic
-  maxItems: 2
+  maxItems: 1
   items:
     - type: trait
       id: SignLanguage
@@ -39,6 +39,12 @@
       id: MonkeyLanguage
     - type: trait
       id: KoboldLanguage
+    - type: trait
+      id: Bilingual
+    - type: trait
+      id: Trilingual
+    - type: trait
+      id: Quadrilingual
     # Floof section end
 
 - type: characterItemGroup

--- a/Resources/Prototypes/_Floof/Traits/Languages/multilingual.yml
+++ b/Resources/Prototypes/_Floof/Traits/Languages/multilingual.yml
@@ -1,0 +1,28 @@
+- type: trait
+  id: Bilingual
+  category: TraitsSpeechLanguages
+  points: -1
+  slots: 0
+  itemGroupSlots: -1
+
+- type: trait
+  id: Trilingual
+  category: TraitsSpeechLanguages
+  points: -3
+  slots: 0
+  itemGroupSlots: -1
+  requirements:
+  - !type:CharacterTraitRequirement
+    traits:
+    - Bilingual
+
+- type: trait
+  id: Quadrilingual
+  category: TraitsSpeechLanguages
+  points: -5
+  slots: 0
+  itemGroupSlots: -1
+  requirements:
+  - !type:CharacterTraitRequirement
+    traits:
+    - Trilingual


### PR DESCRIPTION
# Description

Going off of the suggestion in https://github.com/Floof-Station/Floof-Station/pull/1279#issuecomment-3148903028, this PR adds the traits Bilingual, Trilingual, and Quadrilingual which cost 1, 3, and 5 points each. It reverts the base number of allowed languages to 1 like it was before, so has an effective impact of making any existing loadout that used two basic languages one point more expensive.

---

# TODO

- [ ] Bikeshed about names (is it really "bilingual" if it's in addition to your native language?
- [ ] Ensure that CharacterItemGroupRequirement isn't broken by this change (it shouldn't be, and seems to work just fine still)
- [ ] It's unfortunate that Bilingual is sorted before Natural Language traits but Trilingual/Quadrilingual are sorted after... For why?
- [ ] Gather feedback on how people might use these traits. Perhaps there should be a "polyglot" trait at the extreme of this which allows you to take any number of languages?

---

<details><summary><h1>Media</h1></summary>
<p>

<img width="447" height="685" alt="image" src="https://github.com/user-attachments/assets/869fd0bc-a0eb-4966-9f30-de4c914df77f" />

</p>
</details>

---

# Changelog

:cl:
- add: Add Bilingual, Trilingual, and Quadrilingual traits, allowing you to take more languages than ever before at the cost of your precious points.
- tweak: Revert basic language allotment to one, effectively increasing the cost of taking two basic languages by one point.