### PR TITLE
Radio Band-Aid Fix

### DIFF
--- a/Content.Server/Radio/EntitySystems/RadioDeviceSystem.cs
+++ b/Content.Server/Radio/EntitySystems/RadioDeviceSystem.cs
@@ -1,4 +1,3 @@
-using System.Linq;
 using Content.Server.Chat.Systems;
 using Content.Server.Interaction;
 using Content.Server.Language;
@@ -8,18 +7,20 @@ using Content.Server.Power.EntitySystems;
 using Content.Server.Radio.Components;
 using Content.Server.Speech;
 using Content.Server.Speech.Components;
+using Content.Shared._NC.Radio; // Nuclear-14
+using Content.Shared.Chat;
 using Content.Shared.Examine;
 using Content.Shared.Interaction;
 using Content.Shared.Power;
 using Content.Shared.Radio;
-using Content.Shared.Chat;
 using Content.Shared.Radio.Components;
 using Content.Shared.UserInterface; // Nuclear-14
-using Content.Shared._NC.Radio; // Nuclear-14
 using Robust.Server.GameObjects;
 using Robust.Shared.Network;
 using Robust.Shared.Player; // Nuclear-14
 using Robust.Shared.Prototypes;
+using System.Linq;
+using System.Xml.Linq;
 
 namespace Content.Server.Radio.EntitySystems;
 
@@ -239,6 +240,15 @@ public sealed class RadioDeviceSystem : EntitySystem
             };
             _netMan.ServerSendMessage(msg, actor.PlayerSession.Channel);
         }
+
+        var nameEv = new TransformSpeakerNameEvent(args.MessageSource, Name(args.MessageSource));
+        RaiseLocalEvent(args.MessageSource, nameEv);
+
+        var name = Loc.GetString("speech-name-relay",
+        ("speaker", Name(uid)),
+        ("originalName", nameEv.VoiceName));
+
+        _chat.TrySendInGameICMessage(uid, args.OriginalChatMsg.Message, InGameICChatType.Whisper, ChatTransmitRange.GhostRangeLimit, nameOverride: name, checkRadioPrefix: false);
     }
 
     private void OnIntercomEncryptionChannelsChanged(Entity<IntercomComponent> ent, ref EncryptionChannelsChangedEvent args)

--- a/Content.Server/Radio/EntitySystems/RadioDeviceSystem.cs
+++ b/Content.Server/Radio/EntitySystems/RadioDeviceSystem.cs
@@ -1,3 +1,4 @@
+using System.Linq;
 using Content.Server.Chat.Systems;
 using Content.Server.Interaction;
 using Content.Server.Language;
@@ -7,20 +8,18 @@ using Content.Server.Power.EntitySystems;
 using Content.Server.Radio.Components;
 using Content.Server.Speech;
 using Content.Server.Speech.Components;
-using Content.Shared._NC.Radio; // Nuclear-14
-using Content.Shared.Chat;
 using Content.Shared.Examine;
 using Content.Shared.Interaction;
 using Content.Shared.Power;
 using Content.Shared.Radio;
+using Content.Shared.Chat;
 using Content.Shared.Radio.Components;
 using Content.Shared.UserInterface; // Nuclear-14
+using Content.Shared._NC.Radio; // Nuclear-14
 using Robust.Server.GameObjects;
 using Robust.Shared.Network;
 using Robust.Shared.Player; // Nuclear-14
 using Robust.Shared.Prototypes;
-using System.Linq;
-using System.Xml.Linq;
 
 namespace Content.Server.Radio.EntitySystems;
 


### PR DESCRIPTION
# Description

This PR adds a few removed lines from #1294 with the radio frequencies. Adding them back has the chat bubbles appearing again.

I did not see any issues testing it but I'm not sure if everything added back is needed so if the code can be written better let me know.

---

# TODO

- [x] Add pictures
- [ ] Resolve issue when switching channels needing to turn the speaker on and off to start speaking from that channel.

---

<details><summary><h1>Intercom set to Common.</h1></summary>
<p>
<img width="1186" height="604" alt="FirstOne" src="https://github.com/user-attachments/assets/abddbf08-d10b-4f26-b044-afd852256a1d" />
</p>
</details>

<details><summary><h1>Intercom set to Command.</h1></summary>
<p>
<img width="1221" height="728" alt="Commandone" src="https://github.com/user-attachments/assets/45e7010c-2c4a-488a-a7ed-b864ac6027db" />
</p>
</details>

<details><summary><h1>Both Intercoms set to Common.</h1></summary>
<p>
<img width="1189" height="641" alt="Btoh" src="https://github.com/user-attachments/assets/13b0fccb-75cd-4d81-9c15-37d7c013ba77" />
</p>
</details>

---

# Changelog

:cl:
- fix: Fixed an issue where intercoms don't show chat when speaker is on.
