### PR TITLE
Make NPCs Retaliate

### DIFF
--- a/Content.Server/NPC/Components/NPCRetaliationComponent.cs
+++ b/Content.Server/NPC/Components/NPCRetaliationComponent.cs
@@ -26,5 +26,5 @@ public sealed partial class NPCRetaliationComponent : Component
     ///     Whether this NPC will retaliate against a "Friendly" NPC.
     /// </summary>
     [DataField]
-    public bool RetaliateFriendlies;
+    public bool RetaliateFriendlies = true; // Floofstation - changed this to default to true so animal friends can't abuse it
 }

--- a/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
@@ -2474,6 +2474,8 @@
     - type: NpcFactionMember
       factions:
         - SimpleHostile #floof, makes tarantulas friendly to people with animal friend but not hostile to xenos which was their original faction
+    - type: NPCRetaliation # Vulpstation
+      attackMemoryLength: 20
     - type: InputMover
     - type: MobMover
     - type: HTN

--- a/Resources/Prototypes/Entities/Mobs/NPCs/slimes.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/slimes.yml
@@ -202,6 +202,8 @@
         Base: blue_adult_slime
       Dead:
         Base: blue_adult_slime_dead
+  - type: NPCRetaliation # Floofstation
+    attackMemoryLength: 20
 
 - type: entity
   name: blue slime


### PR DESCRIPTION
# Description
It's not once and not twice that I've seen animal friend trait users abuse their trait to safely kill vent critters and whatnot. It's always been infuriating to me, so this PR puts an end to it.

NPCs will now by default retaliate when attacked, even if the attacker is of a faction friendly to them (AnimalFriend). This will also help combat people taking on e.g. a spider ghost role and safely killing all vent critters because they are friendly to them (SimpleHostile is friendly to itself)

<details><summary><h1>Media</h1></summary><p>

https://github.com/user-attachments/assets/55d22254-4c52-4464-a2f1-ec19ff114618

</p></details>

# Changelog
:cl:
- tweak: NPCs will now retaliate when attacked even if the attacker belongs to a faction they are friendly to. This means that animal friend trait users can ***no longer*** safely kill vent critters (though they can still move them to a spot where they won't hurt anyone).
