### PR TITLE
Command Uniform Update

### DIFF
--- a/Resources/Prototypes/Loadouts/Generic/uniform.yml
+++ b/Resources/Prototypes/Loadouts/Generic/uniform.yml
@@ -277,7 +277,6 @@
       inverted: true
       departments:
         - Security
-        - Command
 
 - type: loadout
   id: LoadoutUniformJumpsuitHawaiBlue
@@ -293,7 +292,6 @@
       inverted: true
       departments:
         - Security
-        - Command
 
 - type: loadout
   id: LoadoutUniformJumpsuitHawaiRed
@@ -324,7 +322,6 @@
       inverted: true
       departments:
         - Security
-        - Command
 
 # AutoDrobe clothes
 - type: loadout
@@ -918,10 +915,6 @@
   requirements:
     - !type:CharacterItemGroupRequirement
       group: LoadoutUniformsCivilian
-    - !type:CharacterDepartmentRequirement
-      inverted: true
-      departments:
-        - Command
 
 - type: loadout
   id: LoadoutClothingJumpsuitSuitBlackAlt
@@ -933,10 +926,6 @@
   requirements:
     - !type:CharacterItemGroupRequirement
       group: LoadoutUniformsCivilian
-    - !type:CharacterDepartmentRequirement
-      inverted: true
-      departments:
-        - Command
 
 - type: loadout
   id: LoadoutClothingJumpsuitSuitBlackMob
@@ -948,10 +937,6 @@
   requirements:
     - !type:CharacterItemGroupRequirement
       group: LoadoutUniformsCivilian
-    - !type:CharacterDepartmentRequirement
-      inverted: true
-      departments:
-        - Command
 
 - type: loadout
   id: LoadoutClothingJumpsuitSuitBrown
@@ -963,11 +948,6 @@
   requirements:
     - !type:CharacterItemGroupRequirement
       group: LoadoutUniformsCivilian
-    - !type:CharacterDepartmentRequirement
-      inverted: true
-      departments:
-        - Command
-        - Security
 
 - type: loadout
   id: LoadoutClothingJumpsuitSuitBrownAlt
@@ -979,10 +959,6 @@
   requirements:
     - !type:CharacterItemGroupRequirement
       group: LoadoutUniformsCivilian
-    - !type:CharacterDepartmentRequirement
-      inverted: true
-      departments:
-        - Command
 
 - type: loadout
   id: LoadoutClothingJumpsuitSuitBrownMob
@@ -994,10 +970,6 @@
   requirements:
     - !type:CharacterItemGroupRequirement
       group: LoadoutUniformsCivilian
-    - !type:CharacterDepartmentRequirement
-      inverted: true
-      departments:
-        - Command
 
 - type: loadout
   id: LoadoutClothingJumpsuitSuitWhite
@@ -1010,11 +982,6 @@
   requirements:
     - !type:CharacterItemGroupRequirement
       group: LoadoutUniformsCivilian
-    - !type:CharacterDepartmentRequirement
-      inverted: true
-      departments:
-        - Command
-        - Security
 
 - type: loadout
   id: LoadoutClothingJumpsuitSuitWhiteAlt
@@ -1027,10 +994,6 @@
   requirements:
     - !type:CharacterItemGroupRequirement
       group: LoadoutUniformsCivilian
-    - !type:CharacterDepartmentRequirement
-      inverted: true
-      departments:
-        - Command
 
 - type: loadout
   id: LoadoutClothingJumpsuitSuitWhiteMob
@@ -1043,7 +1006,3 @@
   requirements:
     - !type:CharacterItemGroupRequirement
       group: LoadoutUniformsCivilian
-    - !type:CharacterDepartmentRequirement
-      inverted: true
-      departments:
-        - Command


### PR DESCRIPTION
<!--
This is a semi-strict format, you can add/remove sections as needed but the order/format should be kept the same
Remove these comments before submitting
-->

# Description

<!--
Explain this PR in as much detail as applicable

Some example prompts to consider:
How might this affect the game? The codebase?
What might be some alternatives to this?
How/Who does this benefit/hurt [the game/codebase]?
-->

Some changes made to suits and hawaiian shirts to fit with tourism lore.

- Suits relaxed in Uniform tab for command
- Hawaiian Shirts in Uniform tab relaxed for command (from when they come back from holiday)

Allows for more command customization while still staying decently professional. 

---

# TODO

<!--
A list of everything you have to do before this PR is "complete"
You probably won't have to complete everything before merging but it's good to leave future references
-->

- [x] Relaxed some requirements for Civilian Uniforms for Command Members
- [ ] Add Command Specific Hawaiian Shirts to match Tourism Sector lore (Upcoming)

---

# Changelog

<!--
You can add an author after the `:cl:` to change the name that appears in the changelog (ex: `:cl: Death`)
Leaving it blank will default to your GitHub display name
This includes all available types for the changelog
-->

:cl:
- tweak: Civilian Uniform (Suits/Hawaiian Shirts) Relaxed Requirements for Command Members 

