### PR TITLE
Epistemics Gaming

### DIFF
--- a/Content.Server/Xenoarchaeology/XenoArtifacts/ArtifactComponent.cs
+++ b/Content.Server/Xenoarchaeology/XenoArtifacts/ArtifactComponent.cs
@@ -64,7 +64,7 @@ public sealed partial class ArtifactComponent : Component
     /// The base amount of research points for each artifact node.
     /// </summary>
     [DataField("pointsPerNode"), ViewVariables(VVAccess.ReadWrite)]
-    public int PointsPerNode = 25000;
+    public int PointsPerNode = 20000;
 
     /// <summary>
     /// Research points which have been "consumed" from the theoretical max value of the artifact.

--- a/Content.Server/Xenoarchaeology/XenoArtifacts/ArtifactComponent.cs
+++ b/Content.Server/Xenoarchaeology/XenoArtifacts/ArtifactComponent.cs
@@ -58,13 +58,13 @@ public sealed partial class ArtifactComponent : Component
     /// to determine the monetary value of the artifact
     /// </summary>
     [DataField("priceMultiplier"), ViewVariables(VVAccess.ReadWrite)]
-    public float PriceMultiplier = 0.05f;
+    public float PriceMultiplier = 0.1f;
 
     /// <summary>
     /// The base amount of research points for each artifact node.
     /// </summary>
     [DataField("pointsPerNode"), ViewVariables(VVAccess.ReadWrite)]
-    public int PointsPerNode = 6500;
+    public int PointsPerNode = 25000;
 
     /// <summary>
     /// Research points which have been "consumed" from the theoretical max value of the artifact.

--- a/Content.Shared/Anomaly/Components/AnomalyComponent.cs
+++ b/Content.Shared/Anomaly/Components/AnomalyComponent.cs
@@ -185,21 +185,21 @@ public sealed partial class AnomalyComponent : Component
     /// The minimum amount of research points generated per second
     /// </summary>
     [DataField("minPointsPerSecond")]
-    public int MinPointsPerSecond = 10;
+    public int MinPointsPerSecond = 40;
 
     /// <summary>
     /// The maximum amount of research points generated per second
     /// This doesn't include the point bonus for being unstable.
     /// </summary>
     [DataField("maxPointsPerSecond")]
-    public int MaxPointsPerSecond = 70;
+    public int MaxPointsPerSecond = 150;
 
     /// <summary>
     /// The multiplier applied to the point value for the
     /// anomaly being above the <see cref="GrowthThreshold"/>
     /// </summary>
     [DataField("growingPointMultiplier")]
-    public float GrowingPointMultiplier = 1.5f;
+    public float GrowingPointMultiplier = 2f;
     #endregion
 
     /// <summary>

--- a/Resources/Prototypes/Nyanotrasen/Entities/Structures/Research/glimmer_prober.yml
+++ b/Resources/Prototypes/Nyanotrasen/Entities/Structures/Research/glimmer_prober.yml
@@ -16,7 +16,7 @@
     graph: GlimmerDevices
     node: glimmerProber
   - type: ResearchPointSource
-    pointspersecond: 20
+    pointspersecond: 100
     active: true
   - type: Sprite
     sprite: DeltaV/Structures/Machines/glimmer_machines.rsi # DeltaV reskin

--- a/Resources/Prototypes/Nyanotrasen/Entities/Structures/Research/glimmer_prober.yml
+++ b/Resources/Prototypes/Nyanotrasen/Entities/Structures/Research/glimmer_prober.yml
@@ -16,7 +16,7 @@
     graph: GlimmerDevices
     node: glimmerProber
   - type: ResearchPointSource
-    pointspersecond: 100
+    pointspersecond: 50
     active: true
   - type: Sprite
     sprite: DeltaV/Structures/Machines/glimmer_machines.rsi # DeltaV reskin


### PR DESCRIPTION
# Description
Greatly increase alternative sources of research points for epistemics.
The reward for your department exploding and you dying was too low.
Also increased the gain on Prober so it's not just a syndie bomb pretending to be something useful.
Updated anomaly point values to upstream ones.

Why?
To be competitive with optimized 6x Experimental Anomaly Vessel generating 1200 points a second for high end research.

# Changelog
:cl:
- tweak: Artifacts and Glimmer Probers give more research