### PR TITLE
Name Fix for Radar Console

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Devices/Circuitboards/computer.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/Circuitboards/computer.yml
@@ -290,7 +290,7 @@
 - type: entity
   parent: BaseComputerCircuitboard
   id: RadarConsoleCircuitboard
-  name: radar console computer board
+  name: mass scanner computer board
   components:
   - type: ComputerBoard
     prototype: ComputerRadar


### PR DESCRIPTION
# Description
Changes the Radar Console Computer Board to Mass Scanner Computer Board, since it makes a mass scanner.

# Changelog
:cl:
- fix: Changed Radar Console to Mass Scanner, because a radar board makes a mass scanner, why ain't it just a mass scanner board?
