### PR TITLE
Better Muzzle Accent (Vulpstation#59)

### DIFF
--- a/Content.Server/Chat/Systems/ChatSystem.Emote.cs
+++ b/Content.Server/Chat/Systems/ChatSystem.Emote.cs
@@ -139,7 +139,7 @@ public partial class ChatSystem
     ///     Tries to find and play relevant emote sound in emote sounds collection.
     /// </summary>
     /// <returns>True if emote sound was played.</returns>
-    public bool TryPlayEmoteSound(EntityUid uid, EmoteSoundsPrototype? proto, string emoteId)
+    public bool TryPlayEmoteSound(EntityUid uid, EmoteSoundsPrototype? proto, string emoteId, float volumeDb = 0f) // Vulpstation - added volume control
     {
         if (proto == null)
             return false;
@@ -155,7 +155,7 @@ public partial class ChatSystem
 
         // if general params for all sounds set - use them
         var param = proto.GeneralParams ?? sound.Params;
-        _audio.PlayPvs(sound, uid, param);
+        _audio.PlayPvs(sound, uid, param.AddVolume(volumeDb)); // Vulpstation - added volume control
         return true;
     }
     /// <summary>

--- a/Content.Server/Speech/EntitySystems/VocalSystem.cs
+++ b/Content.Server/Speech/EntitySystems/VocalSystem.cs
@@ -1,3 +1,4 @@
+using Content.Server._Vulp.Speech.Accents.Mumble;
 using Content.Server.Actions;
 using Content.Server.Chat.Systems;
 using Content.Server.Speech.Components;
@@ -61,19 +62,24 @@ public sealed class VocalSystem : EntitySystem
     {
         if (args.Handled
             || !args.Emote.Category.HasFlag(EmoteCategory.Vocal)
-            || !_actionBlocker.CanSpeak(uid)
-            || TryComp<ReplacementAccentComponent>(uid, out var replacement) && replacement.Accent == MuzzleAccent) // This is not ideal, but it works.
+            || !_actionBlocker.CanSpeak(uid)) // Vulpstation - removed the muzzle check
             return;
 
         // snowflake case for wilhelm scream easter egg
-        if (args.Emote.ID == component.ScreamId)
-        {
-            args.Handled = TryPlayScreamSound(uid, component);
-            return;
-        }
+        // Vulpstation - this is honestly just annoying.
+        // if (args.Emote.ID == component.ScreamId)
+        // {
+        //     args.Handled = TryPlayScreamSound(uid, component);
+        //     return;
+        // }
+
+        // Vulpstation
+        var volume = TryComp<MumbleAccentComponent>(uid, out var mumble)
+            ? mumble.AccentPrototype?.EmoteVolume ?? 0f
+            : 0f;
 
         // just play regular sound based on emote proto
-        args.Handled = _chat.TryPlayEmoteSound(uid, component.EmoteSounds, args.Emote);
+        args.Handled = _chat.TryPlayEmoteSound(uid, component.EmoteSounds, args.Emote.ID, volume); // Vulpstation - added volume control
     }
 
     private void OnScreamAction(EntityUid uid, VocalComponent component, ScreamActionEvent args)

--- a/Content.Server/_Vulp/Speech/Accents/Mumble/MumbleAccentComponent.cs
+++ b/Content.Server/_Vulp/Speech/Accents/Mumble/MumbleAccentComponent.cs
@@ -1,0 +1,22 @@
+using Content.Shared._Vulp.Speech.Accents.Mumble;
+using Robust.Shared.Prototypes;
+
+
+namespace Content.Server._Vulp.Speech.Accents.Mumble;
+
+
+[RegisterComponent]
+public sealed partial class MumbleAccentComponent : Component
+{
+    /// <summary>
+    ///     The accent to apply to the entity. Do not modify directly unless the component is non-map-initialized.
+    /// </summary>
+    [DataField(required: true), Access(typeof(MumbleAccentSystem), Other = AccessPermissions.Read)]
+    public ProtoId<MumbleAccentPrototype> Accent = "BasicMuzzle";
+
+    /// <summary>
+    ///     The loaded accent prototype.
+    /// </summary>
+    [NonSerialized, ViewVariables]
+    public MumbleAccentPrototype? AccentPrototype;
+}

--- a/Content.Server/_Vulp/Speech/Accents/Mumble/MumbleAccentSystem.cs
+++ b/Content.Server/_Vulp/Speech/Accents/Mumble/MumbleAccentSystem.cs
@@ -1,0 +1,135 @@
+using System.Text;
+using Content.Server.Chat.Systems;
+using Content.Shared._Vulp.Speech.Accents.Mumble;
+using Robust.Shared.Prototypes;
+using Robust.Shared.Random;
+
+
+namespace Content.Server._Vulp.Speech.Accents.Mumble;
+
+
+public sealed class MumbleAccentSystem : EntitySystem
+{
+    [Dependency] private readonly IPrototypeManager _protoMan = default!;
+    [Dependency] private readonly ChatSystem _chat = default!;
+    [Dependency] private readonly IRobustRandom _random = default!;
+
+    public override void Initialize()
+    {
+        // Can we all just agree to burn the event bus down? I have to subscribe to this broadcasted event instead of AccentGetEvent
+        // because making sure this is applied after every other accept system is basically impossible
+        SubscribeLocalEvent<TransformSpeechEvent>(OnTransformSpeech);
+    }
+
+    private void OnTransformSpeech(TransformSpeechEvent args)
+    {
+        // Note to self: TransformSpeechEvent is not raised if the language doesn't require speech
+        if (!TryComp<MumbleAccentComponent>(args.Sender, out var accent))
+            return;
+
+        OnTransformSpeech((args.Sender, accent), ref args);
+    }
+
+    private void OnTransformSpeech(Entity<MumbleAccentComponent> ent, ref TransformSpeechEvent args)
+    {
+        if (ent.Comp.AccentPrototype == null && !LoadAccent(ent) || ent.Comp.AccentPrototype is not { Initialized: true } accent)
+            return;
+
+        // The code below doesn't preserve case anyway, so why bother?
+        args.Message = args.Message.ToLower();
+
+        var i = 0;
+        var result = new StringBuilder(args.Message.Length);
+        while (i < args.Message.Length)
+        {
+            // Try to find a suitable replacement
+            start:
+            var maxSubstr = Math.Min(args.Message.Length - i, accent.MaxCharacterLength);
+            for (var substrLen = maxSubstr; substrLen > 0; substrLen--)
+            {
+                var span = args.Message.AsMemory(i, substrLen);
+                var lookup = accent.Lookups![substrLen - 1];
+                if (lookup.TryGetValue(span, out var replacement))
+                {
+                    result.Append(replacement);
+                    i += substrLen;
+                    goto start;
+                }
+            }
+
+            // No replacement, use the original character
+            var c = args.Message[i];
+            var isLetter = char.IsLetter(c);
+            if (isLetter && _random.Prob(accent.DropChance))
+                continue;
+
+            result.Append(c);
+            if (isLetter && _random.Prob(accent.DoubleChance))
+                result.Append(c);
+
+            i++;
+        }
+
+        args.Message = _chat.SanitizeMessageCapital(result.ToString());
+    }
+
+    /// <summary>
+    ///     Sets mumble accent on the entity. If accent is null, removes it instead.
+    /// </summary>
+    /// <returns>True if accent was set or removed successfully, false otherwise.</returns>
+    public bool SetAccent(Entity<MumbleAccentComponent?> ent, MumbleAccentPrototype? accent)
+    {
+        if (accent == null)
+        {
+            if (!Resolve(ent, ref ent.Comp, false))
+                return false;
+
+            RemCompDeferred(ent, ent.Comp);
+            return true;
+        }
+
+        if (ent.Comp == null)
+            ent.Comp = EnsureComp<MumbleAccentComponent>(ent);
+
+        ent.Comp.Accent = accent;
+        return LoadAccent(ent!);
+    }
+
+    private bool LoadAccent(Entity<MumbleAccentComponent> ent)
+    {
+        if (!_protoMan.TryIndex(ent.Comp.Accent, out var accent))
+            return false;
+
+        ent.Comp.AccentPrototype = accent;
+        if (!accent.Initialized)
+            InitializePrototype(accent);
+
+        return true;
+    }
+
+    public void InitializePrototype(MumbleAccentPrototype accent)
+    {
+        accent.Lookups?.Clear();
+        accent.Lookups ??= new();
+
+        for (var i = 0; i < accent.MaxCharacterLength; i++)
+        {
+            var dict = accent.Replacements[i];
+            accent.Replacements[i] = new(dict, new StringSpanComparer());
+            accent.Lookups.Add(accent.Replacements[i].GetAlternateLookup<ReadOnlyMemory<char>>());
+        }
+
+        accent.Initialized = true;
+    }
+
+    // Why is this not part of C#, RobustToolbox, or anything else? This is so useful.
+    private struct StringSpanComparer : IEqualityComparer<string>, IAlternateEqualityComparer<ReadOnlyMemory<char>, string>
+    {
+        public bool Equals(string? x, string? y) => x == y;
+        public bool Equals(ReadOnlyMemory<char> alternate, string other) => alternate.Span.SequenceEqual(other);
+        public int GetHashCode(string obj) => obj.GetHashCode();
+        public int GetHashCode(ReadOnlyMemory<char> alternate) => string.GetHashCode(alternate.Span);
+        // This is only called in edge cases like when throwing an exception or doing GetOrNew so it's fine
+        public string Create(ReadOnlyMemory<char> alternate) => new(alternate.ToArray());
+    }
+}

--- a/Content.Shared/_Vulp/Speech/Accents/Mumble/MumbleAccentPrototype.cs
+++ b/Content.Shared/_Vulp/Speech/Accents/Mumble/MumbleAccentPrototype.cs
@@ -1,0 +1,47 @@
+using Robust.Shared.Prototypes;
+
+
+namespace Content.Shared._Vulp.Speech.Accents.Mumble;
+
+
+[Prototype("mumbleAccent")]
+public sealed class MumbleAccentPrototype : IPrototype
+{
+    [IdDataField]
+    public string ID { get; } = default!;
+
+    /// <summary>
+    ///     A list where the nth entry contains replacements for char sequences that are exactly n characters long.
+    ///     E.g. the 1st entry must contain replacements like "a" -> "foo". The 2nd is like "ab" -> "bar". The 3rd is "abc" -> "baz". And so on.
+    ///     This is done to achieve roughly O(1) lookup time instead of O(n), where n is the number of replacements.
+    /// </summary>
+    [DataField(required: true)]
+    public List<Dictionary<string, string>> Replacements = default!;
+
+    /// <summary>
+    ///     If there's no replacement for a sequence, this is the chance to duplicate or drop the said character.
+    /// </summary>
+    [DataField]
+    public float DoubleChance = 0f, DropChance = 0f;
+
+    /// <summary>
+    ///     How many db to add to the volume of emote sounds.
+    /// </summary>
+    [DataField]
+    public float EmoteVolume = 0f;
+
+
+    /// <summary>
+    ///     Whether this accent has been initialized. Do not modify directly, call MumbleAccentSystem.InitializePrototype!
+    /// </summary>
+    [NonSerialized]
+    public bool Initialized = false;
+
+    /// <summary>
+    ///     Initialized on demand by the system, this provides a lookup for each replacement in <see cref="Replacements"/>.
+    /// </summary>
+    [NonSerialized]
+    public List<Dictionary<string, string>.AlternateLookup<ReadOnlyMemory<char>>>? Lookups = null;
+
+    public int MaxCharacterLength => Replacements.Count;
+}

--- a/Resources/Prototypes/Entities/Clothing/Masks/masks.yml
+++ b/Resources/Prototypes/Entities/Clothing/Masks/masks.yml
@@ -354,8 +354,8 @@
     sprite: Clothing/Mask/muzzle.rsi
   - type: IngestionBlocker
   - type: AddAccentClothing
-    accent: ReplacementAccent
-    replacement: mumble
+    accent: MumbleAccent # Vulpstation - better muzzle. If we get more mumble accents, we need to add a way to choose the proto here.
+    # replacement: mumble
   - type: Construction
     graph: Muzzle
     node: muzzle

--- a/Resources/Prototypes/_Vulp/Accents/mumble.yml
+++ b/Resources/Prototypes/_Vulp/Accents/mumble.yml
@@ -1,0 +1,85 @@
+- type: mumbleAccent
+  id: BasicMuzzle
+  emoteVolume: -20
+  doubleChance: 0.2
+  dropChance: 0.3
+  replacements:
+  # Length 1
+  - m: n
+    n: ng
+    w: oo
+    y: ee
+    c: sh
+    q: g
+    x: ksh
+    s: sh
+    z: zh
+    r: w
+    l: w
+    v: f
+    p: h
+    b: f
+    t: d
+    k: g
+    g: ng
+    d: n
+    f: h
+    h: hh
+    a: uh
+    e: eh
+    i: eh
+    o: u
+    u: uh
+  # Length 2
+  - ph: h
+    wh: uh
+    tr: nr
+    gr: ng
+    cl: ng
+    bl: mn
+    st: nn
+    sp: hn
+    pr: ng
+    br: ng
+    cr: ng
+    dr: nn
+    fl: hn
+    fr: hn
+    sl: sn
+    sm: nm
+    sn: nn
+    sw: nn
+    tw: nn
+    qu: ng
+    ai: eh
+    ei: eh
+    ie: eh
+    ea: eh
+    ou: uh
+    au: uh
+    oi: uh
+    io: uh
+    ua: uh
+    th: mm
+    ch: mm
+    sh: mm
+    oo: oh
+    on: oh
+    no: nu
+    pl: mn
+    hi: ha
+    ae: eh
+    me: ee
+  # Length 3
+  - str: nnn
+    spl: nnn
+    spr: nnn
+    scr: ng
+    thr: nn
+    shr: nn
+    sch: nn
+    squ: ng
+    yes: ehh
+    the: eh
+    too: oh
+    you: hu


### PR DESCRIPTION
Downstream PR: https://github.com/vulpstation/vulpstation/pull/59

Port from vulpstation, changes the way muzzles work to make them actually obfuscate your speech, and also makes them make emotes quieter instead of completely blocking them.

-----

# Description
<img width="481" height="195" alt="image" src="https://github.com/user-attachments/assets/5b41f180-0912-4f28-89c5-c77aa08bb53c" />

# Changelog
:cl: EinsteinEngines
- feat: Muzzles no longer use a ReplacementAccent and instead apply a unique accent that makes your speech pretty much incomprehensible and also makes your emote sounds quieter.