### PR TITLE
Slime Inventory Occlusion

### DIFF
--- a/Content.Shared/Storage/EntitySystems/SharedStorageSystem.cs
+++ b/Content.Shared/Storage/EntitySystems/SharedStorageSystem.cs
@@ -1419,7 +1419,8 @@ public abstract class SharedStorageSystem : EntitySystem
         if (!canInteract)
             return false;
 
-        var ev = new StorageInteractAttemptEvent(silent);
+        // Floof: add User field
+        var ev = new StorageInteractAttemptEvent(user, silent);
         RaiseLocalEvent(storage, ref ev);
 
         return !ev.Cancelled;

--- a/Content.Shared/Storage/StorageComponent.cs
+++ b/Content.Shared/Storage/StorageComponent.cs
@@ -235,8 +235,9 @@ namespace Content.Shared.Storage
         }
     }
 
+    // Floof: add User field
     [ByRefEvent]
-    public record struct StorageInteractAttemptEvent(bool Silent, bool Cancelled = false);
+    public record struct StorageInteractAttemptEvent(EntityUid User, bool Silent, bool Cancelled = false);
 
     [ByRefEvent]
     public record struct StorageInteractUsingAttemptEvent(bool Cancelled = false);

--- a/Content.Shared/_Floof/Clothing/StorageBlockedByClothing/StorageBlockedByClothingComponent.cs
+++ b/Content.Shared/_Floof/Clothing/StorageBlockedByClothing/StorageBlockedByClothingComponent.cs
@@ -1,0 +1,17 @@
+using Content.Shared.Inventory;
+using Robust.Shared.GameStates;
+
+namespace Content.Shared._Floof.Clothing.StorageBlockedByClothing;
+
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
+public sealed partial class StorageBlockedByClothingComponent : Component
+{
+    /// <summary>
+    /// Slots that block storage access
+    /// </summary>
+    [DataField, AutoNetworkedField]
+    public SlotFlags Slots = SlotFlags.NONE;
+
+    [DataField, AutoNetworkedField]
+    public bool SelfCanAccess = true;
+}

--- a/Content.Shared/_Floof/Clothing/StorageBlockedByClothing/StorageBlockedByClothingComponent.cs
+++ b/Content.Shared/_Floof/Clothing/StorageBlockedByClothing/StorageBlockedByClothingComponent.cs
@@ -1,5 +1,7 @@
 using Content.Shared.Inventory;
+using Content.Shared.Tag;
 using Robust.Shared.GameStates;
+using Robust.Shared.Prototypes;
 
 namespace Content.Shared._Floof.Clothing.StorageBlockedByClothing;
 
@@ -7,11 +9,20 @@ namespace Content.Shared._Floof.Clothing.StorageBlockedByClothing;
 public sealed partial class StorageBlockedByClothingComponent : Component
 {
     /// <summary>
-    /// Slots that block storage access
+    /// Slots that block storage access when occupied.
     /// </summary>
     [DataField, AutoNetworkedField]
     public SlotFlags Slots = SlotFlags.NONE;
 
+    /// <summary>
+    /// If set to true, the entity can always access its own storage.
+    /// </summary>
     [DataField, AutoNetworkedField]
     public bool SelfCanAccess = true;
+
+    /// <summary>
+    /// Items with any of these tags will not block storage.
+    /// </summary>
+    [DataField, AutoNetworkedField]
+    public List<ProtoId<TagPrototype>> AllowedTags = new();
 }

--- a/Content.Shared/_Floof/Clothing/StorageBlockedByClothing/StorageBlockedByClothingSystem.cs
+++ b/Content.Shared/_Floof/Clothing/StorageBlockedByClothing/StorageBlockedByClothingSystem.cs
@@ -1,0 +1,60 @@
+using Content.Shared.Clothing;
+using Content.Shared.Inventory;
+using Content.Shared.Storage;
+
+namespace Content.Shared._Floof.Clothing.StorageBlockedByClothing;
+
+public sealed class StorageBlockedByClothingSystem : EntitySystem
+{
+    [Dependency] private readonly InventorySystem _inventory = default!;
+    [Dependency] private readonly SharedUserInterfaceSystem _ui = default!;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeLocalEvent<StorageBlockedByClothingComponent, ClothingDidEquippedEvent>(OnClothingEquipped);
+        SubscribeLocalEvent<StorageBlockedByClothingComponent, StorageInteractAttemptEvent>(OnStorageInteractAttempt);
+    }
+
+    private void OnClothingEquipped(Entity<StorageBlockedByClothingComponent> ent, ref ClothingDidEquippedEvent args)
+    {
+        if (!TryComp(ent, out InventoryComponent? inventory))
+            return;
+        if (!TryComp(ent, out UserInterfaceComponent? ui))
+            return;
+
+        if (!IsBlocked(new(ent, inventory), ent.Comp))
+            return;
+
+        foreach (var actor in _ui.GetActors(new(ent, ui), StorageComponent.StorageUiKey.Key))
+        {
+            if (ent.Comp.SelfCanAccess && actor == ent.Owner)
+                continue;
+
+            _ui.CloseUi(new(ent, ui), StorageComponent.StorageUiKey.Key, actor);
+        }
+    }
+
+    private void OnStorageInteractAttempt(Entity<StorageBlockedByClothingComponent> ent, ref StorageInteractAttemptEvent args)
+    {
+        if (ent.Comp.SelfCanAccess && args.User == ent.Owner)
+            return;
+
+        if (!TryComp(ent, out InventoryComponent? inventory))
+            return;
+
+        if (IsBlocked(new(ent, inventory), ent.Comp))
+            args.Cancelled = true;
+    }
+
+    private bool IsBlocked(Entity<InventoryComponent> ent, StorageBlockedByClothingComponent comp)
+    {
+        for (var i = 0; i < ent.Comp.Slots.Length; i++)
+        {
+            if ((ent.Comp.Slots[i].SlotFlags & comp.Slots) != 0 && ent.Comp.Containers[i].ContainedEntity is { Valid: true })
+                return true;
+        }
+        return false;
+    }
+}

--- a/Content.Shared/_Floof/Clothing/StorageBlockedByClothing/StorageBlockedByClothingSystem.cs
+++ b/Content.Shared/_Floof/Clothing/StorageBlockedByClothing/StorageBlockedByClothingSystem.cs
@@ -1,3 +1,4 @@
+using Content.Shared._Floof.Clothing.SlotBlocker;
 using Content.Shared.Clothing;
 using Content.Shared.Inventory;
 using Content.Shared.Storage;
@@ -9,6 +10,7 @@ public sealed class StorageBlockedByClothingSystem : EntitySystem
 {
     [Dependency] private readonly SharedUserInterfaceSystem _ui = default!;
     [Dependency] private readonly TagSystem _tag = default!;
+    [Dependency] private readonly SlotBlockerSystem _slotBlocker = default!;
 
     public override void Initialize()
     {
@@ -51,6 +53,16 @@ public sealed class StorageBlockedByClothingSystem : EntitySystem
 
     private bool IsBlocked(Entity<InventoryComponent> ent, StorageBlockedByClothingComponent comp)
     {
+        // if our slots are obstructed
+        if (_slotBlocker.IsSlotObstructed(
+            ent,
+            null,
+            SlotBlockerSystem.CheckType.IgnoreBlockerPreference,
+            comp.Slots,
+            out _))
+            return true;
+
+        // or if they have non-allowed items
         for (var i = 0; i < ent.Comp.Slots.Length; i++)
         {
             if ((ent.Comp.Slots[i].SlotFlags & comp.Slots) != 0

--- a/Content.Shared/_Floof/Clothing/StorageBlockedByClothing/StorageBlockedByClothingSystem.cs
+++ b/Content.Shared/_Floof/Clothing/StorageBlockedByClothing/StorageBlockedByClothingSystem.cs
@@ -1,13 +1,14 @@
 using Content.Shared.Clothing;
 using Content.Shared.Inventory;
 using Content.Shared.Storage;
+using Content.Shared.Tag;
 
 namespace Content.Shared._Floof.Clothing.StorageBlockedByClothing;
 
 public sealed class StorageBlockedByClothingSystem : EntitySystem
 {
-    [Dependency] private readonly InventorySystem _inventory = default!;
     [Dependency] private readonly SharedUserInterfaceSystem _ui = default!;
+    [Dependency] private readonly TagSystem _tag = default!;
 
     public override void Initialize()
     {
@@ -52,7 +53,9 @@ public sealed class StorageBlockedByClothingSystem : EntitySystem
     {
         for (var i = 0; i < ent.Comp.Slots.Length; i++)
         {
-            if ((ent.Comp.Slots[i].SlotFlags & comp.Slots) != 0 && ent.Comp.Containers[i].ContainedEntity is { Valid: true })
+            if ((ent.Comp.Slots[i].SlotFlags & comp.Slots) != 0
+                    && ent.Comp.Containers[i].ContainedEntity is { Valid: true } item
+                    && !_tag.HasAnyTag(item, comp.AllowedTags))
                 return true;
         }
         return false;

--- a/Resources/Prototypes/Entities/Mobs/Species/slime.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/slime.yml
@@ -27,6 +27,8 @@
     slots:
     - INNERCLOTHING
     - OUTERCLOTHING
+    allowedTags:
+    - ShirtlessClothing
   - type: ContainerContainer
     containers:
       storagebase: !type:Container

--- a/Resources/Prototypes/Entities/Mobs/Species/slime.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/slime.yml
@@ -26,7 +26,6 @@
   - type: StorageBlockedByClothing # Floof
     slots:
     - INNERCLOTHING
-    - OUTERCLOTHING
     allowedTags:
     - ShirtlessClothing
   - type: ContainerContainer

--- a/Resources/Prototypes/Entities/Mobs/Species/slime.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/slime.yml
@@ -21,6 +21,12 @@
     maxItemSize: Large
     storageInsertSound:
       path: /Audio/Voice/Slime/slime_squish.ogg
+    storageRemoveSound: # Floof: add remove sound too
+      path: /Audio/Voice/Slime/slime_squish.ogg
+  - type: StorageBlockedByClothing # Floof
+    slots:
+    - INNERCLOTHING
+    - OUTERCLOTHING
   - type: ContainerContainer
     containers:
       storagebase: !type:Container


### PR DESCRIPTION
# Description

Other people can no longer access the internal storage of slime people if they're wearing clothes. This allows their internal storage to be somewhat private as long as they have inner/outer clothing on, though certain clothing items with the ShirtlessClothing tag (such as Public Nudity Permit) will allow access through them.

---

# Changelog

:cl:
- tweak: The internal storage of slime people is no longer accessible from the outside while wearing clothes.