### PR TITLE
Port Autocall From The Den, No. 626

### DIFF
--- a/Content.Client/Voting/VoteManager.cs
+++ b/Content.Client/Voting/VoteManager.cs
@@ -138,7 +138,9 @@ namespace Content.Client.Voting
                     return;
                 }
 
-                _voteSource?.Restart();
+                if (message.PlayVoteSound)
+                    _voteSource?.Restart();
+
                 @new = true;
 
                 // Refresh

--- a/Content.Server/RoundEnd/RoundEndSystem.cs
+++ b/Content.Server/RoundEnd/RoundEndSystem.cs
@@ -71,7 +71,7 @@ namespace Content.Server.RoundEnd
         /// <summary>
         /// Should we not allow recall due to round hard end being met?
         /// </summary>
-        public bool RespectRoundHardEnd { get; set; } = true;
+        public bool RespectRoundHardEnd { get; set; } = false; // Floof
 
         private CancellationTokenSource? _countdownTokenSource = null;
         private CancellationTokenSource? _cooldownTokenSource = null;

--- a/Content.Server/Voting/Managers/VoteManager.cs
+++ b/Content.Server/Voting/Managers/VoteManager.cs
@@ -209,7 +209,7 @@ namespace Content.Server.Voting.Managers
             var start = _timing.RealTime;
             var end = start + options.Duration;
             var reg = new VoteReg(id, entries, options.Title, options.InitiatorText,
-                options.InitiatorPlayer, start, end);
+                options.InitiatorPlayer, start, end, options.PlayVoteSound);
 
             var handle = new VoteHandle(this, reg);
 
@@ -251,6 +251,7 @@ namespace Content.Server.Voting.Managers
                 msg.VoteInitiator = v.InitiatorText;
                 msg.StartTime = v.StartTime;
                 msg.EndTime = v.EndTime;
+                msg.PlayVoteSound = v.PlayVoteSound;
             }
 
             if (v.CastVotes.TryGetValue(player, out var cast))
@@ -444,6 +445,7 @@ namespace Content.Server.Voting.Managers
             public readonly HashSet<ICommonSession> VotesDirty = new();
 
             public bool Cancelled;
+            public bool PlayVoteSound;
             public bool Finished;
             public bool Dirty = true;
 
@@ -452,7 +454,7 @@ namespace Content.Server.Voting.Managers
             public ICommonSession? Initiator { get; }
 
             public VoteReg(int id, VoteEntry[] entries, string title, string initiatorText,
-                ICommonSession? initiator, TimeSpan start, TimeSpan end)
+                ICommonSession? initiator, TimeSpan start, TimeSpan end, bool playVoteSound)
             {
                 Id = id;
                 Entries = entries;
@@ -461,6 +463,7 @@ namespace Content.Server.Voting.Managers
                 Initiator = initiator;
                 StartTime = start;
                 EndTime = end;
+                PlayVoteSound = playVoteSound;
             }
         }
 

--- a/Content.Server/Voting/VoteOptions.cs
+++ b/Content.Server/Voting/VoteOptions.cs
@@ -40,6 +40,11 @@ namespace Content.Server.Voting
         public List<(string text, object data)> Options { get; set; } = new();
 
         /// <summary>
+        ///     Whether the iconic vote sound should play or not.
+        /// </summary>
+        public bool PlayVoteSound { get; set; } = true;
+
+        /// <summary>
         ///     Sets <see cref="InitiatorPlayer"/> and <see cref="InitiatorText"/>
         ///     by setting the latter to the player's name.
         /// </summary>

--- a/Content.Server/_DEN/RoundEnd/RoundEndSystem.DEN.cs
+++ b/Content.Server/_DEN/RoundEnd/RoundEndSystem.DEN.cs
@@ -1,0 +1,113 @@
+using System.Threading;
+using Content.Server.Voting;
+using Content.Shared.CCVar;
+using Robust.Shared.Player;
+using Timer = Robust.Shared.Timing.Timer;
+
+
+namespace Content.Server.RoundEnd;
+
+
+public sealed partial class RoundEndSystem
+{
+    private void InitializeDen()
+    {
+        InitializeTimer();
+
+        SubscribeLocalEvent<CanCallOrRecallEvent>(CheckIfCanCallOrRecall);
+        SubscribeLocalEvent<ShuttleAutoCallAttemptedEvent>(OnShuttleAutoCallAttempted);
+    }
+
+    private TimeSpan WarnAt() => RoundHardEnd - RoundHardEndWarningTime;
+
+    private void InitializeTimer()
+    {
+        Timer.Spawn(WarnAt(), SendWarningAnnouncement);
+        Timer.Spawn(RoundHardEnd, UpdateRoundEnd);
+    }
+
+    private void CheckIfCanCallOrRecall(ref CanCallOrRecallEvent ev)
+    {
+        if (_gameTicker.RoundDuration() > RoundHardEnd && RespectRoundHardEnd)
+            ev.Cancelled = true;
+    }
+
+    private void ShuttleRecallVoteFinished(VoteFinishedEventArgs args)
+    {
+        if (args.Winner == null)
+            return;
+
+        var votedYes = (bool) args.Winner;
+
+        if (votedYes || !CanCallOrRecallIgnoringCooldown())
+            return;
+
+        RequestRoundEnd(null, false, "round-end-system-shuttle-auto-called-announcement");
+        _autoCalledBefore = true;
+    }
+
+    /// <summary>
+    /// Send recall vote.
+    /// </summary>
+    private void OnShuttleAutoCallAttempted(ref ShuttleAutoCallAttemptedEvent ev)
+    {
+        if (!CanCallOrRecallIgnoringCooldown())
+            return;
+
+        var alone = _playerManager.PlayerCount == 1;
+        var options = new VoteOptions
+        {
+            Title = Loc.GetString("ui-vote-recall-title"),
+            Duration = alone
+                ? TimeSpan.FromSeconds(_cfg.GetCVar(CCVars.VoteTimerAlone))
+                : TimeSpan.FromSeconds(_cfg.GetCVar(CCVars.VoteTimerRestart)) // just use restart vote timer
+        };
+
+        var localeYes = Loc.GetString("ui-vote-restart-yes");
+        var localeNo = Loc.GetString("ui-vote-restart-no");
+
+        options.InitiatorText = "Server";
+        options.PlayVoteSound = false; // we expect to be doing this several times a shift.
+        options.Options.Add((localeYes, true));
+        options.Options.Add((localeNo, false));
+
+        var recallVote = _voteManager.CreateVote(options);
+        recallVote.OnFinished += (_, args) => ShuttleRecallVoteFinished(args);
+    }
+
+    public void UpdateRoundEnd() => RaiseLocalEvent(RoundEndSystemChangedEvent.Default);
+
+    private void SendWarningAnnouncement()
+    {
+        if (!RespectRoundHardEnd)
+            return;
+
+        var warnAt = WarnAt();
+
+        int time;
+        string units;
+
+        if (warnAt.TotalSeconds < 60)
+        {
+            time = warnAt.Seconds;
+            units = "eta-units-seconds";
+        }
+        else
+        {
+            time = warnAt.Minutes;
+            units = "eta-units-minutes";
+        }
+
+        _announcer.SendAnnouncement(
+            _announcer.GetAnnouncementId("CommandReport"),
+            Filter.Broadcast(),
+            "round-end-system-shuttle-no-longer-recall-soon",
+            "Station",
+            Color.Gold,
+            null,
+            null,
+            ("time", time),
+            ("units", Loc.GetString(units))
+        );
+    }
+}

--- a/Content.Server/_DEN/RoundEnd/RoundEndSystem.DEN.cs
+++ b/Content.Server/_DEN/RoundEnd/RoundEndSystem.DEN.cs
@@ -66,7 +66,7 @@ public sealed partial class RoundEndSystem
         var localeYes = Loc.GetString("ui-vote-restart-yes");
         var localeNo = Loc.GetString("ui-vote-restart-no");
 
-        options.InitiatorText = "Server";
+        options.InitiatorText = "Central Command";
         options.PlayVoteSound = false; // we expect to be doing this several times a shift.
         options.Options.Add((localeYes, true));
         options.Options.Add((localeNo, false));

--- a/Content.Server/_DEN/RoundEnd/ToggleHardEndCommand.cs
+++ b/Content.Server/_DEN/RoundEnd/ToggleHardEndCommand.cs
@@ -1,0 +1,24 @@
+using Content.Server.Administration;
+using Content.Shared.Administration;
+using Robust.Shared.Console;
+
+namespace Content.Server.RoundEnd;
+
+[AdminCommand(AdminFlags.Admin)]
+public sealed class ToggleHardEndCommand : IConsoleCommand
+{
+    public string Command { get; } = "togglehardend";
+    public string Description { get; } = "Toggles whether or not recall should be allowed after hard end is reached.";
+    public string Help { get; } = "togglehardend";
+
+    public void Execute(IConsoleShell shell, string argStr, string[] args)
+    {
+        var sysManager = IoCManager.Resolve<IEntitySystemManager>();
+        var roundEndSystem = sysManager.GetEntitySystem<RoundEndSystem>();
+        roundEndSystem.RespectRoundHardEnd = !roundEndSystem.RespectRoundHardEnd;
+        roundEndSystem.UpdateRoundEnd();
+
+        var toggled = roundEndSystem.RespectRoundHardEnd ? "will now" : "will no longer";
+        shell.WriteLine($"The round {toggled} end when hard end is reached.");
+    }
+}

--- a/Content.Shared/Voting/MsgVoteData.cs
+++ b/Content.Shared/Voting/MsgVoteData.cs
@@ -14,6 +14,7 @@ namespace Content.Shared.Voting
         public string VoteInitiator = string.Empty;
         public TimeSpan StartTime; // Server RealTime.
         public TimeSpan EndTime; // Server RealTime.
+        public bool PlayVoteSound;
         public (ushort votes, string name)[] Options = default!;
         public bool IsYourVoteDirty;
         public byte? YourVote;

--- a/Resources/Locale/en-US/communications/communications-console-component.ftl
+++ b/Resources/Locale/en-US/communications/communications-console-component.ftl
@@ -2,9 +2,13 @@
 comms-console-menu-title = Communications Console
 comms-console-menu-announcement-placeholder = Announcement text...
 comms-console-menu-announcement-button = Announce
+comms-console-menu-announcement-button-tooltip = Send your message as a station-wide radio announcement.
 comms-console-menu-broadcast-button = Broadcast
+comms-console-menu-broadcast-button-tooltip = Broadcast your message to wall-mounted screens around the station. Note: They fit only ten characters!
+comms-console-menu-alert-level-button-tooltip = Change the station alert level. Applies immediately on selecting.
 comms-console-menu-call-shuttle = Call emergency shuttle
 comms-console-menu-recall-shuttle = Recall emergency shuttle
+comms-console-menu-emergency-shuttle-button-tooltip = Calls or recalls the emergency shuttle. You can only recall when there's enough time left.
 comms-console-menu-time-remaining = Time remaining: {$time}
 
 # Popup
@@ -21,3 +25,4 @@ comms-console-announcement-title-station = Communications Console
 comms-console-announcement-title-centcom = Central Command
 comms-console-announcement-title-nukie = Syndicate Nuclear Operative
 comms-console-announcement-title-station-ai = Station AI
+comms-console-announcement-title-wizard = Wizard

--- a/Resources/Locale/en-US/round-end/round-end-system.ftl
+++ b/Resources/Locale/en-US/round-end/round-end-system.ftl
@@ -2,9 +2,15 @@
 
 round-end-system-shuttle-called-announcement = An emergency shuttle has been sent. ETA: {$time} {$units}.
 round-end-system-shuttle-already-called-announcement = An emergency shuttle has already been sent.
+round-end-system-shuttle-no-longer-recall-soon = The emergency shuttle will no longer be recallable in {$time} {$units}.
+round-end-system-shuttle-no-longer-recall = The maximum Central Command shift time has been reached, and the emergency shuttle can no longer be recalled. If Central Command does not intervene, the emergency shuttle will arrive as normal in {$time} {$units}.
 round-end-system-shuttle-auto-called-announcement = An automatic crew shift change shuttle has been sent. ETA: {$time} {$units}. Recall the shuttle to extend the shift.
 round-end-system-shuttle-recalled-announcement = The emergency shuttle has been recalled.
 round-end-system-round-restart-eta-announcement = Restarting the round in {$time} {$units}...
 
 eta-units-minutes = minutes
 eta-units-seconds = seconds
+
+ui-vote-recall-title = Extend the round?
+ui-vote-yes = Yes
+ui-vote-no = No

--- a/Resources/Locale/en-US/round-end/round-end-system.ftl
+++ b/Resources/Locale/en-US/round-end/round-end-system.ftl
@@ -11,6 +11,6 @@ round-end-system-round-restart-eta-announcement = Restarting the round in {$time
 eta-units-minutes = minutes
 eta-units-seconds = seconds
 
-ui-vote-recall-title = Extend the round?
+ui-vote-recall-title = Call the emergency shuttle (end the shift)?
 ui-vote-yes = Yes
 ui-vote-no = No


### PR DESCRIPTION
<!--
This is a semi-strict format, you can add/remove sections as needed but the order/format should be kept the same
Remove these comments before submitting
-->

# Description

<!--
Explain this PR in as much detail as applicable

Some example prompts to consider:
How might this affect the game? The codebase?
What might be some alternatives to this?
How/Who does this benefit/hurt [the game/codebase]?
-->

This PR aims to cherry-pick a PR from The Den, No. 626.

626 makes the hourly shuttle call now handled by an OOC vote. Depending on the results of said vote, it will handle automatically recalling the shuttle, or letting it continue on it's merry way.

This also comes with a hard end system, which will be disabled by default.

---

<!--
This is default collapsed, readers click to expand it and see all your media
The PR media section can get very large at times, so this is a good way to keep it clean
The title is written using HTML tags
The title must be within the <summary> tags or you won't see it
-->

<details><summary><h1>Media</h1></summary>
<p>

<img width="237" height="83" alt="image" src="https://github.com/user-attachments/assets/a1656ece-3fce-4d9b-93b8-301a7c5ebfe4" />

</p>
</details>

---

# Changelog

<!--
You can add an author after the `:cl:` to change the name that appears in the changelog (ex: `:cl: Death`)
Leaving it blank will default to your GitHub display name
This includes all available types for the changelog
-->

:cl: The Den
- add: The hourly shuttle call is now handled via an automated OOC vote.
