### PR TITLE
Security Cyborg Nerfs and Station Ai Fix

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/Cyborgs/base_borg_chassis.yml
+++ b/Resources/Prototypes/Entities/Mobs/Cyborgs/base_borg_chassis.yml
@@ -102,9 +102,10 @@
     doAfterDelay: 4
     allowSelfRepair: false
     damage: # Floofstation - don't just allow cyborgs to get insta-repaired. In turn the do-after is faster.
-      groups: # Those are all the damage types the silicon damage container supports
-        Brute: -8
-      types:
+      types: # Those are all the damage types the silicon damage container supports
+        Blunt: -8
+        Slash: -8
+        Piercing: -8
         Heat: -8
         Shock: -8
   - type: BorgChassis

--- a/Resources/Prototypes/Entities/Mobs/Cyborgs/base_borg_chassis.yml
+++ b/Resources/Prototypes/Entities/Mobs/Cyborgs/base_borg_chassis.yml
@@ -99,8 +99,14 @@
     - Science
   - type: ZombieImmune
   - type: Repairable
-    doAfterDelay: 10
+    doAfterDelay: 4
     allowSelfRepair: false
+    damage: # Floofstation - don't just allow cyborgs to get insta-repaired. In turn the do-after is faster.
+      groups: # Those are all the damage types the silicon damage container supports
+        Brute: -8
+      types:
+        Heat: -8
+        Shock: -8
   - type: BorgChassis
   - type: WiresPanel
   - type: ActivatableUIRequiresPanel

--- a/Resources/Prototypes/Recipes/Construction/Graphs/machines/cyborg.yml
+++ b/Resources/Prototypes/Recipes/Construction/Graphs/machines/cyborg.yml
@@ -205,7 +205,7 @@
 
       - tool: Screwing
         doAfter: 0.5
-        
+
     - to: Quadsalv
       steps:
       - assemblyId: quadsalv
@@ -232,7 +232,7 @@
 
       - tool: Screwing
         doAfter: 0.5
-        
+
     - to: Quadserv
       steps:
       - assemblyId: quadserv
@@ -259,7 +259,7 @@
 
       - tool: Screwing
         doAfter: 0.5
-    
+
     - to: Quadmed
       steps:
       - assemblyId: quadmed
@@ -286,22 +286,22 @@
 
       - tool: Screwing
         doAfter: 0.5
-        
+
   - node: Quadborg
-    entity: BorgChassisQuad
-    
+    entity: BorgChassisQuadSec
+
   - node: Quadsalv
     entity: BorgChassisQuadsalv
-    
+
   - node: Quadserv
     entity: BorgChassisQuadserv
-    
+
   - node: Quadmed
     entity: BorgChassisQuadmed
 
   - node: cyborg
     entity: BorgChassisGeneric
-    
+
   - node: engineer
     entity: BorgChassisEngineer
 

--- a/Resources/Prototypes/Roles/Jobs/departments.yml
+++ b/Resources/Prototypes/Roles/Jobs/departments.yml
@@ -125,7 +125,7 @@
   color: "#D381C9"
   roles:
   - Borg
-  - StationAi disabled until it is actually playable.
+  - StationAi
 
 # Floof section - Remove station-specific job pseudo-department
 #- type: department

--- a/Resources/Prototypes/Roles/Jobs/departments.yml
+++ b/Resources/Prototypes/Roles/Jobs/departments.yml
@@ -125,7 +125,7 @@
   color: "#D381C9"
   roles:
   - Borg
-#  - StationAi disabled until it is actually playable.
+  - StationAi disabled until it is actually playable.
 
 # Floof section - Remove station-specific job pseudo-department
 #- type: department

--- a/Resources/Prototypes/_Floof/Access/borg.yml
+++ b/Resources/Prototypes/_Floof/Access/borg.yml
@@ -1,0 +1,12 @@
+# For security borgs. Unlike most borgs, doesn't include the mini-AA because it's a game changer when chasing antags.
+- type: accessGroup
+  id: AllAccessSecurityBorg
+  tags:
+  - Security
+  - Detective
+  - Corpsman
+  - Lawyer
+  - Maintenance
+  - External
+  - Justice
+  - Prosecutor

--- a/Resources/Prototypes/_Floof/Entities/Mobs/Cyborgs/quadborg.yml
+++ b/Resources/Prototypes/_Floof/Entities/Mobs/Cyborgs/quadborg.yml
@@ -2,6 +2,31 @@
 - type: entity
   id: BorgChassisQuad
   parent: BaseBorgChassisNT
+  abstract: true
+  components:
+  - type: Stripping
+  - type: BorgTransponder
+    sprite:
+      sprite: _Floof/Mobs/Silicon/quad.rsi
+      state: quadsprite
+    name: cyborg
+  - type: Construction
+    node: cyborg
+  - type: Speech
+    speechVerb: Robotic
+  - type: LayingDown
+  - type: LeashAnchor
+  - type: GuideHelp
+    guides:
+    - Quadborgs
+    - Cyborgs
+  - type: FootstepModifier
+    footstepSoundCollection:
+      collection: FootstepQuadBorg
+
+- type: entity
+  id: BorgChassisQuadSec
+  parent: BorgChassisQuad
   components:
   - type: Sprite
     sprite: _Floof/Mobs/Silicon/quad.rsi
@@ -24,7 +49,6 @@
     noMovementLayers:
       movement:
         state: quadsprite
-  - type: Stripping
   - type: IntrinsicRadioTransmitter
     channels:
     - Security
@@ -51,27 +75,8 @@
     - AllAccessSecurityBorg
   - type: AccessReader
     access: [["Armory"], ["Command"]] # Only command and the warden can unlock it, not other borgs
-  - type: BorgTransponder
-    sprite:
-      sprite: _Floof/Mobs/Silicon/quad.rsi
-      state: quadsprite
-    name: cyborg
-  - type: Construction
-    node: cyborg
-  - type: Speech
-    speechVerb: Robotic
-  - type: LayingDown
   - type: SiliconLawProvider
     laws: Qborg
-  - type: LeashAnchor
-  - type: GuideHelp
-    guides:
-    - Quadborgs
-    - Cyborgs
-  - type: FootstepModifier
-    footstepSoundCollection:
-      collection: FootstepQuadBorg
-
 
 - type: entity
   id: BorgChassisQuadCC

--- a/Resources/Prototypes/_Floof/Entities/Mobs/Cyborgs/quadborg.yml
+++ b/Resources/Prototypes/_Floof/Entities/Mobs/Cyborgs/quadborg.yml
@@ -80,7 +80,7 @@
 
 - type: entity
   id: BorgChassisQuadCC
-  parent: BorgChassisQuad
+  parent: BorgChassisQuadSec
   components:
   - type: Sprite
     sprite: _Floof/Mobs/Silicon/quad.rsi

--- a/Resources/Prototypes/_Floof/Entities/Mobs/Cyborgs/quadborg.yml
+++ b/Resources/Prototypes/_Floof/Entities/Mobs/Cyborgs/quadborg.yml
@@ -45,8 +45,12 @@
       - BorgModuleSecurity
     hasMindState: quadspritel
     noMindState: quadspriter
+  - type: Access
+    enabled: false
+    groups:
+    - AllAccessSecurityBorg
   - type: AccessReader
-    access: [["Security"], ["Armory"], ["Command"]]
+    access: [["Armory"], ["Command"]] # Only command and the warden can unlock it, not other borgs
   - type: BorgTransponder
     sprite:
       sprite: _Floof/Mobs/Silicon/quad.rsi

--- a/Resources/Prototypes/_Floof/Entities/Objects/Specific/Robotics/Borgmodules.yml
+++ b/Resources/Prototypes/_Floof/Entities/Objects/Specific/Robotics/Borgmodules.yml
@@ -45,7 +45,7 @@
     - state: icon-kill
   - type: ItemBorgModule
     items:
-    - WeaponAdvancedLaser
+    - WeaponBorgAdvancedLaser
     - WeaponborgPistolMk58
     - CombatKnife
   - type: GuideHelp

--- a/Resources/Prototypes/_Floof/Entities/Objects/Weapons/Borgmodules/guns.yml
+++ b/Resources/Prototypes/_Floof/Entities/Objects/Weapons/Borgmodules/guns.yml
@@ -31,8 +31,8 @@
   - type: Gun
     fireRate: 5
     minAngle: 3
-    maxAngle: 10
-    angleIncrease: 2
+    maxAngle: 20
+    angleIncrease: 5
     angleDecay: 2 # Must shoot 1 shot/second to achieve full accuracy
     availableModes:
     - SemiAuto
@@ -62,7 +62,7 @@
   - type: Gun
     minAngle: 3
     maxAngle: 10
-    angleIncrease: 3
+    angleIncrease: 5
     angleDecay: 1
 
 - type: entity
@@ -80,4 +80,21 @@
     maxAngle: 10
     angleIncrease: 3
     angleDecay: 1
+
+- type: entity
+  id: WeaponBorgAdvancedLaser
+  parent: WeaponAdvancedLaser
+  name: Cyber-laser
+  suffix: Robot
+  categories: [ HideSpawnMenu ]
+  components:
+  - type: Gun
+    fireRate: 1.2
+    minAngle: 3
+    maxAngle: 20
+    angleIncrease: 5
+    angleDecay: 1
+  - type: HitscanBatteryAmmoProvider
+    proto: RedLaser # Less DPS than the advanced laser and less shots
+    fireCost: 200
 

--- a/Resources/Prototypes/_Floof/Entities/Objects/Weapons/Borgmodules/guns.yml
+++ b/Resources/Prototypes/_Floof/Entities/Objects/Weapons/Borgmodules/guns.yml
@@ -30,10 +30,10 @@
       map: ["enum.GunVisualLayers.Base"]
   - type: Gun
     fireRate: 5
-    minAngle: 3
+    minAngle: 0.5
     maxAngle: 20
     angleIncrease: 5
-    angleDecay: 2 # Must shoot 1 shot/second to achieve full accuracy
+    angleDecay: 7.5 # Must shoot at most 1.5 shots/second to achieve full accuracy
     availableModes:
     - SemiAuto
     soundGunshot:
@@ -76,10 +76,10 @@
     autoRecharge: true
     autoRechargeRate: 30
   - type: Gun
-    minAngle: 3
+    minAngle: 1
     maxAngle: 10
-    angleIncrease: 3
-    angleDecay: 1
+    angleIncrease: 5
+    angleDecay: 2
 
 - type: entity
   id: WeaponBorgAdvancedLaser
@@ -90,10 +90,10 @@
   components:
   - type: Gun
     fireRate: 1.2
-    minAngle: 3
+    minAngle: 0.5
     maxAngle: 20
     angleIncrease: 5
-    angleDecay: 1
+    angleDecay: 3 # Roughly 1.3 shots per second for maximum accuracy
   - type: HitscanBatteryAmmoProvider
     proto: RedLaser # Less DPS than the advanced laser and less shots
     fireCost: 200

--- a/Resources/Prototypes/_Floof/Entities/Objects/Weapons/Borgmodules/guns.yml
+++ b/Resources/Prototypes/_Floof/Entities/Objects/Weapons/Borgmodules/guns.yml
@@ -30,6 +30,10 @@
       map: ["enum.GunVisualLayers.Base"]
   - type: Gun
     fireRate: 5
+    minAngle: 3
+    maxAngle: 10
+    angleIncrease: 2
+    angleDecay: 2 # Must shoot 1 shot/second to achieve full accuracy
     availableModes:
     - SemiAuto
     soundGunshot:
@@ -55,6 +59,11 @@
   - type: BatterySelfRecharger
     autoRecharge: true
     autoRechargeRate: 30
+  - type: Gun
+    minAngle: 3
+    maxAngle: 10
+    angleIncrease: 3
+    angleDecay: 1
 
 - type: entity
   parent: WeaponPulseRifle
@@ -66,4 +75,9 @@
   - type: BatterySelfRecharger
     autoRecharge: true
     autoRechargeRate: 30
+  - type: Gun
+    minAngle: 3
+    maxAngle: 10
+    angleIncrease: 3
+    angleDecay: 1
 

--- a/Resources/Prototypes/_Floof/Entities/Objects/Weapons/Borgmodules/nonlethal.yml
+++ b/Resources/Prototypes/_Floof/Entities/Objects/Weapons/Borgmodules/nonlethal.yml
@@ -7,7 +7,7 @@
   components:
     - type: BatterySelfRecharger
       autoRecharge: true
-      autoRechargeRate: 30
+      autoRechargeRate: 15
 
 - type: entity
   name: borg stun baton
@@ -18,7 +18,7 @@
   components:
   - type: BatterySelfRecharger
     autoRecharge: true
-    autoRechargeRate: 40
+    autoRechargeRate: 15
 
 - type: entity
   name: Borg flash

--- a/Resources/ServerInfo/Guidebook/Science/Quadborgs.xml
+++ b/Resources/ServerInfo/Guidebook/Science/Quadborgs.xml
@@ -8,14 +8,14 @@
   <GuideEntityEmbed Entity="ExosuitFabricator" Caption="Exosuit Fabricator"/>
   </Box>
   All quadborgs start off as a [color=#a4885c]four-legged[/color] endoskeleton. Much like the cyborg endoskeleton, this is crafted at the [color=#a4885c]Exosuit Fabricator[/color], and uses cyborg parts. Assembly steps can be followed by [color=#a4885c]examining[/color] the endoskeleton. While assembly is similiar, [bold]Quadborgs do not have arms, and instead utilize two right legs, and two left legs as part of it's construction.[/bold]
-    
+
   Once built, further upgrades such as additional tooling and better power cells can be installed later on.
-    
+
   ## Chassis
   Quadborg chassis are similiar in function to the cyborg chassis, bearing the same nuances revolving [color=#a4885c]radio communication[/color] and [color=#a4885c]all-access[/color] except command areas. [bold]Quadborg chassis can fit up to 4 modules, with exception to the Service chassis which while it can fit 4 modules, it has some built in modules as well,[/bold] made possible from it's [italic]"auxillary hardware"[/italic] purpose-built for it.
   <Box>
   <GuideEntityEmbed Entity="BorgChassisQuadserv" Caption="Service" Rotation="270"/>
-  <GuideEntityEmbed Entity="BorgChassisQuad" Caption="Security" Rotation="270"/>
+  <GuideEntityEmbed Entity="BorgChassisQuadSec" Caption="Security" Rotation="270"/>
   <GuideEntityEmbed Entity="BorgChassisQuadsalv" Caption="Salvage" Rotation="270"/>
   <GuideEntityEmbed Entity="BorgChassisQuadmed" Caption="Medical" Rotation="270"/>
   </Box>
@@ -27,7 +27,7 @@
   ## Security Applications
   Unique to quadborgs is the capability to serve in the security department as a silicon. [bold]Using generic cyborg parts on a quadborg endoskeleton will construct the security chassis.[/bold]
   <Box>
-  <GuideEntityEmbed Entity="BorgChassisQuad" Caption="Security Quadborg" Rotation="270"/>
+  <GuideEntityEmbed Entity="BorgChassisQuadSec" Caption="Security Quadborg" Rotation="270"/>
   <GuideEntityEmbed Entity="SecurityTechFab" Caption="Security TechFab"/>
   </Box>
   The security chassis can only be unlocked by security, command, or another borg. Epistemics personnel will not be able to unlock the chassis due to access restrictions. [italic](Afterall, it can fit weapons!)[/italic]


### PR DESCRIPTION
# Description
Based on the discussion here: https://discord.com/channels/1255902263667331193/1404930548836597870

The mini-AA allows secborgs to chase antags all around the station and let security through, forcing an antag to fight instead of flight, which is unhealthy in a roleplay-oriented server.

This also fixes the issue with borg weapons having no inaccuracy at all (now they have SOME base inaccuracy, and it can increase if they are firing rapidly, just like most other firearms) and having insane DPS (for example, the advanced laser used to have 34 dps with 10 shots on one full charge)

This also makes all cyborgs non-instantly-healable. Instead, each use of a welder will now heal 8 units of damage of all supported types, with the do-after for it taking 2.5 times less (4 secodns vs 10). This should make it less viable to patch borgs up mid-battle as a full heal will now take about 40 seconds at 100 damage, and more if they have more damage.

Finally, this PR uncomments the StationAI job from the command department. This is something #1222 was supposed to do, but never did. Most maps don't have a station AI job slot anyway, so it's still going to require admins to map a station AI before players can sign up as it.

# Media
Demonstration (note: i'm going to further tweak the gun stats to make them more accurate when shooting single shots):

https://github.com/user-attachments/assets/1a5a387e-5c3e-4c2a-9fa8-61b182a82dcd



# Changelog
:cl:
- tweak: Security cyborgs no longer have mini-AA, and require armory or command access to unlock. No more secborgs unlocking each other.
- tweak: You can no longer instantly heal a cyborg with a welder. Instead, each use of the welder will heal 8 damage of each type, with the do-after for it being way shorter.
- fix: Station AI will now correctly display on the job selection screen.
