### PR TITLE
Syndie Injectors

### DIFF
--- a/Resources/Locale/en-US/_Floof/store/uplink-catalog.ftl
+++ b/Resources/Locale/en-US/_Floof/store/uplink-catalog.ftl
@@ -7,6 +7,15 @@ uplink-coder-socks-valid-desc = These socks add onto your robustness by making y
 uplink-Cryptobiolininjector-name = Cryptobiolin injector
 uplink-Cryptobiolininjector-desc = Made by SESWC. This item is prefilled with 20u of Cryptobiolin to help you get rid of those pesky psionic weirdo's.
 
+uplink-libidozenithizineinjector-free-name = Free Libidozenithizine Injector
+uplink-libidozenithizineinjector-free-desc = 3 Libidozenithizine Injectors on the house. Go have fun!
+
+uplink-libidozenithizineinjector-name = Libidozenithizine Injector
+uplink-libidozenithizineinjector-desc = Injector with Libidozenithizine, used to sleep with or honeypot your objective.
+
+uplink-nocturineinjector-name = Nocturine Injector
+uplink-nocturineinjector-desc = Disposable rapid injector filled with 15 units of Nocturine, filled into an injector for ease of use so even the clumsiest of agents can sleep their target.
+
 # Weapons
 uplink-EnergySabre-name = Energy Sabre MK. 9
 uplink-EnergySabre-desc = Crafted by Fae, the CyberSun Weapons Designer, a brilliant display of plasma weaponry crafted into a beautiful sabre.

--- a/Resources/Prototypes/_Floof/Catalog/uplink_catalog.yml
+++ b/Resources/Prototypes/_Floof/Catalog/uplink_catalog.yml
@@ -135,3 +135,40 @@
   conditions:
   - !type:ListingLimitedStockCondition
     stock: 2
+
+- type: listing
+  id: UplinkLibidozenithizineInjectorFree
+  name: uplink-libidozenithizineinjector-free-name
+  description: uplink-libidozenithizineinjector-free-desc
+  icon: { sprite: Objects/Specific/Medical/medipen.rsi, state: hypovolemic }
+  productEntity: LibidozenithizineInjector
+  categories:
+  - UplinkPointless
+  conditions:
+  - !type:ListingLimitedStockCondition
+    stock: 3
+
+- type: listing
+  id: UplinkLibidozenithizineInjector
+  name: uplink-libidozenithizineinjector-name
+  description: uplink-libidozenithizineinjector-desc
+  icon: { sprite: Objects/Specific/Medical/medipen.rsi, state: hypovolemic }
+  productEntity: LibidozenithizineInjector
+  categories:
+  - UplinkPointless
+  cost:
+    Telecrystal: 1
+
+- type: listing
+  id: UplinkNocturineInjector
+  name: uplink-nocturineinjector-name
+  description: uplink-nocturineinjector-desc
+  icon: { sprite: Objects/Specific/Medical/medipen.rsi, state: dermpen }
+  productEntity: NocturineInjector
+  discountCategory: usualDiscounts
+  discountDownTo:
+    Telecrystal: 1
+  cost:
+    Telecrystal: 3
+  categories:
+  - UplinkChemicals

--- a/Resources/Prototypes/_Floof/Entities/Objects/Tools/uplink.yml
+++ b/Resources/Prototypes/_Floof/Entities/Objects/Tools/uplink.yml
@@ -17,3 +17,30 @@
         - ReagentId: Cryptobiolin
           Quantity: 20
 
+- type: entity
+  name: Libidozenithizine Injector
+  parent: SpaceMedipen
+  id: LibidozenithizineInjector
+  description: A rapid dose of Horny. Contains 20 units of Libidozenithizine, use for recreation.
+  components:
+  - type: SolutionContainerManager
+      solutions:
+        pen:
+          maxVol: 20
+          reagents:
+            - ReagentId: Libidozenithizine
+              Quantity: 20
+
+- type: entity
+  name: Nocturine Injector
+  parent: BurnAutoInjector
+  id: NocturineInjector
+  description: A rapid dose of Eepy. Contains 15 units of Nocturine, for god's eepiest soldiers.
+  components:
+  - type: SolutionContainerManager
+      solutions:
+        pen:
+          maxVol: 15
+          reagents:
+            - ReagentId: Nocturine
+              Quantity: 15

--- a/Resources/Prototypes/_Floof/Entities/Objects/Tools/uplink.yml
+++ b/Resources/Prototypes/_Floof/Entities/Objects/Tools/uplink.yml
@@ -24,12 +24,12 @@
   description: A rapid dose of Horny. Contains 20 units of Libidozenithizine, use for recreation.
   components:
   - type: SolutionContainerManager
-      solutions:
-        pen:
-          maxVol: 20
-          reagents:
-            - ReagentId: Libidozenithizine
-              Quantity: 20
+    solutions:
+      pen:
+        maxVol: 20
+        reagents:
+        - ReagentId: Libidozenithizine
+          Quantity: 20
 
 - type: entity
   name: Nocturine Injector
@@ -38,9 +38,9 @@
   description: A rapid dose of Eepy. Contains 15 units of Nocturine, for god's eepiest soldiers.
   components:
   - type: SolutionContainerManager
-      solutions:
-        pen:
-          maxVol: 15
-          reagents:
-            - ReagentId: Nocturine
-              Quantity: 15
+    solutions:
+      pen:
+        maxVol: 15
+        reagents:
+        - ReagentId: Nocturine
+          Quantity: 15


### PR DESCRIPTION
# Description

Adds Nocturine Injector, a disposable injector with 15 units of Nocturine, economically more expensive then a bottle and hypo pen, but even a mechanically clumsy antag can use it. (or fumble, press Z and self inject it.)

Adds Libidozenithizine Injector, a disposable injector with 20 units of Libidozenithizine. You get 3 free ones for recreational use. But start paying after the third if you want more. You can also use it to RP honeypotting someone if you want.

(Considering putting the Libido injectors into the sex crates)

# Changelog
:cl:
- add: Added 💉 Nocturine Injector, for the unrobust, clumsy or lagging players.
- add: Added 💉 Libidozenithizine Injector, horny injector, you know what you must do.