### PR TITLE
#FASTTRACK - Justice Spawn Hotfix

### DIFF
--- a/Resources/Prototypes/Maps/asterisk.yml
+++ b/Resources/Prototypes/Maps/asterisk.yml
@@ -34,7 +34,6 @@
             Botanist: [ 2, 3 ]
             Chef: [ 1, 2 ]
             Clown: [ 1, 1 ]
-            Lawyer: [ 1, 1 ]
             Reporter: [ 1, 1 ]
             Musician: [ 1, 1 ]
             Janitor: [ 1, 2 ]
@@ -77,3 +76,8 @@
             CargoTechnician: [ 2, 4 ]
           #civilian
             Passenger: [ -1, -1 ]
+          # Justice added by FloofStation
+            ChiefJustice: [ 1, 1 ] #FloofStation
+            Clerk: [ 1, 1 ] #FloofStation
+            Lawyer: [ 2, 2 ] #FloofStation
+            Prosecutor: [ 1, 1 ] #FloofStation

--- a/Resources/Prototypes/Maps/core.yml
+++ b/Resources/Prototypes/Maps/core.yml
@@ -60,9 +60,6 @@
             HeadOfSecurity: [ 1, 1 ]
             SecurityOfficer: [ 4, 6 ]
             Warden: [ 1, 1 ]
-            ChiefJustice: [ 1, 1 ] #FloofStation
-            Lawyer: [ 1, 2 ]
-            Prosecutor: [ 1, 1 ] #FloofStation
             Brigmedic: [ 1, 1 ]
             SecurityCadet: [ 3, 6 ]
             Detective: [ 1, 1 ]
@@ -81,3 +78,8 @@
             Boxer: [ 2, 4 ]
             Reporter: [ 2, 4 ]
             Passenger: [ -1, -1 ]
+            # Justice added by FloofStation
+            ChiefJustice: [ 1, 1 ] #FloofStation
+            Clerk: [ 1, 1 ] #FloofStation
+            Lawyer: [ 2, 2 ] #FloofStation
+            Prosecutor: [ 1, 1 ] #FloofStation

--- a/Resources/Prototypes/Maps/edge.yml
+++ b/Resources/Prototypes/Maps/edge.yml
@@ -32,7 +32,6 @@
             Boxer: [ 2, 3 ]
             Chef: [ 2, 3 ]
             Clown: [ 1, 1 ]
-            Lawyer: [ 1, 1 ]
             Reporter: [ 1, 1 ]
             Musician: [ 1, 1 ]
             Janitor: [ 2, 3 ]
@@ -78,4 +77,8 @@
             CargoTechnician: [ 2, 4 ]
           #civilian
             Passenger: [ -1, -1 ]
-
+          # Justice added by FloofStation
+            ChiefJustice: [ 1, 1 ] #FloofStation
+            Clerk: [ 1, 1 ] #FloofStation
+            Lawyer: [ 2, 2 ] #FloofStation
+            Prosecutor: [ 1, 1 ] #FloofStation

--- a/Resources/Prototypes/Maps/edge.yml
+++ b/Resources/Prototypes/Maps/edge.yml
@@ -82,3 +82,4 @@
             Clerk: [ 1, 1 ] #FloofStation
             Lawyer: [ 2, 2 ] #FloofStation
             Prosecutor: [ 1, 1 ] #FloofStation
+

--- a/Resources/Prototypes/Maps/fland.yml
+++ b/Resources/Prototypes/Maps/fland.yml
@@ -61,7 +61,6 @@
             Brigmedic: [ 1, 1 ]
             Prisoner: [ 2, 3 ] # has a small perma so less prisoners
             PrisonGuard: [ 1, 2 ]
-            Lawyer: [ 2, 2 ]
             SeniorOfficer: [ 1, 1 ]
             #supply
             Quartermaster: [ 1, 1 ]
@@ -77,3 +76,8 @@
             Anomaly: [ 4, 4 ] # Floofstation
             #silicon
             Borg: [ 2, 3 ]
+            # Justice added by FloofStation
+            ChiefJustice: [ 1, 1 ] #FloofStation
+            Clerk: [ 1, 1 ] #FloofStation
+            Lawyer: [ 2, 2 ] #FloofStation
+            Prosecutor: [ 1, 1 ] #FloofStation

--- a/Resources/Prototypes/Maps/hammurabi.yml
+++ b/Resources/Prototypes/Maps/hammurabi.yml
@@ -60,7 +60,6 @@
             Clown: [ 1, 1 ]
             HeadOfPersonnel: [ 1, 1 ]
             Janitor: [ 2, 4 ]
-            Lawyer: [ 2, 2 ]
             Mime: [ 1, 2 ]
             Musician: [ 2, 3 ]
             Reporter: [ 2, 2 ]
@@ -80,3 +79,8 @@
             CargoTechnician: [ 2, 4 ]
             SalvageSpecialist: [ 3, 5 ]
             MailCarrier: [ 2, 3 ]
+          # Justice added by FloofStation
+            ChiefJustice: [ 1, 1 ] #FloofStation
+            Clerk: [ 1, 1 ] #FloofStation
+            Lawyer: [ 2, 2 ] #FloofStation
+            Prosecutor: [ 1, 1 ] #FloofStation

--- a/Resources/Prototypes/Maps/hive.yml
+++ b/Resources/Prototypes/Maps/hive.yml
@@ -61,7 +61,6 @@
             Clown: [ 1, 2 ]
             HeadOfPersonnel: [ 1, 1 ]
             Janitor: [ 2, 3 ]
-            Lawyer: [ 2, 2 ]
             Mime: [ 1, 2 ]
             Musician: [ 1, 3 ]
             Reporter: [ 1, 2 ]
@@ -81,3 +80,8 @@
             CargoTechnician: [ 2, 3 ]
             SalvageSpecialist: [ 2, 3 ]
             MailCarrier: [ 2, 2 ]
+          # Justice added by FloofStation
+            ChiefJustice: [ 1, 1 ] #FloofStation
+            Clerk: [ 1, 1 ] #FloofStation
+            Lawyer: [ 2, 2 ] #FloofStation
+            Prosecutor: [ 1, 1 ] #FloofStation

--- a/Resources/Prototypes/Maps/kettle.yml
+++ b/Resources/Prototypes/Maps/kettle.yml
@@ -76,5 +76,8 @@
             Reporter: [ 2, 2 ]
             Zookeeper: [ 1, 1 ]
             Anomaly: [ 4, 4 ] # Floofstation
-            #justice
-            Lawyer: [ 2, 2 ]
+            # Justice added by FloofStation
+            ChiefJustice: [ 1, 1 ] #FloofStation
+            Clerk: [ 1, 1 ] #FloofStation
+            Lawyer: [ 2, 2 ] #FloofStation
+            Prosecutor: [ 1, 1 ] #FloofStation

--- a/Resources/Prototypes/Maps/lighthouse.yml
+++ b/Resources/Prototypes/Maps/lighthouse.yml
@@ -32,7 +32,6 @@
           Boxer: [ 2, 2 ]
           Chef: [ 1, 2 ]
           Clown: [ 1, 1 ]
-          Lawyer: [ 2, 2 ]
           Reporter: [ 0, 2 ]
           Musician: [ 1, 1 ]
           Janitor: [ 1, 2 ]
@@ -80,3 +79,8 @@
           Passenger: [ -1, -1 ]
           # Silicon
           #StationAi: [ 1, 1 ]
+        # Justice added by FloofStation
+          ChiefJustice: [ 1, 1 ] #FloofStation
+          Clerk: [ 1, 1 ] #FloofStation
+          Lawyer: [ 2, 2 ] #FloofStation
+          Prosecutor: [ 1, 1 ] #FloofStation

--- a/Resources/Prototypes/Maps/pebble.yml
+++ b/Resources/Prototypes/Maps/pebble.yml
@@ -30,7 +30,6 @@
             Boxer: [ 2, 2 ]
             Chef: [ 2 , 2 ]
             Clown: [ 1, 1 ]
-            Lawyer: [ 1, 1 ]
             Musician: [ 1, 1 ]
             Janitor: [ 1, 2 ]
             Mime: [ 1, 1 ]
@@ -71,3 +70,8 @@
             CargoTechnician: [ 2, 3 ]
           #civilian
             Passenger: [ -1, -1 ]
+          # Justice added by FloofStation
+            ChiefJustice: [ 1, 1 ] #FloofStation
+            Clerk: [ 1, 1 ] #FloofStation
+            Lawyer: [ 2, 2 ] #FloofStation
+            Prosecutor: [ 1, 1 ] #FloofStation

--- a/Resources/Prototypes/Maps/shoukou.yml
+++ b/Resources/Prototypes/Maps/shoukou.yml
@@ -25,7 +25,6 @@
           Passenger: [ -1, -1 ]
           ServiceWorker: [ 1, 2]
           Reporter: [ 0, 1 ]
-          Lawyer: [ 1, 1 ]
           Bartender: [ 1, 2 ]
           Botanist: [ 1, 2 ]
           MartialArtist: [ 2, 3 ]
@@ -77,3 +76,8 @@
           SalvageSpecialist: [ 2, 4 ]
           MailCarrier: [ 1, 2 ]
           CargoTechnician: [ 2, 3 ]
+          # Justice added by FloofStation
+          ChiefJustice: [ 1, 1 ] #FloofStation
+          Clerk: [ 1, 1 ] #FloofStation
+          Lawyer: [ 2, 2 ] #FloofStation
+          Prosecutor: [ 1, 1 ] #FloofStation

--- a/Resources/Prototypes/Maps/submarine.yml
+++ b/Resources/Prototypes/Maps/submarine.yml
@@ -59,7 +59,6 @@
             Clown: [ 1, 2 ]
             HeadOfPersonnel: [ 1, 1 ]
             Janitor: [ 2, 3 ]
-            Lawyer: [ 2, 2 ]
             MartialArtist: [ 2, 2 ]
             Mime: [ 1, 2 ]
             Musician: [ 2, 2 ]
@@ -80,3 +79,8 @@
             SalvageSpecialist: [ 3, 5 ]
             Quartermaster: [ 1, 1 ]
             InventorySpecialist: [ 1, 1 ] #FloofStation
+          # Justice added by FloofStation
+            ChiefJustice: [ 1, 1 ] #FloofStation
+            Clerk: [ 1, 1 ] #FloofStation
+            Lawyer: [ 2, 2 ] #FloofStation
+            Prosecutor: [ 1, 1 ] #FloofStation

--- a/Resources/Prototypes/Maps/tortuga.yml
+++ b/Resources/Prototypes/Maps/tortuga.yml
@@ -60,7 +60,6 @@
             Clown: [ 1, 2 ]
             HeadOfPersonnel: [ 1, 1 ]
             Janitor: [ 2, 3 ]
-            Lawyer: [ 2, 2 ]
             Mime: [ 1, 2 ]
             Musician: [ 2, 3 ]
             Reporter: [ 2, 2 ]
@@ -80,3 +79,8 @@
             CargoTechnician: [ 2, 4 ]
             SalvageSpecialist: [ 3, 4 ]
             MailCarrier: [ 2, 2 ]
+          # Justice added by FloofStation
+            ChiefJustice: [ 1, 1 ] #FloofStation
+            Clerk: [ 1, 1 ] #FloofStation
+            Lawyer: [ 2, 2 ] #FloofStation
+            Prosecutor: [ 1, 1 ] #FloofStation


### PR DESCRIPTION

# Description

This pr adds justice department slots to the maps that were missing it as per list from discord:

<img width="731" height="686" alt="image" src="https://github.com/user-attachments/assets/89cf44f0-224b-4d43-a05d-b381eb135b35" />

(just slots, NOT spawn points, it willl defoult the spawn to passager spawn points)

---

# TODO

- [ ] Task

---

# Changelog


:cl:
- tweak: added justice department slots to maps that were missing it

