### PR TITLE
Don't Leave a Used GrantCqc Component on the Chef

### DIFF
--- a/Content.Shared/_Goobstation/MartialArts/SharedMartialArtsSystem.CQC.cs
+++ b/Content.Shared/_Goobstation/MartialArts/SharedMartialArtsSystem.CQC.cs
@@ -41,6 +41,9 @@ public partial class SharedMartialArtsSystem
 
             if (TryComp<MartialArtsKnowledgeComponent>(ent, out var knowledge))
                 knowledge.Blocked = true;
+
+            // Floof: Don't leave the component lying around on Chef since it affects examine text.
+            RemComp<GrantCqcComponent>(ent);
         }
 
     private void OnGrantCQCUse(Entity<GrantCqcComponent> ent, ref UseInHandEvent args)


### PR DESCRIPTION
# Description

Fixes used CQC manual text appearing on examine:
<img width="412" height="146" alt="image" src="https://github.com/user-attachments/assets/3910c53f-bb93-42e9-83b0-a4b61b68a242" />

---

# Changelog

:cl:
- fix: The chef no longer appears to be "already used".