### PR TITLE
Make Subtle Actually Filterable By All Players.

### DIFF
--- a/Content.Client/UserInterface/Systems/Chat/ChatUIController.cs
+++ b/Content.Client/UserInterface/Systems/Chat/ChatUIController.cs
@@ -552,7 +552,7 @@ public sealed class ChatUIController : UIController
             if (_ghost is not {IsGhost: true})
             {
                 FilterableChannels |= ChatChannel.Subtle;
-                FilterableChannels |= ChatChannel.SubtleOOC;
+                /*FilterableChannels |= ChatChannel.SubtleOOC;*/ // Floof - Deprecated
                 CanSendChannels |= ChatSelectChannel.Local;
                 CanSendChannels |= ChatSelectChannel.Whisper;
                 CanSendChannels |= ChatSelectChannel.Radio;
@@ -567,14 +567,17 @@ public sealed class ChatUIController : UIController
         {
             FilterableChannels |= ChatChannel.Dead;
             CanSendChannels |= ChatSelectChannel.Dead;
+            FilterableChannels |= ChatChannel.Subtle; // Floof - M3739 - So it can be filtered out proper.
         }
-
+        // Floof Start
+        /* 
         if (_admin.HasFlag(AdminFlags.Pii) && _ghost is { IsGhost: true })
         {
             FilterableChannels |= ChatChannel.Subtle;
             FilterableChannels |= ChatChannel.SubtleOOC;
-        }
-
+        }*/
+        // Floof End
+        
         // only admins can see / filter asay
         if (_admin.HasFlag(AdminFlags.Adminchat))
         {


### PR DESCRIPTION
<!--
This is a semi-strict format, you can add/remove sections as needed but the order/format should be kept the same
Remove these comments before submitting
-->

# Description

<!--
Explain this PR in as much detail as applicable

Some example prompts to consider:
How might this affect the game? The codebase?
What might be some alternatives to this?
How/Who does this benefit/hurt [the game/codebase]?
-->

**It's one thing when it's a bug. It's another when it causes admins to have their sanity slowly leave their body by unintentionally witnessing someone else's smut in the text chat, and they can't filter it out because for some odd reason, they needed a pretty sensitive and powerful permission to do so.**

Why a client-side ability to filter out a channel everyone in-game had access to, behind a admin permission relating to personally identifiable information, is beyond me. But after some debugging, that is indeed the case.

So therefore, I have made the executive decision (with some suggestions from Mnemo) to remove the check entirely, and alter the code a bit so ALL players, admins, observers, and in-game players have the ability to filter out this channel.

---

<!--
This is default collapsed, readers click to expand it and see all your media
The PR media section can get very large at times, so this is a good way to keep it clean
The title is written using HTML tags
The title must be within the <summary> tags or you won't see it
-->

<details><summary><h1>Media</h1></summary>
<p>

## Without Admin, Ghost:
<img width="1264" height="554" alt="Pasted image 20250828223130" src="https://github.com/user-attachments/assets/f4e23271-5971-4ba1-9e9b-4f1e20c4bfde" />
## With Admin, Ghost:
<img width="1269" height="547" alt="Pasted image 20250828223204" src="https://github.com/user-attachments/assets/f4fade31-7783-43e0-9a8b-8cc5e6aea950" />
## In-game Player:
<img width="1262" height="639" alt="Pasted image 20250828223333" src="https://github.com/user-attachments/assets/8449b61b-5f11-4ae1-bf79-b6188d873b81" />

</p>
</details>

---

# Changelog

<!--
You can add an author after the `:cl:` to change the name that appears in the changelog (ex: `:cl: Death`)
Leaving it blank will default to your GitHub display name
This includes all available types for the changelog
-->

:cl:
- fix: Ghosts can now properly filter out 'Subtle' messages.
