### PR TITLE
Add Contact Interaction to TryEquip

### DIFF
--- a/Content.Shared/Inventory/InventorySystem.Equip.cs
+++ b/Content.Shared/Inventory/InventorySystem.Equip.cs
@@ -183,6 +183,9 @@ public abstract partial class InventorySystem
             return false;
         }
 
+        // Floofstation - do contact interaction just in case it's called from loadouts or roundstart spawn
+        _interactionSystem.DoContactInteraction(actor, itemUid);
+
         if (!_containerSystem.Insert(itemUid, slotContainer))
         {
             if(!silent && _gameTiming.IsFirstTimePredicted)


### PR DESCRIPTION
# Description
Fixes gloves and other clothes lacking the owner's fingerprints when received via loadouts.

I decided to only perform a contact interaction between the actor and the item being equipped, but not between the target and the . If the action is performed IC, the interaction and verb systems will invoke DoContactInteractions on their own.

<details><summary><h1>Media</h1></summary><p>

<img width="1114" height="499" alt="image" src="https://github.com/user-attachments/assets/9a1fbbe6-fad0-4341-a1ae-4a6605bf12bf" />

<img width="1920" height="1200" alt="image" src="https://github.com/user-attachments/assets/8e778047-c8e4-4264-ac82-d96313f4c9d1" />

<img width="1920" height="1200" alt="image" src="https://github.com/user-attachments/assets/a5154656-a292-4588-afb3-c6ffeac3646d" />

</p></details>

# Changelog
:cl:
- fix: Clothing received via loadouts will now correctly have the owner's fingerprints.