### PR TITLE
Fix the R&D Console Exploit

### DIFF
--- a/Content.Server/Research/Systems/ResearchSystem.Technology.cs
+++ b/Content.Server/Research/Systems/ResearchSystem.Technology.cs
@@ -21,6 +21,7 @@ public sealed partial class ResearchSystem
         primaryDb.SupportedDisciplines = otherDb.SupportedDisciplines;
         primaryDb.UnlockedTechnologies = otherDb.UnlockedTechnologies;
         primaryDb.UnlockedRecipes = otherDb.UnlockedRecipes;
+        primaryDb.SoftCapMultiplier = otherDb.SoftCapMultiplier; // Floofstation - why was this missing?!
 
         Dirty(primaryUid, primaryDb);
 


### PR DESCRIPTION
# Description
EE code.

<details><summary><h1>Media</h1></summary><p>

https://github.com/user-attachments/assets/42b545d3-ce6f-4423-bf93-be12c9344af7

</p></details>

---

# Changelog
:cl:
- fix: The R&D console should now correctly preserve the research cost multiplier after getting deconstructed.