### PR TITLE
Return Corpsman to Saltern

### DIFF
--- a/Resources/Prototypes/Maps/saltern.yml
+++ b/Resources/Prototypes/Maps/saltern.yml
@@ -64,6 +64,7 @@
             SeniorResearcher: [ 1, 1 ]
             #security
             HeadOfSecurity: [ 1, 1 ]
+            Brigmedic: [ 1, 1 ]
             Warden: [ 1, 1 ]
             Detective: [ 1, 1 ]
             SecurityOfficer: [ 4, 6 ]


### PR DESCRIPTION
# Description

Adds the corpsman job slot back to Saltern. Double checked and the spawn point is in, just the slot was missing.
---

# Changelog

:cl: sprkl
- fix: Corpsman can be hired on Saltern again.
