### PR TITLE
Justice Access Revamp

### DIFF
--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/lawdrobe.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/lawdrobe.yml
@@ -12,7 +12,7 @@
     ClothingUniformJumpsuitLawyerGood: 1
     ClothingUniformJumpskirtLawyerGood: 1
     ClothingShoesBootsLaceup: 2
-    ClothingHeadsetService: 2
+    ClothingHeadsetSecurity: 2 # Not service <3
     ClothingNeckLawyerbadge: 2
     ClothingOuterCoatOvercoat: 2 # DeltaV - add overcoat to LawDrobe
     RubberStampLawyer: 1 # DeltaV

--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/lawdrobe.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/lawdrobe.yml
@@ -12,7 +12,7 @@
     ClothingUniformJumpsuitLawyerGood: 1
     ClothingUniformJumpskirtLawyerGood: 1
     ClothingShoesBootsLaceup: 2
-    ClothingHeadsetSecurity: 2 # Not service <3
+    ClothingHeadsetJustice: 2 # Not service <3
     ClothingNeckLawyerbadge: 2
     ClothingOuterCoatOvercoat: 2 # DeltaV - add overcoat to LawDrobe
     RubberStampLawyer: 1 # DeltaV

--- a/Resources/Prototypes/DeltaV/Roles/Jobs/Justice/chief_justice.yml
+++ b/Resources/Prototypes/DeltaV/Roles/Jobs/Justice/chief_justice.yml
@@ -27,6 +27,8 @@
   - ChiefJustice
   - Justice
   - Security
+  - Lawyer # No idea why this isn't default.
+  - Prosecutor # It is their department? Let them be the departmental head...
   - Maintenance
   - External
   special:

--- a/Resources/Prototypes/DeltaV/Roles/Jobs/Justice/prosecutor.yml
+++ b/Resources/Prototypes/DeltaV/Roles/Jobs/Justice/prosecutor.yml
@@ -23,7 +23,7 @@
     back: ClothingBackpackFilled
     shoes: ClothingShoesBootsLaceup
     id: ProsecutorPDA
-    ears: ClothingHeadsetSecurity
+    ears: ClothingHeadsetJustice
     pocket1: HyperlinkBookSecuritySop # Floof - M3739 - Standardization across legal representatives. If the Attorney is going to have one, only makes sense that the Prosecutor does as well.
     pocket2: RubberStampLawyer # Floof - M3739 - DeltaV's Lawyer stamp addition is now a pocket item instead to ensure deployment across loadouts. ClothingBackpackLawyerFilled and it's variants don't really work when people can choose their bags.
     # TODO - Floof - M3739 - Make a stamp specific to the Prosecutor?

--- a/Resources/Prototypes/DeltaV/radio_channels.yml
+++ b/Resources/Prototypes/DeltaV/radio_channels.yml
@@ -3,7 +3,7 @@
   name: chat-radio-justice
   keycode: "j"
   frequency: 1420
-  color: "#A11058"
+  color: "#A11058" # I just want it to be visible man.
 
 - type: radioChannel
   id: Prison

--- a/Resources/Prototypes/DeltaV/radio_channels.yml
+++ b/Resources/Prototypes/DeltaV/radio_channels.yml
@@ -3,7 +3,7 @@
   name: chat-radio-justice
   keycode: "j"
   frequency: 1420
-  color: "#701442"
+  color: "#A11058"
 
 - type: radioChannel
   id: Prison

--- a/Resources/Prototypes/Roles/Jobs/Civilian/lawyer.yml
+++ b/Resources/Prototypes/Roles/Jobs/Civilian/lawyer.yml
@@ -19,7 +19,7 @@
     back: ClothingBackpackFilled
     shoes: ClothingShoesBootsLaceup
     id: LawyerPDA
-    ears: ClothingHeadsetSecurity
+    ears: ClothingHeadsetJustice
     pocket1: HyperlinkBookSecuritySop # Floof - M3739 - Replacement of the standard BookSecurity that came originally. Throw the book at em!
     pocket2: RubberStampLawyer # Floof - M3739 - DeltaV's Lawyer stamp addition is now a pocket item instead to ensure deployment across loadouts. ClothingBackpackLawyerFilled and it's variants don't really work when people can choose their bags.
   inhand:

--- a/Resources/Prototypes/Roles/Jobs/Civilian/lawyer.yml
+++ b/Resources/Prototypes/Roles/Jobs/Civilian/lawyer.yml
@@ -7,7 +7,7 @@
   icon: "JobIconLawyer"
   supervisors: job-supervisors-cj  # Delta V - Change supervisor to chief justice
   access:
-  - Service
+  # - Service # Yeah we aren't wizden, Lawyers are not service.
   - Lawyer
   - Maintenance
   - Justice

--- a/Resources/Prototypes/Roles/Jobs/Command/head_of_personnel.yml
+++ b/Resources/Prototypes/Roles/Jobs/Command/head_of_personnel.yml
@@ -37,7 +37,7 @@
 #  - Salvage
 #  - Security # NoooOoOo!! My HoPcurity!1
 #  - Brig
-  - Lawyer
+#  - Lawyer # Not their department.
   - Cargo
 #  - Atmospherics
 #  - Medical


### PR DESCRIPTION
<!--
This is a semi-strict format, you can add/remove sections as needed but the order/format should be kept the same
Remove these comments before submitting
-->

# Description

<!--
Explain this PR in as much detail as applicable

Some example prompts to consider:
How might this affect the game? The codebase?
What might be some alternatives to this?
How/Who does this benefit/hurt [the game/codebase]?
-->

How has this not been done before? CJ doesn't have access to their own department. This literally just gives CJ Lawyer and Prosecutor access as that is quite literally their department, they couldn't hire someone to their department even if they wanted to. UNLESS IF IT WAS A CLERK APPARENTLY! Also removed service assess from Attorney, we are not wizden. Also again, another change from wizden, HoP should not have lawyer access.

---

# Changelog

<!--
You can add an author after the `:cl:` to change the name that appears in the changelog (ex: `:cl: Death`)
Leaving it blank will default to your GitHub display name
This includes all available types for the changelog
-->

:cl:
- tweak: Added Law/Prosecutor access to Chief Justice; removed service access from Attorney, and Lawyer access from HoP.
