### PR TITLE
Remove CC Items From Uniform Printer.

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
@@ -1697,13 +1697,13 @@
       # Floofstation section end
   - type: EmagLatheRecipes
     emagStaticRecipes:
-      - ClothingHeadHatCentcomcap
-      - ClothingHeadHatCentcom
-      - ClothingUniformJumpsuitCentcomAgent
-      - ClothingUniformJumpsuitCentcomFormal
-      - ClothingUniformJumpskirtCentcomFormalDress
-      - ClothingUniformJumpsuitCentcomOfficer
-      - ClothingUniformJumpsuitCentcomOfficial
+      # - ClothingHeadHatCentcomcap # Start - Floof - Remove CC recipes.
+      # - ClothingHeadHatCentcom
+      # - ClothingUniformJumpsuitCentcomAgent
+      # - ClothingUniformJumpsuitCentcomFormal
+      # - ClothingUniformJumpskirtCentcomFormalDress
+      # - ClothingUniformJumpsuitCentcomOfficer
+      # - ClothingUniformJumpsuitCentcomOfficial # End - Floof - Remove CC recipes.
       - ClothingHeadHatSyndieMAA
       - ClothingHeadHatSyndie
       - ClothingUniformJumpsuitOperative
@@ -1716,7 +1716,7 @@
       - ClothingUniformJumpsuitPyjamaSyndicatePink
       - ClothingHeadPyjamaSyndicateRed
       - ClothingUniformJumpsuitPyjamaSyndicateRed
-      - ClothingOuterWinterCentcom
+      # - ClothingOuterWinterCentcom # Floof - Remove CC recipes.
       - ClothingOuterWinterSyndie
       - ClothingOuterWinterSyndieCap
       # Floofstation - Department Socks, Armwarmers ect

--- a/Resources/Prototypes/Recipes/Lathes/clothing.yml
+++ b/Resources/Prototypes/Recipes/Lathes/clothing.yml
@@ -93,50 +93,52 @@
   materials:
     Cloth: 500 #It's armored but I don't want to include durathread for a non-head
 
-- type: latheRecipe
-  id: ClothingUniformJumpsuitCentcomAgent
-  result: ClothingUniformJumpsuitCentcomAgent
-  category: ClothingOther # Floof - add uniform printer clothing categories
-  completetime: 4
-  materials:
-    Cloth: 300
-    Durathread: 100
+# Start - Floof - To stop potential confusion on who is an admin and accidental rule-breaks.
+# - type: latheRecipe
+#   id: ClothingUniformJumpsuitCentcomAgent
+#   result: ClothingUniformJumpsuitCentcomAgent
+#   category: ClothingOther # Floof - add uniform printer clothing categories
+#   completetime: 4
+#   materials:
+#     Cloth: 300
+#     Durathread: 100
 
-- type: latheRecipe
-  id: ClothingUniformJumpsuitCentcomFormal
-  result: ClothingUniformJumpsuitCentcomFormal
-  category: ClothingOther # Floof - add uniform printer clothing categories
-  completetime: 4
-  materials:
-    Cloth: 300
-    Durathread: 100
+# - type: latheRecipe
+#   id: ClothingUniformJumpsuitCentcomFormal
+#   result: ClothingUniformJumpsuitCentcomFormal
+#   category: ClothingOther # Floof - add uniform printer clothing categories
+#   completetime: 4
+#   materials:
+#     Cloth: 300
+#     Durathread: 100
 
-- type: latheRecipe
-  id: ClothingUniformJumpskirtCentcomFormalDress
-  result: ClothingUniformJumpskirtCentcomFormalDress
-  category: ClothingOther # Floof - add uniform printer clothing categories
-  completetime: 4
-  materials:
-    Cloth: 300
-    Durathread: 100
+# - type: latheRecipe
+#   id: ClothingUniformJumpskirtCentcomFormalDress
+#   result: ClothingUniformJumpskirtCentcomFormalDress
+#   category: ClothingOther # Floof - add uniform printer clothing categories
+#   completetime: 4
+#   materials:
+#     Cloth: 300
+#     Durathread: 100
 
-- type: latheRecipe
-  id: ClothingUniformJumpsuitCentcomOfficer
-  result: ClothingUniformJumpsuitCentcomOfficer
-  category: ClothingOther # Floof - add uniform printer clothing categories
-  completetime: 4
-  materials:
-    Cloth: 300
-    Durathread: 100
+# - type: latheRecipe
+#   id: ClothingUniformJumpsuitCentcomOfficer
+#   result: ClothingUniformJumpsuitCentcomOfficer
+#   category: ClothingOther # Floof - add uniform printer clothing categories
+#   completetime: 4
+#   materials:
+#     Cloth: 300
+#     Durathread: 100
 
-- type: latheRecipe
-  id: ClothingUniformJumpsuitCentcomOfficial
-  result: ClothingUniformJumpsuitCentcomOfficial
-  category: ClothingOther # Floof - add uniform printer clothing categories
-  completetime: 4
-  materials:
-    Cloth: 300
-    Durathread: 100
+# - type: latheRecipe
+#   id: ClothingUniformJumpsuitCentcomOfficial
+#   result: ClothingUniformJumpsuitCentcomOfficial
+#   category: ClothingOther # Floof - add uniform printer clothing categories
+#   completetime: 4
+#   materials:
+#     Cloth: 300
+#     Durathread: 100
+# End - Floof
 
 - type: latheRecipe
   id: ClothingUniformJumpsuitChiefEngineer


### PR DESCRIPTION
# Description

Per moderator request, this PR removes the CC items from emagged uniform printers to reduce confusion and help admins.

---

<details><summary><h1>Before</h1></summary>
<p>
<img width="864" height="568" alt="BEFORE" src="https://github.com/user-attachments/assets/8bcf1371-4a60-4850-ac3b-fb2fe0d583ad" />
</p>
</details>

<details><summary><h1>After
</h1></summary>
<p>
<img width="1003" height="615" alt="After" src="https://github.com/user-attachments/assets/de8cd9e8-9d18-4191-b59b-a93e7d19a5cf" />
</p>
</details>

---

# Changelog

:cl:
- remove: Emagged Uniform Printer can no longer print CC clothing.
