### PR TITLE
[HOTFIX] Hard Grab Throw Weight Check

### DIFF
--- a/Content.Shared/Movement/Pulling/Systems/PullingSystem.cs
+++ b/Content.Shared/Movement/Pulling/Systems/PullingSystem.cs
@@ -311,6 +311,9 @@ public sealed class PullingSystem : EntitySystem
             || component.Pulling != args.BlockingEntity)
             return;
 
+        if (!TryComp<PhysicsComponent>(args.BlockingEntity, out var throweePhysics)) // Floof - Get physics info of throwee
+            return;
+
         if (!TryComp(args.BlockingEntity, out PullableComponent? comp))
             return;
 
@@ -318,6 +321,20 @@ public sealed class PullingSystem : EntitySystem
             || HasComp<GrabThrownComponent>(args.BlockingEntity)
             || component.GrabStage <= GrabStage.Soft)
             return;
+        // Floof Start - Check if the thrower is strong enough to throw the throwee.
+        if (throwerPhysics.Mass * 2f < throweePhysics.Mass)
+        {
+            args.Cancel();
+            _popup.PopupEntity(
+                Loc.GetString(
+                    "popup-grab-throw-fail-weight", ("puller", Identity.Entity(uid, EntityManager)),
+                    ("pulled", Identity.Entity(args.BlockingEntity, EntityManager))),
+                args.BlockingEntity,
+                uid,
+                PopupType.MediumCaution);
+            return;
+        }
+        // Floof End
 
         if (_timing.CurTime < component.WhenCanThrow)
         {

--- a/Resources/Locale/en-US/_Floof/grab/grab.ftl
+++ b/Resources/Locale/en-US/_Floof/grab/grab.ftl
@@ -1,0 +1,1 @@
+﻿popup-grab-throw-fail-weight = {CAPITALIZE($pulled)} is too heavy for you to throw!


### PR DESCRIPTION
<!--
This is a semi-strict format, you can add/remove sections as needed but the order/format should be kept the same
Remove these comments before submitting
-->

# Description

<!--
Explain this PR in as much detail as applicable

Some example prompts to consider:
How might this affect the game? The codebase?
What might be some alternatives to this?
How/Who does this benefit/hurt [the game/codebase]?
-->

**This PR aims to address an issue discovered by the administration shortly after the deployment of #1345, where a thrower can throw *any* hard-grabbed throwee, regardless of weight, due to a missing check.** This results in the player being able to chuck a hard-grabbed xeno queen, which weighs like a freight train, at someone, where the resulting damage due to weight and how it interacts with the throw system, would insta-gib the unfortunate soul.

This is addressed by implementing a weight check in `PullingSystem.cs`, along with the associated FTL.

---

<!--
This is default collapsed, readers click to expand it and see all your media
The PR media section can get very large at times, so this is a good way to keep it clean
The title is written using HTML tags
The title must be within the <summary> tags or you won't see it
-->

<details><summary><h1>Media</h1></summary>
<p>

<img width="306" height="213" alt="image" src="https://github.com/user-attachments/assets/02cff559-60a9-44f1-af4e-733141325a3b" />

</p>
</details>

---

# Changelog

<!--
You can add an author after the `:cl:` to change the name that appears in the changelog (ex: `:cl: Death`)
Leaving it blank will default to your GitHub display name
This includes all available types for the changelog
-->

:cl:
- fix: Hard grab throws will now fail if your character isn't strong enough to do so.
