### PR TITLE
Hide Votes From Evac Autocall And Refine Vote Localization

### DIFF
--- a/Content.Client/Voting/UI/VotePopup.xaml.cs
+++ b/Content.Client/Voting/UI/VotePopup.xaml.cs
@@ -54,7 +54,19 @@ namespace Content.Client.Voting.UI
             for (var i = 0; i < _voteButtons.Length; i++)
             {
                 var entry = _vote.Entries[i];
-                _voteButtons[i].Text = Loc.GetString("ui-vote-button", ("text", entry.Text), ("votes", entry.Votes));
+                // Floof start - Hide autocall vote numbers to eliminate comformity voting
+                // TODO: Make this an option for the voting system in general
+                // Begin logic
+                var autocall = Loc.GetString("round-end-system-shuttle-call-vote-initiator");
+                if (_vote.Initiator == autocall)
+                {
+                    _voteButtons[i].Text = Loc.GetString("ui-secret-ballot-vote-button", ("text", entry.Text));
+                }
+                else
+                {
+                    _voteButtons[i].Text = Loc.GetString("ui-vote-button", ("text", entry.Text), ("votes", entry.Votes));
+                }
+                // Floof End
 
                 if (_vote.OurVote == i)
                     _voteButtons[i].Pressed = true;

--- a/Content.Server/RoundEnd/RoundEndSystem.cs
+++ b/Content.Server/RoundEnd/RoundEndSystem.cs
@@ -406,12 +406,13 @@ namespace Content.Server.RoundEnd
                         new VoteOptions
                         {
                             Duration = TimeSpan.FromSeconds(_cfg.GetCVar(VulpCCVars.EvacVoteDuration)),
-                            Title = Loc.GetString("round-end-system-shuttle-call-vote"),
+                            Title = Loc.GetString("floof-round-end-system-shuttle-call-vote"), // Floof
                             InitiatorText = Loc.GetString("round-end-system-shuttle-call-vote-initiator"),
                             Options =
                             [
-                                (Loc.GetString("ui-vote-restart-yes"), true),
-                                (Loc.GetString("ui-vote-restart-no"), false)
+                                // Floof - Changed to "Stay" or "Leave"
+                                (Loc.GetString("ui-vote-autocall-leave"), true),
+                                (Loc.GetString("ui-vote-autocall-stay"), false)
                             ],
                         });
 

--- a/Resources/Locale/en-US/_Floof/voting/ui/vote-popup.ftl
+++ b/Resources/Locale/en-US/_Floof/voting/ui/vote-popup.ftl
@@ -1,0 +1,6 @@
+﻿# Autocall
+floof-round-end-system-shuttle-call-vote = Stay, or leave?
+ui-vote-autocall-stay =  Stay
+ui-vote-autocall-leave = Leave
+# Secret Ballot
+ui-secret-ballot-vote-button = { $text }

--- a/Resources/Locale/en-US/voting/ui/vote-popup.ftl
+++ b/Resources/Locale/en-US/voting/ui/vote-popup.ftl
@@ -1,2 +1,4 @@
 ui-vote-created = { $initiator } has called a vote:
 ui-vote-button  = { $text } ({ $votes })
+# Floof - Secret Ballot
+ui-secret-ballot-vote-button = { $text }

--- a/Resources/Locale/en-US/voting/ui/vote-popup.ftl
+++ b/Resources/Locale/en-US/voting/ui/vote-popup.ftl
@@ -1,4 +1,2 @@
 ui-vote-created = { $initiator } has called a vote:
 ui-vote-button  = { $text } ({ $votes })
-# Floof - Secret Ballot
-ui-secret-ballot-vote-button = { $text }


### PR DESCRIPTION
<!--
This is a semi-strict format, you can add/remove sections as needed but the order/format should be kept the same
Remove these comments before submitting
-->

# Description

<!--
Explain this PR in as much detail as applicable

Some example prompts to consider:
How might this affect the game? The codebase?
What might be some alternatives to this?
How/Who does this benefit/hurt [the game/codebase]?
-->

This PR aims to solve an issue observed by players and admins alike: the tendency of the community to match the votes, regardless of what that vote actually is. While this may be humorous the first or second times, according to reports, they have been doing this since the last weekend we introduced this system in the first place.

To resolve this, I have altered the voting code with a conditional check that checks for the vote initiator before deciding to forward the vote buttons without vote numbers tied to them. In addition, the vote message and options have been altered to better suit our community's practices, which was suggested by Chokovit.

In the future, I plan on this being a more refined system where it is an option for votes to become a secret ballot, which is essentially what we are making the evac autocall vote become.

---

<!--
This is default collapsed, readers click to expand it and see all your media
The PR media section can get very large at times, so this is a good way to keep it clean
The title is written using HTML tags
The title must be within the <summary> tags or you won't see it
-->

<details><summary><h1>Media</h1></summary>
<p>

<img width="301" height="97" alt="image" src="https://github.com/user-attachments/assets/ce50d5a4-729c-4e55-8ddb-31709963d557" />
<img width="296" height="194" alt="image" src="https://github.com/user-attachments/assets/5e0acf7f-b1d3-4e96-a843-fe7c88ad8a52" />

</p>
</details>

---

# Changelog

<!--
You can add an author after the `:cl:` to change the name that appears in the changelog (ex: `:cl: Death`)
Leaving it blank will default to your GitHub display name
This includes all available types for the changelog
-->

:cl:
- tweak: The automatic shuttle call has been revised.
