### PR TITLE
Fix Ghost Timer Getting Garbled when the Player Returns to Body

### DIFF
--- a/Content.Server/Body/Systems/BodySystem.cs
+++ b/Content.Server/Body/Systems/BodySystem.cs
@@ -51,7 +51,7 @@ public sealed class BodySystem : SharedBodySystem
 
         if (_mobState.IsDead(ent) && _mindSystem.TryGetMind(ent, out var mindId, out var mind))
         {
-            mind.TimeOfDeath ??= _gameTiming.RealTime;
+            mind.TimeOfDeath ??= _gameTiming.CurTime; // Vulpstation - changed to use CurTime like the ghost system
             _ticker.OnGhostAttempt(mindId, canReturnGlobal: true, mind: mind);
         }
     }

--- a/Content.Server/Ghost/GhostReturnToRoundSystem.cs
+++ b/Content.Server/Ghost/GhostReturnToRoundSystem.cs
@@ -56,7 +56,14 @@ public sealed class GhostReturnToRoundSystem : EntitySystem
             return;
         }
 
-        var deathTime = EnsureComp<GhostComponent>(uid).TimeOfDeath;
+        // Vulpstation - who on EE let this exploit through?
+        if (!TryComp<GhostComponent>(uid, out var ghost))
+        {
+            message = wrappedMessage = "sus";
+            return;
+        }
+
+        var deathTime = ghost.TimeOfDeath;
         var timeUntilRespawn = _cfg.GetCVar(CCVars.GhostRespawnTime);
         var timePast = (_gameTiming.CurTime - deathTime).TotalMinutes;
         if (timePast >= timeUntilRespawn)

--- a/Content.Server/Ghost/GhostSystem.cs
+++ b/Content.Server/Ghost/GhostSystem.cs
@@ -190,7 +190,7 @@ namespace Content.Server.Ghost
 
             SetCanSeeGhosts(uid, true);
 
-            var time = _gameTiming.CurTime;
+            var time = _gameTiming.CurTime; // Vulpstation note - BodySystem was changed to use CurTime as well. Adjust it if this is ever changed.
             component.TimeOfDeath = time;
 
             _actions.AddAction(uid, ref component.BooActionEntity, component.BooAction);


### PR DESCRIPTION
# Description
1 year after I submitted a similar fix on frontier, it's still not fixed upstream. When a player ghosts from an already dead body, the body system would set their death time in RealTime instead of CurTime, so returning to your body and ghosting would set your death time to the server's real time, which, depending on the amount of lag, could be as much as dozens of minutes ahead of the server's simulated time, softlocking you from using the ghost respawn system.

Also fixes a minor exploit in the ghost respawn system.

<img width="429" height="115" alt="image" src="https://github.com/user-attachments/assets/14dcd9d3-1985-4861-b7a8-174203d9fa0f" />
<img width="215" height="134" alt="image" src="https://github.com/user-attachments/assets/3c40b5d0-94a5-439d-8b5e-ca4b62549dae" />


# Changelog
:cl:
- fix: Returning to body as a ghost should no longer garble your death time and prevent returning to lobby as a consequence.