### PR TITLE
Merge Upstream - Fe69fe6, Fixes Pulling Breaking if the Mob that Is Being Pulled Dies

### DIFF
--- a/Content.Shared/Mobs/Systems/MobStateSystem.Subscribers.cs
+++ b/Content.Shared/Mobs/Systems/MobStateSystem.Subscribers.cs
@@ -123,10 +123,6 @@ public partial class MobStateSystem
                 RemComp<CollisionWakeComponent>(target);
                 if (component.CurrentState is MobState.Alive)
                     _standing.Stand(target);
-
-                if (!_standing.IsDown(target) && TryComp<PhysicsComponent>(target, out var physics))
-                    _physics.SetCanCollide(target, true, body: physics);
-
                 break;
             case MobState.Invalid:
                 //unused
@@ -164,10 +160,6 @@ public partial class MobStateSystem
                 EnsureComp<CollisionWakeComponent>(target);
                 if (component.DownWhenDead)
                     _standing.Down(target);
-
-                if (_standing.IsDown(target) && TryComp<PhysicsComponent>(target, out var physics))
-                    _physics.SetCanCollide(target, false, body: physics);
-
                 _appearance.SetData(target, MobStateVisuals.State, MobState.Dead);
                 break;
             case MobState.Invalid:


### PR DESCRIPTION
Cherrypicks commit ``fe69fe6`` from https://github.com/Simple-Station/Einstein-Engines/commit/fe69fe6e546e9a1c65a7021a7b91d549ab46723e

This fixes pulls breaking when the mob that is being pulled dies while in crit

:cl: Wizden
- fix: Fixed pulls breaking if the mob you are pulling dies
