### PR TITLE
Make Platelet Factories Improve Clotting

### DIFF
--- a/Resources/Prototypes/Traits/disabilities.yml
+++ b/Resources/Prototypes/Traits/disabilities.yml
@@ -281,6 +281,10 @@
       inverted: true
       species:
         - IPC
+    - !type:CharacterTraitRequirement
+      inverted: true
+      traits:
+      - PlateletFactories
   functions:
     - !type:TraitAddComponent
       components:

--- a/Resources/Prototypes/Traits/physical.yml
+++ b/Resources/Prototypes/Traits/physical.yml
@@ -573,6 +573,10 @@
       inverted: true
       traits:
         - BloodDeficiency
+    - !type:CharacterTraitRequirement
+      inverted: true
+      traits:
+        - Hemophilia
   functions: # TODO: Code Platelet factories as an actual obtainable implant, and replace this with TraitAddImplant
     - !type:TraitReplaceComponent
       components:
@@ -590,6 +594,9 @@
               Genetic: -0.2
         - type: BloodDeficiency # Incredibly actually works
           bloodLossPercentage: -0.025
+        - type: Hemophilia # Floof: platelets should actually clot?
+          bleedReductionModifier: 2.0
+          damageModifiers: {}
 
 - type: trait
   id: DermalArmor


### PR DESCRIPTION
# Description

platelet factories are now mutually exclusive with hemophilia
this is a balance change and should be analyzed as such. in my testing it was the difference between being able to walk off three melee hits with the captain's sabre with food to replenish blood vs just being able to walk it off (with improved clotting)

in my opinion platelet factories is a stupidly overpowered trait and would benefit from being split into multiple traits that separately:
- reduce bleeding and replenish blood
- passively heal more damage types

---

# Changelog

:cl:
- tweak: Platelet Factories now actually improve clotting, as the name would suggest.