### PR TITLE
Hire Justice

### DIFF
--- a/Resources/Prototypes/Maps/asterisk.yml
+++ b/Resources/Prototypes/Maps/asterisk.yml
@@ -34,7 +34,6 @@
             Botanist: [ 2, 3 ]
             Chef: [ 1, 2 ]
             Clown: [ 1, 1 ]
-            Lawyer: [ 1, 1 ]
             Reporter: [ 1, 1 ]
             Musician: [ 1, 1 ]
             Janitor: [ 1, 2 ]
@@ -69,6 +68,11 @@
             SecurityCadet: [ 1, 3 ]
             Prisoner: [ 1, 2 ] # :^)
             SeniorOfficer: [ 1, 1 ]
+            #justice added by FloofStation
+            ChiefJustice: [ 1, 1 ] #FloofStation
+            Clerk: [ 1, 1 ] #FloofStation
+            Lawyer: [ 1, 1 ] #FloofStation
+            Prosecutor: [ 1, 1 ] #FloofStation
           #supply
             Quartermaster: [ 1, 1 ]
             InventorySpecialist: [ 1, 1 ] #FloofStation

--- a/Resources/Prototypes/Maps/asterisk.yml
+++ b/Resources/Prototypes/Maps/asterisk.yml
@@ -68,11 +68,11 @@
             SecurityCadet: [ 1, 3 ]
             Prisoner: [ 1, 2 ] # :^)
             SeniorOfficer: [ 1, 1 ]
-            #justice added by FloofStation
-            ChiefJustice: [ 1, 1 ] #FloofStation
-            Clerk: [ 1, 1 ] #FloofStation
+          #justice added by FloofStation
+            ChiefJustice: [ 0, 1 ] #FloofStation
+            Clerk: [ 0, 1 ] #FloofStation
             Lawyer: [ 1, 1 ] #FloofStation
-            Prosecutor: [ 1, 1 ] #FloofStation
+            Prosecutor: [ 0, 1 ] #FloofStation
           #supply
             Quartermaster: [ 1, 1 ]
             InventorySpecialist: [ 1, 1 ] #FloofStation

--- a/Resources/Prototypes/Maps/edge.yml
+++ b/Resources/Prototypes/Maps/edge.yml
@@ -69,11 +69,11 @@
             Brigmedic: [ 1, 1 ]
             Prisoner: [ 2, 3 ]
             SeniorOfficer: [ 1, 1 ]
-            #justice added by FloofStation
-            ChiefJustice: [ 1, 1 ] #FloofStation
-            Clerk: [ 1, 1 ] #FloofStation
+          #justice added by FloofStation
+            ChiefJustice: [ 0, 1 ] #FloofStation
+            Clerk: [ 0, 1 ] #FloofStation
             Lawyer: [ 2, 2 ] #FloofStation
-            Prosecutor: [ 1, 1 ] #FloofStation
+            Prosecutor: [ 0, 1 ] #FloofStation
           #supply
             Quartermaster: [ 1, 1 ]
             InventorySpecialist: [ 1, 1 ] #FloofStation

--- a/Resources/Prototypes/Maps/edge.yml
+++ b/Resources/Prototypes/Maps/edge.yml
@@ -32,7 +32,6 @@
             Boxer: [ 2, 3 ]
             Chef: [ 2, 3 ]
             Clown: [ 1, 1 ]
-            Lawyer: [ 1, 1 ]
             Reporter: [ 1, 1 ]
             Musician: [ 1, 1 ]
             Janitor: [ 2, 3 ]
@@ -70,6 +69,11 @@
             Brigmedic: [ 1, 1 ]
             Prisoner: [ 2, 3 ]
             SeniorOfficer: [ 1, 1 ]
+            #justice added by FloofStation
+            ChiefJustice: [ 1, 1 ] #FloofStation
+            Clerk: [ 1, 1 ] #FloofStation
+            Lawyer: [ 2, 2 ] #FloofStation
+            Prosecutor: [ 1, 1 ] #FloofStation
           #supply
             Quartermaster: [ 1, 1 ]
             InventorySpecialist: [ 1, 1 ] #FloofStation

--- a/Resources/Prototypes/Maps/fland.yml
+++ b/Resources/Prototypes/Maps/fland.yml
@@ -62,11 +62,11 @@
             Prisoner: [ 2, 3 ] # has a small perma so less prisoners
             PrisonGuard: [ 1, 2 ]
             SeniorOfficer: [ 1, 1 ]
-           #justice added by FloofStation
-            ChiefJustice: [ 1, 1 ] #FloofStation
-            Clerk: [ 1, 1 ] #FloofStation
+            #justice added by FloofStation
+            ChiefJustice: [ 0, 1 ] #FloofStation
+            Clerk: [ 0, 1 ] #FloofStation
             Lawyer: [ 2, 2 ] #FloofStation
-            Prosecutor: [ 1, 1 ] #FloofStation
+            Prosecutor: [ 0, 1 ] #FloofStation
             #supply
             Quartermaster: [ 1, 1 ]
             InventorySpecialist: [ 1, 1 ] #FloofStation

--- a/Resources/Prototypes/Maps/fland.yml
+++ b/Resources/Prototypes/Maps/fland.yml
@@ -61,8 +61,12 @@
             Brigmedic: [ 1, 1 ]
             Prisoner: [ 2, 3 ] # has a small perma so less prisoners
             PrisonGuard: [ 1, 2 ]
-            Lawyer: [ 2, 2 ]
             SeniorOfficer: [ 1, 1 ]
+           #justice added by FloofStation
+            ChiefJustice: [ 1, 1 ] #FloofStation
+            Clerk: [ 1, 1 ] #FloofStation
+            Lawyer: [ 2, 2 ] #FloofStation
+            Prosecutor: [ 1, 1 ] #FloofStation
             #supply
             Quartermaster: [ 1, 1 ]
             InventorySpecialist: [ 1, 1 ] #FloofStation

--- a/Resources/Prototypes/Maps/hammurabi.yml
+++ b/Resources/Prototypes/Maps/hammurabi.yml
@@ -53,10 +53,10 @@
             Warden: [ 1, 1 ]
             SeniorOfficer: [ 1, 1 ]
           #justice added by FloofStation
-            ChiefJustice: [ 1, 1 ] #FloofStation
-            Clerk: [ 1, 1 ] #FloofStation
+            ChiefJustice: [ 0, 1 ] #FloofStation
+            Clerk: [ 0, 1 ] #FloofStation
             Lawyer: [ 2, 2 ] #FloofStation
-            Prosecutor: [ 1, 1 ] #FloofStation
+            Prosecutor: [ 0, 1 ] #FloofStation
           #service
             Bartender: [ 2, 3 ]
             Botanist: [ 2, 3 ]

--- a/Resources/Prototypes/Maps/hammurabi.yml
+++ b/Resources/Prototypes/Maps/hammurabi.yml
@@ -52,6 +52,11 @@
             SecurityCadet: [ 2, 3 ]
             Warden: [ 1, 1 ]
             SeniorOfficer: [ 1, 1 ]
+          #justice added by FloofStation
+            ChiefJustice: [ 1, 1 ] #FloofStation
+            Clerk: [ 1, 1 ] #FloofStation
+            Lawyer: [ 2, 2 ] #FloofStation
+            Prosecutor: [ 1, 1 ] #FloofStation
           #service
             Bartender: [ 2, 3 ]
             Botanist: [ 2, 3 ]
@@ -60,7 +65,6 @@
             Clown: [ 1, 1 ]
             HeadOfPersonnel: [ 1, 1 ]
             Janitor: [ 2, 4 ]
-            Lawyer: [ 2, 2 ]
             Mime: [ 1, 2 ]
             Musician: [ 2, 3 ]
             Reporter: [ 2, 2 ]

--- a/Resources/Prototypes/Maps/hive.yml
+++ b/Resources/Prototypes/Maps/hive.yml
@@ -54,10 +54,10 @@
             Warden: [ 1, 1 ]
             SeniorOfficer: [ 1, 1 ]
           #justice added by FloofStation
-            ChiefJustice: [ 1, 1 ] #FloofStation
-            Clerk: [ 1, 1 ] #FloofStation
+            ChiefJustice: [ 0, 1 ] #FloofStation
+            Clerk: [ 0, 1 ] #FloofStation
             Lawyer: [ 2, 2 ] #FloofStation
-            Prosecutor: [ 1, 1 ] #FloofStation
+            Prosecutor: [ 0, 1 ] #FloofStation
           #service
             Bartender: [ 2, 2 ]
             Botanist: [ 2, 3 ]

--- a/Resources/Prototypes/Maps/hive.yml
+++ b/Resources/Prototypes/Maps/hive.yml
@@ -53,6 +53,11 @@
             SecurityCadet: [ 1, 2 ]
             Warden: [ 1, 1 ]
             SeniorOfficer: [ 1, 1 ]
+          #justice added by FloofStation
+            ChiefJustice: [ 1, 1 ] #FloofStation
+            Clerk: [ 1, 1 ] #FloofStation
+            Lawyer: [ 2, 2 ] #FloofStation
+            Prosecutor: [ 1, 1 ] #FloofStation
           #service
             Bartender: [ 2, 2 ]
             Botanist: [ 2, 3 ]
@@ -61,7 +66,6 @@
             Clown: [ 1, 2 ]
             HeadOfPersonnel: [ 1, 1 ]
             Janitor: [ 2, 3 ]
-            Lawyer: [ 2, 2 ]
             Mime: [ 1, 2 ]
             Musician: [ 1, 3 ]
             Reporter: [ 1, 2 ]

--- a/Resources/Prototypes/Maps/kettle.yml
+++ b/Resources/Prototypes/Maps/kettle.yml
@@ -76,8 +76,8 @@
             Reporter: [ 2, 2 ]
             Zookeeper: [ 1, 1 ]
             Anomaly: [ 4, 4 ] # Floofstation
-          #justice added by FloofStation
-            ChiefJustice: [ 1, 1 ] #FloofStation
-            Clerk: [ 1, 1 ] #FloofStation
+            #justice added by FloofStation
+            ChiefJustice: [ 0, 1 ] #FloofStation
+            Clerk: [ 0, 1 ] #FloofStation
             Lawyer: [ 2, 2 ] #FloofStation
-            Prosecutor: [ 1, 1 ] #FloofStation
+            Prosecutor: [ 0, 1 ] #FloofStation

--- a/Resources/Prototypes/Maps/kettle.yml
+++ b/Resources/Prototypes/Maps/kettle.yml
@@ -76,5 +76,8 @@
             Reporter: [ 2, 2 ]
             Zookeeper: [ 1, 1 ]
             Anomaly: [ 4, 4 ] # Floofstation
-            #justice
-            Lawyer: [ 2, 2 ]
+          #justice added by FloofStation
+            ChiefJustice: [ 1, 1 ] #FloofStation
+            Clerk: [ 1, 1 ] #FloofStation
+            Lawyer: [ 2, 2 ] #FloofStation
+            Prosecutor: [ 1, 1 ] #FloofStation

--- a/Resources/Prototypes/Maps/lighthouse.yml
+++ b/Resources/Prototypes/Maps/lighthouse.yml
@@ -32,7 +32,6 @@
           Boxer: [ 2, 2 ]
           Chef: [ 1, 2 ]
           Clown: [ 1, 1 ]
-          Lawyer: [ 2, 2 ]
           Reporter: [ 0, 2 ]
           Musician: [ 1, 1 ]
           Janitor: [ 1, 2 ]
@@ -70,6 +69,11 @@
           Brigmedic: [ 1, 1 ]
           Prisoner: [ 2, 3 ]
           SeniorOfficer: [ 1, 1 ]
+        #justice added by FloofStation
+          ChiefJustice: [ 1, 1 ] #FloofStation
+          Clerk: [ 1, 1 ] #FloofStation
+          Lawyer: [ 2, 2 ] #FloofStation
+          Prosecutor: [ 1, 1 ] #FloofStation
         #supply
           Quartermaster: [ 1, 1 ]
           InventorySpecialist: [ 1, 1 ] #FloofStation

--- a/Resources/Prototypes/Maps/lighthouse.yml
+++ b/Resources/Prototypes/Maps/lighthouse.yml
@@ -70,10 +70,10 @@
           Prisoner: [ 2, 3 ]
           SeniorOfficer: [ 1, 1 ]
         #justice added by FloofStation
-          ChiefJustice: [ 1, 1 ] #FloofStation
-          Clerk: [ 1, 1 ] #FloofStation
+          ChiefJustice: [ 0, 1 ] #FloofStation
+          Clerk: [ 0, 1 ] #FloofStation
           Lawyer: [ 2, 2 ] #FloofStation
-          Prosecutor: [ 1, 1 ] #FloofStation
+          Prosecutor: [ 0, 1 ] #FloofStation
         #supply
           Quartermaster: [ 1, 1 ]
           InventorySpecialist: [ 1, 1 ] #FloofStation

--- a/Resources/Prototypes/Maps/pebble.yml
+++ b/Resources/Prototypes/Maps/pebble.yml
@@ -63,10 +63,10 @@
             SecurityCadet: [ 1, 1 ]
             SeniorOfficer: [ 1, 1 ]
           #justice added by FloofStation
-            ChiefJustice: [ 1, 1 ] #FloofStation
-            Clerk: [ 1, 1 ] #FloofStation
+            ChiefJustice: [ 0, 1 ] #FloofStation
+            Clerk: [ 0, 1 ] #FloofStation
             Lawyer: [ 1, 1 ] #FloofStation
-            Prosecutor: [ 1, 1 ] #FloofStation
+            Prosecutor: [ 0, 1 ] #FloofStation
           #supply
             Quartermaster: [ 1, 1 ]
             InventorySpecialist: [ 1, 1 ] #FloofStation

--- a/Resources/Prototypes/Maps/pebble.yml
+++ b/Resources/Prototypes/Maps/pebble.yml
@@ -30,7 +30,6 @@
             Boxer: [ 2, 2 ]
             Chef: [ 2 , 2 ]
             Clown: [ 1, 1 ]
-            Lawyer: [ 1, 1 ]
             Musician: [ 1, 1 ]
             Janitor: [ 1, 2 ]
             Mime: [ 1, 1 ]
@@ -63,6 +62,11 @@
             SecurityOfficer: [ 2, 2 ]
             SecurityCadet: [ 1, 1 ]
             SeniorOfficer: [ 1, 1 ]
+          #justice added by FloofStation
+            ChiefJustice: [ 1, 1 ] #FloofStation
+            Clerk: [ 1, 1 ] #FloofStation
+            Lawyer: [ 1, 1 ] #FloofStation
+            Prosecutor: [ 1, 1 ] #FloofStation
           #supply
             Quartermaster: [ 1, 1 ]
             InventorySpecialist: [ 1, 1 ] #FloofStation

--- a/Resources/Prototypes/Maps/shoukou.yml
+++ b/Resources/Prototypes/Maps/shoukou.yml
@@ -63,10 +63,10 @@
           Prisoner: [ 2, 2 ]
           SeniorOfficer: [ 1, 1 ]
           #justice added by FloofStation
-          ChiefJustice: [ 1, 1 ] #FloofStation
-          Clerk: [ 1, 1 ] #FloofStation
+          ChiefJustice: [ 0, 1 ] #FloofStation
+          Clerk: [ 0, 1 ] #FloofStation
           Lawyer: [ 1, 1 ] #FloofStation
-          Prosecutor: [ 1, 1 ] #FloofStation
+          Prosecutor: [ 0, 1 ] #FloofStation
           #Science
           ResearchDirector: [ 1, 1 ]
           Scientist: [ 2, 4 ]

--- a/Resources/Prototypes/Maps/shoukou.yml
+++ b/Resources/Prototypes/Maps/shoukou.yml
@@ -25,7 +25,6 @@
           Passenger: [ -1, -1 ]
           ServiceWorker: [ 1, 2]
           Reporter: [ 0, 1 ]
-          Lawyer: [ 1, 1 ]
           Bartender: [ 1, 2 ]
           Botanist: [ 1, 2 ]
           MartialArtist: [ 2, 3 ]
@@ -63,6 +62,11 @@
           Brigmedic: [ 1, 1 ]
           Prisoner: [ 2, 2 ]
           SeniorOfficer: [ 1, 1 ]
+          #justice added by FloofStation
+          ChiefJustice: [ 1, 1 ] #FloofStation
+          Clerk: [ 1, 1 ] #FloofStation
+          Lawyer: [ 1, 1 ] #FloofStation
+          Prosecutor: [ 1, 1 ] #FloofStation
           #Science
           ResearchDirector: [ 1, 1 ]
           Scientist: [ 2, 4 ]

--- a/Resources/Prototypes/Maps/submarine.yml
+++ b/Resources/Prototypes/Maps/submarine.yml
@@ -51,6 +51,11 @@
             SecurityCadet: [ 3, 4 ]
             Warden: [ 1, 1 ]
             SeniorOfficer: [ 1, 1 ]
+          #justice added by FloofStation
+            ChiefJustice: [ 1, 1 ] #FloofStation
+            Clerk: [ 1, 1 ] #FloofStation
+            Lawyer: [ 2, 2 ] #FloofStation
+            Prosecutor: [ 1, 1 ] #FloofStation
           #service
             Bartender: [ 2, 3 ]
             Botanist: [ 2, 4 ]
@@ -59,7 +64,6 @@
             Clown: [ 1, 2 ]
             HeadOfPersonnel: [ 1, 1 ]
             Janitor: [ 2, 3 ]
-            Lawyer: [ 2, 2 ]
             MartialArtist: [ 2, 2 ]
             Mime: [ 1, 2 ]
             Musician: [ 2, 2 ]

--- a/Resources/Prototypes/Maps/submarine.yml
+++ b/Resources/Prototypes/Maps/submarine.yml
@@ -52,10 +52,10 @@
             Warden: [ 1, 1 ]
             SeniorOfficer: [ 1, 1 ]
           #justice added by FloofStation
-            ChiefJustice: [ 1, 1 ] #FloofStation
-            Clerk: [ 1, 1 ] #FloofStation
+            ChiefJustice: [ 0, 1 ] #FloofStation
+            Clerk: [ 0, 1 ] #FloofStation
             Lawyer: [ 2, 2 ] #FloofStation
-            Prosecutor: [ 1, 1 ] #FloofStation
+            Prosecutor: [ 0, 1 ] #FloofStation
           #service
             Bartender: [ 2, 3 ]
             Botanist: [ 2, 4 ]

--- a/Resources/Prototypes/Maps/tortuga.yml
+++ b/Resources/Prototypes/Maps/tortuga.yml
@@ -52,6 +52,11 @@
             SecurityCadet: [ 2, 4 ]
             Warden: [ 1, 1 ]
             SeniorOfficer: [ 1, 1 ]
+          #justice added by FloofStation
+            ChiefJustice: [ 1, 1 ] #FloofStation
+            Clerk: [ 1, 1 ] #FloofStation
+            Lawyer: [ 2, 2 ] #FloofStation
+            Prosecutor: [ 1, 1 ] #FloofStation
           #service
             Bartender: [ 2, 2 ]
             Botanist: [ 2, 3 ]
@@ -60,7 +65,6 @@
             Clown: [ 1, 2 ]
             HeadOfPersonnel: [ 1, 1 ]
             Janitor: [ 2, 3 ]
-            Lawyer: [ 2, 2 ]
             Mime: [ 1, 2 ]
             Musician: [ 2, 3 ]
             Reporter: [ 2, 2 ]

--- a/Resources/Prototypes/Maps/tortuga.yml
+++ b/Resources/Prototypes/Maps/tortuga.yml
@@ -53,10 +53,10 @@
             Warden: [ 1, 1 ]
             SeniorOfficer: [ 1, 1 ]
           #justice added by FloofStation
-            ChiefJustice: [ 1, 1 ] #FloofStation
-            Clerk: [ 1, 1 ] #FloofStation
+            ChiefJustice: [ 0, 1 ] #FloofStation
+            Clerk: [ 0, 1 ] #FloofStation
             Lawyer: [ 2, 2 ] #FloofStation
-            Prosecutor: [ 1, 1 ] #FloofStation
+            Prosecutor: [ 0, 1 ] #FloofStation
           #service
             Bartender: [ 2, 2 ]
             Botanist: [ 2, 3 ]


### PR DESCRIPTION
# Description

Adds late join Justice job slots to all the maps that were missing them. This does not make any actual map changes. No new rooms, no new spawners, no lockers. This just makes these pretty much RP only jobs available for those that want to use them. Also a first step towards normalizing the Justice department being present to allow for proper following of SOP.

Late join only is so they don't end up stuck in engineering or some other random place, as they did in testing.

---

# Changelog

:cl: sprkl
- fix: Justice department jobs are now available on all station models.
