### PR TITLE
Let Organs Be Preserved in the Fridge Like Meat

### DIFF
--- a/Resources/Prototypes/Body/Organs/base.yml
+++ b/Resources/Prototypes/Body/Organs/base.yml
@@ -9,6 +9,10 @@
   - type: RotInto
     entity: AshOrganic
     stage: 2
+  # Floof: let organs be preserved in cold environments
+  - type: AtmosExposed
+  - type: Temperature
+    currentTemperature: 290 # copied from meat
 
 # Simply to distinguish from normal ash. TODO: make this an actual unique entity rather than just renamed ash.
 - type: entity


### PR DESCRIPTION
# Description

As @Raikyr0 pointed out on discord, organs are not preserved in the freezer like meat. This is because they lacked a TemperatureComponent (and AtmosExposed to exchange heat with the air). This PR addresses the issue by adding Temperature and AtmosExposed to the BaseOrganRotting prototype that all rot-prone organs inherit from.

---

# Changelog

:cl:
- fix: Organs no longer rot in the freezer.