### PR TITLE
Research and Print Welder Varieties

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
@@ -350,6 +350,8 @@
       - ClothingBackpackSatchelHolding
       - ClothingBackpackDuffelHolding
       - WelderExperimental
+      - WelderIndustrial # Floof
+      - WelderIndustrialAdvanced # Floof
       - JawsOfLife
       - CoreSilver # Nyanotrasen - Silver Golem core
       - FauxTileAstroGrass
@@ -1228,6 +1230,8 @@
       - HolofanProjector
       - HoloprojectorField
       - WelderExperimental
+      - WelderIndustrial # Floof
+      - WelderIndustrialAdvanced # Floof
       - PowerDrill # Can make two of the three advanced tools - jaws of life are too OP to give them away
       - WeaponParticleDecelerator
       - ClothingMaskWeldingGas

--- a/Resources/Prototypes/Research/industrial.yml
+++ b/Resources/Prototypes/Research/industrial.yml
@@ -57,6 +57,7 @@
   - ProtolatheHyperConvectionMachineCircuitboard
   - CircuitImprinterHyperConvectionMachineCircuitboard
   - SheetifierMachineCircuitboard
+  - WelderIndustrial # Floof
 
 - type: technology
   id: PowerGeneration
@@ -165,6 +166,7 @@
   cost: 10000
   recipeUnlocks:
     - WelderExperimental
+    - WelderIndustrialAdvanced # Floof
     - PowerDrill
     - JawsOfLife
     - BorgModuleAdvancedTool

--- a/Resources/Prototypes/_Floof/Recipes/Lathes/tools.yml
+++ b/Resources/Prototypes/_Floof/Recipes/Lathes/tools.yml
@@ -33,3 +33,18 @@
     Glass: 50
     Steel: 100
     Plastic: 50
+
+- type: latheRecipe
+  id: WelderIndustrial
+  result: WelderIndustrial
+  completetime: 4
+  materials:
+    Steel: 800
+
+- type: latheRecipe
+  id: WelderIndustrialAdvanced
+  result: WelderIndustrialAdvanced
+  completetime: 5
+  materials:
+    Steel: 600
+    Plasteel: 200


### PR DESCRIPTION
# Description

Makes the Industrial and Industrial Advanced Welders research-able in the industrial tree at tiers one and two. Also adds them to the dynamic recipes of the protolathe and engineering techfab.

---

# Changelog

:cl: sprkl
- add: More welder varieties can be researched and printed by crew.
