### PR TITLE
Fix CI Test Cascading Failure

### DIFF
--- a/Content.IntegrationTests/PoolManagerTestEventHandler.cs
+++ b/Content.IntegrationTests/PoolManagerTestEventHandler.cs
@@ -4,7 +4,7 @@
 public sealed class PoolManagerTestEventHandler
 {
     // This value is completely arbitrary.
-    private static TimeSpan MaximumTotalTestingTimeLimit => TimeSpan.FromMinutes(20);
+    private static TimeSpan MaximumTotalTestingTimeLimit => TimeSpan.FromMinutes(120);
     private static TimeSpan HardStopTimeLimit => MaximumTotalTestingTimeLimit.Add(TimeSpan.FromMinutes(1));
 
     [OneTimeSetUp]

--- a/Content.IntegrationTests/Tests/PostMapInitTest.cs
+++ b/Content.IntegrationTests/Tests/PostMapInitTest.cs
@@ -62,7 +62,7 @@ namespace Content.IntegrationTests.Tests
             "Hammurabi", //DeltaV
             "Lighthouse", //DeltaV
             "Submarine", //DeltaV
-            "Gax",
+            //"Gax", // Floof - Derotated, no current maintainer
             "Rad",
             "Meta",
             "Kettle", // Floof
@@ -70,7 +70,7 @@ namespace Content.IntegrationTests.Tests
             "Train", // Floof
             "Fland", // Floof,
             "Amber", // Apparently, floof?
-            "Europa"
+            //"Europa" // Floof - Derotated, no current maintainer
         };
 
         /// <summary>

--- a/Resources/Prototypes/Maps/Pools/default.yml
+++ b/Resources/Prototypes/Maps/Pools/default.yml
@@ -14,7 +14,7 @@
   - Submarine
   - Tortuga
   - TheHive
-  #- Gax # Floof - Remvoe Gax due to mapping issues, power, access, etc.
+  #- Gax # Floof - Remove Gax due to mapping issues, power, access, etc. | M3739 - No current maintainer
   - Rad
   - Meta
   - Kettle # Floof

--- a/Resources/Prototypes/Maps/europa.yml
+++ b/Resources/Prototypes/Maps/europa.yml
@@ -1,67 +1,68 @@
-- type: gameMap
-  id: Europa
-  mapName: 'Europa'
-  mapPath: /Maps/europa.yml
-  minPlayers: 0
-  maxPlayers: 30
-  stations:
-    Europa:
-      stationProto: StandardNanotrasenStation
-      components:
-        - type: StationNameSetup
-          mapNameTemplate: '{0} Europa Outpost {1}'
-          nameGenerator:
-            !type:NanotrasenNameGenerator
-            prefixCreator: 'B'
-        - type: StationJobs
-          overflowJobs:
-            - Passenger
-          availableJobs:
-          #service
-            Captain: [ 1, 1 ]
-            #BlueshieldOfficer: [ 1, 1] Floof - uncomment once implemented on Floof maps
-            #NanotrasenRepresentative: [ 1, 1 ] Floof - uncomment once implemented on Floof maps
-            #AdministrativeAssistant: [ 1, 1 ] Floof - uncomment once implemented on Floof maps
-            HeadOfPersonnel: [ 1, 1 ]
-            Bartender: [ 1, 1 ]
-            Botanist: [ 2, 2 ]
-            Boxer: [ 2, 2 ]
-            Chef: [ 1 , 1 ]
-            Clown: [ 1, 1 ]
-            Lawyer: [ 1, 1 ]
-            Musician: [ 1, 1 ]
-            Janitor: [ 1, 2 ]
-            Mime: [ 1, 1 ]
-          #engineering
-            ChiefEngineer: [ 1, 1 ]
-            AtmosphericTechnician: [ 1, 2 ]
-            StationEngineer: [ 2, 2 ]
-            TechnicalAssistant: [ 2, 2 ]
-          #medical
-            ChiefMedicalOfficer: [ 1, 1 ]
-            Chemist: [ 1, 1 ]
-            MedicalDoctor: [ 2, 3 ]
-            MedicalIntern: [ 2, 2 ]
-            Paramedic: [ 1, 1 ]
-            Psychologist: [ 1, 1 ]
-          #science
-            ResearchDirector: [ 1, 1 ]
-            Chaplain: [ 1, 1 ]
-            ForensicMantis: [ 1, 1 ]
-            Scientist: [ 2, 3 ]
-            ResearchAssistant: [ 2, 2 ]
-            Borg: [ 1, 1 ]
-          #security
-            HeadOfSecurity: [ 1, 1 ]
-            Warden: [ 1, 1 ]
-            Detective: [ 1, 1 ]
-            SecurityOfficer: [ 2, 2 ]
-            SecurityCadet: [ 1, 1 ]
-            Prisoner: [ 1, 2 ]
-          #supply
-            Quartermaster: [ 1, 1 ]
-            MailCarrier: [ 1, 2 ]
-            SalvageSpecialist: [ 2, 2 ]
-            CargoTechnician: [ 2, 3 ]
-          #civilian
-            Passenger: [ -1, -1 ]
+#- type: gameMap
+#  id: Europa
+#  mapName: 'Europa'
+#  mapPath: /Maps/europa.yml
+#  minPlayers: 0
+#  maxPlayers: 30
+#  stations:
+#    Europa:
+#      stationProto: StandardNanotrasenStation
+#      components:
+#        - type: StationNameSetup
+#          mapNameTemplate: '{0} Europa Outpost {1}'
+#          nameGenerator:
+#            !type:NanotrasenNameGenerator
+#            prefixCreator: 'B'
+#        - type: StationJobs
+#          overflowJobs:
+#            - Passenger
+#          availableJobs:
+#          #service
+#            Captain: [ 1, 1 ]
+#            #BlueshieldOfficer: [ 1, 1] Floof - uncomment once implemented on Floof maps
+#            #NanotrasenRepresentative: [ 1, 1 ] Floof - uncomment once implemented on Floof maps
+#            #AdministrativeAssistant: [ 1, 1 ] Floof - uncomment once implemented on Floof maps
+#            HeadOfPersonnel: [ 1, 1 ]
+#            Bartender: [ 1, 1 ]
+#            Botanist: [ 2, 2 ]
+#            Boxer: [ 2, 2 ]
+#            Chef: [ 1 , 1 ]
+#            Clown: [ 1, 1 ]
+#            Lawyer: [ 1, 1 ]
+#            Musician: [ 1, 1 ]
+#            Janitor: [ 1, 2 ]
+#            Mime: [ 1, 1 ]
+#          #engineering
+#            ChiefEngineer: [ 1, 1 ]
+#            AtmosphericTechnician: [ 1, 2 ]
+#            StationEngineer: [ 2, 2 ]
+#            TechnicalAssistant: [ 2, 2 ]
+#          #medical
+#            ChiefMedicalOfficer: [ 1, 1 ]
+#            Chemist: [ 1, 1 ]
+#            MedicalDoctor: [ 2, 3 ]
+#            MedicalIntern: [ 2, 2 ]
+#            Paramedic: [ 1, 1 ]
+#            Psychologist: [ 1, 1 ]
+#          #science
+#            ResearchDirector: [ 1, 1 ]
+#            Chaplain: [ 1, 1 ]
+#            ForensicMantis: [ 1, 1 ]
+#            Scientist: [ 2, 3 ]
+#            ResearchAssistant: [ 2, 2 ]
+#            Borg: [ 1, 1 ]
+#          #security
+#            HeadOfSecurity: [ 1, 1 ]
+#            Warden: [ 1, 1 ]
+#            Detective: [ 1, 1 ]
+#            SecurityOfficer: [ 2, 2 ]
+#            SecurityCadet: [ 1, 1 ]
+#            Prisoner: [ 1, 2 ]
+#          #supply
+#            Quartermaster: [ 1, 1 ]
+#            MailCarrier: [ 1, 2 ]
+#            SalvageSpecialist: [ 2, 2 ]
+#            CargoTechnician: [ 2, 3 ]
+#          #civilian
+#            Passenger: [ -1, -1 ]
+#

--- a/Resources/Prototypes/Maps/gaxstation.yml
+++ b/Resources/Prototypes/Maps/gaxstation.yml
@@ -1,78 +1,79 @@
-- type: gameMap
-  id: Gax
-  mapName: 'NCS Gax'
-  mapPath: /Maps/Floof/gaxstation.yml # Floofstation
-  minPlayers: 10
-  maxPlayers: 45
-  fallback: true
-  stations:
-    Gaxstation:
-      stationProto: StandardNanotrasenStation
-      components:
-        - type: StationEmergencyShuttle
-          emergencyShuttlePath: /Maps/Shuttles/DeltaV/NTES_Delta.yml
-        - type: StationNameSetup
-          mapNameTemplate: '{0} NCS Gax {1}'
-          nameGenerator:
-            !type:NanotrasenNameGenerator
-            prefixCreator: 'YG'
-        - type: StationJobs
-          overflowJobs:
-          - Passenger
-          #- Anomaly # Floofstation
-          availableJobs:
-            Anomaly: [ 4, 4 ] # Floofstation
-            #service
-            Captain: [ 1, 1 ]
-            #BlueshieldOfficer: [ 1, 1] Floof - uncomment once implemented on Floof maps
-            #NanotrasenRepresentative: [ 1, 1 ] Floof - uncomment once implemented on Floof maps
-            #AdministrativeAssistant: [ 1, 1 ] Floof - uncomment once implemented on Floof maps
-            HeadOfPersonnel: [ 1, 1 ]
-            Bartender: [ 1, 1 ]
-            Botanist: [3 , 3 ]
-            Chef: [ 2, 2 ]
-            Janitor: [ 2, 2 ]
-            ServiceWorker: [ 2, 2 ]
-            #Engineering
-            ChiefEngineer: [ 1, 1 ]
-            AtmosphericTechnician: [ 4, 4 ]
-            StationEngineer: [ 4, 4 ]
-            TechnicalAssistant: [ 2, 2 ]
-            #Medical
-            ChiefMedicalOfficer: [ 1, 1 ]
-            Chemist: [ 2, 2 ]
-            MedicalDoctor: [ 3, 3 ]
-            MedicalIntern: [ 3, 3 ]
-            Paramedic: [ 2, 2 ]
-            MedicalBorg: [ 1, 1 ]
-            #Epistemics
-            ResearchDirector: [ 1, 1 ]
-            Scientist: [ 4, 4 ]
-            ResearchAssistant: [ 2, 2 ]
-            Roboticist: [ 1, 2 ]
-            Borg: [ 2, 2 ]
-            Chaplain: [ 1, 1 ]
-            Librarian: [ 1, 1 ]
-            ForensicMantis: [ 1, 1 ]
-            #Security
-            HeadOfSecurity: [ 1, 1 ]
-            Warden: [ 1, 1 ]
-            SecurityOfficer: [ 4, 4 ]
-            SecurityCadet: [ 4, 4 ]
-            Detective: [ 1, 1 ]
-            Prisoner: [ 1, 2 ]
-            PrisonGuard: [ 1, 2 ]
-            Brigmedic: [ 1, 1 ]
-            Lawyer: [ 1, 1 ]
-            #Supply
-            Quartermaster: [ 1, 1 ]
-            InventorySpecialist: [ 1, 1 ] #FloofStation
-            SalvageSpecialist: [ 1, 3 ]
-            CargoTechnician: [ 2, 2 ]
-            MailCarrier: [ 1, 2 ]
-            #Civillian
-            Passenger: [ -1, -1 ]
-            Clown: [ 1, 1 ]
-            Mime: [ 1, 1 ]
-            Musician: [ 1, 1 ]
-
+#- type: gameMap
+#  id: Gax
+#  mapName: 'NCS Gax'
+#  mapPath: /Maps/Floof/gaxstation.yml # Floofstation
+#  minPlayers: 10
+#  maxPlayers: 45
+#  fallback: true
+#  stations:
+#    Gaxstation:
+#      stationProto: StandardNanotrasenStation
+#      components:
+#        - type: StationEmergencyShuttle
+#          emergencyShuttlePath: /Maps/Shuttles/DeltaV/NTES_Delta.yml
+#        - type: StationNameSetup
+#          mapNameTemplate: '{0} NCS Gax {1}'
+#          nameGenerator:
+#            !type:NanotrasenNameGenerator
+#            prefixCreator: 'YG'
+#        - type: StationJobs
+#          overflowJobs:
+#          - Passenger
+#          #- Anomaly # Floofstation
+#          availableJobs:
+#            Anomaly: [ 4, 4 ] # Floofstation
+#            #service
+#            Captain: [ 1, 1 ]
+#            #BlueshieldOfficer: [ 1, 1] Floof - uncomment once implemented on Floof maps
+#            #NanotrasenRepresentative: [ 1, 1 ] Floof - uncomment once implemented on Floof maps
+#            #AdministrativeAssistant: [ 1, 1 ] Floof - uncomment once implemented on Floof maps
+#            HeadOfPersonnel: [ 1, 1 ]
+#            Bartender: [ 1, 1 ]
+#            Botanist: [3 , 3 ]
+#            Chef: [ 2, 2 ]
+#            Janitor: [ 2, 2 ]
+#            ServiceWorker: [ 2, 2 ]
+#            #Engineering
+#            ChiefEngineer: [ 1, 1 ]
+#            AtmosphericTechnician: [ 4, 4 ]
+#            StationEngineer: [ 4, 4 ]
+#            TechnicalAssistant: [ 2, 2 ]
+#            #Medical
+#            ChiefMedicalOfficer: [ 1, 1 ]
+#            Chemist: [ 2, 2 ]
+#            MedicalDoctor: [ 3, 3 ]
+#            MedicalIntern: [ 3, 3 ]
+#            Paramedic: [ 2, 2 ]
+#            MedicalBorg: [ 1, 1 ]
+#            #Epistemics
+#            ResearchDirector: [ 1, 1 ]
+#            Scientist: [ 4, 4 ]
+#            ResearchAssistant: [ 2, 2 ]
+#            Roboticist: [ 1, 2 ]
+#            Borg: [ 2, 2 ]
+#            Chaplain: [ 1, 1 ]
+#            Librarian: [ 1, 1 ]
+#            ForensicMantis: [ 1, 1 ]
+#            #Security
+#            HeadOfSecurity: [ 1, 1 ]
+#            Warden: [ 1, 1 ]
+#            SecurityOfficer: [ 4, 4 ]
+#            SecurityCadet: [ 4, 4 ]
+#            Detective: [ 1, 1 ]
+#            Prisoner: [ 1, 2 ]
+#            PrisonGuard: [ 1, 2 ]
+#            Brigmedic: [ 1, 1 ]
+#            Lawyer: [ 1, 1 ]
+#            #Supply
+#            Quartermaster: [ 1, 1 ]
+#            InventorySpecialist: [ 1, 1 ] #FloofStation
+#            SalvageSpecialist: [ 1, 3 ]
+#            CargoTechnician: [ 2, 2 ]
+#            MailCarrier: [ 1, 2 ]
+#            #Civillian
+#            Passenger: [ -1, -1 ]
+#            Clown: [ 1, 1 ]
+#            Mime: [ 1, 1 ]
+#            Musician: [ 1, 1 ]
+#
+#


### PR DESCRIPTION
<!--
This is a semi-strict format, you can add/remove sections as needed but the order/format should be kept the same
Remove these comments before submitting
-->

# Description

<!--
Explain this PR in as much detail as applicable

Some example prompts to consider:
How might this affect the game? The codebase?
What might be some alternatives to this?
How/Who does this benefit/hurt [the game/codebase]?
-->

This PR aims to address the issues in the CI tests that has led it to be more of a paperweight than anything, greatly hindering our operations and hurting development.

The cascading failure has been addressed by implementing a part of EE 1803, which increases the maximum time for CI tests to complete to 2 hours instead of 20 minutes. This was causing the cascading failure as the pool manager would fold on itself once it was taking longer than the set time.

I am currently working on addressing a `DisposeAsync` issue with `RoundEndTest`.

---

# TODO

<!--
A list of everything you have to do before this PR is "complete"
You probably won't have to complete everything before merging but it's good to leave future references
-->

- [x] Fix cascading failure
- [ ] Fix `DisposeAsync` in `RoundEndTest` delivering a pair with an unexpected state

---

No CL is needed as this is purely a backend change.