### PR TITLE
Golden Cup PR

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Consumable/Drinks/drinks_cups.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Drinks/drinks_cups.yml
@@ -53,6 +53,10 @@
   components:
   - type: Sprite
     sprite: Objects/Consumable/Drinks/golden_cup.rsi
+  - type: SolutionContainerManager
+    solutions:
+      drink:
+        maxVol: 100
 
 - type: entity
   parent: DrinkBaseCup


### PR DESCRIPTION
# Description
This PR increases the Golden Cup's capacity from 20 to 100, so you may use it to chug alcohol like it was meant to be.

Yes, I made this PR when I realized I couldn't use it to get blackout drunk from chugging from it.

# Changelog
:cl:
- tweak: The Golden Cup can now be used to chug alcohol better.
