### PR TITLE
Cyber Eyes Update + Restricted Gear Trait

### DIFF
--- a/Resources/Locale/en-US/traits/traits.ftl
+++ b/Resources/Locale/en-US/traits/traits.ftl
@@ -543,3 +543,9 @@ trait-description-BionicPryArm =
     Your arms have been reinforced with steel and hydraulics. You can force your way out of some unpleasant situations.
     This trait gives you cybernetic DX-1 Pryarms, which let you pry open unpowered doors easily.
     (They essentially function like a crowbar)
+
+trait-name-RestrictedGear = Restricted Gear
+trait-description-RestrictedGear = 
+    Either through personal ownership or theft, you have access to equipment that isn't particularly standard issue.
+    Note that starting with an item [color=red]doesn't certify its legality[/color]. Conceal it or justify it.
+    (You equip other jobs' items and traits in the loadouts and traits menu) 

--- a/Resources/Prototypes/Traits/physical.yml
+++ b/Resources/Prototypes/Traits/physical.yml
@@ -644,7 +644,7 @@
 - type: trait
   id: CyberEyes
   category: Physical
-  points: -4
+  points: -2
   slots: 0
   requirements:
     - !type:CharacterJobRequirement
@@ -653,6 +653,10 @@
         - Prisoner # Bionics should be "Confiscated" from long term prisoners.
         - Gladiator # Floof
         - Anomaly
+    - !type:CharacterSpeciesRequirement
+      inverted: true
+      species:
+        - IPC
     - !type:CharacterTraitRequirement
       inverted: true
       traits:
@@ -692,7 +696,7 @@
 - type: trait
   id: CyberEyesSecurity
   category: Physical
-  points: -1
+  points: -2
   requirements:
     - !type:CharacterJobRequirement
       inverted: true
@@ -700,12 +704,24 @@
         - Prisoner # Bionics should be "Confiscated" from long term prisoners.
         - Gladiator # Floof
         - Anomaly
-    - !type:CharacterDepartmentRequirement
-      departments:
-        - Security
-    - !type:CharacterTraitRequirement
-      traits:
-        - CyberEyes
+    - !type:CharacterLogicOrRequirement
+      requirements:
+        - !type:CharacterDepartmentRequirement
+          departments:
+            - Security
+            - Dignitary
+            - Command
+        #- !type:CharacterTraitRequirement
+        #  traits:
+        #    - RestrictedGear
+    - !type:CharacterLogicOrRequirement
+      requirements:
+        - !type:CharacterTraitRequirement
+          traits:
+            - CyberEyes
+        - !type:CharacterSpeciesRequirement
+          species:
+            - IPC
     - !type:CharacterTraitRequirement
       inverted: true
       traits:
@@ -716,6 +732,8 @@
         - type: ShowJobIcons
         - type: ShowMindShieldIcons
         - type: ShowCriminalRecordIcons
+        - type: FlashImmunity
+        - type: EyeProtection
 
 - type: trait
   id: CyberEyesMedical
@@ -728,17 +746,22 @@
         - Prisoner # Bionics should be "Confiscated" from long term prisoners.
         - Gladiator # Floof
         - Anomaly
-    - !type:CharacterTraitRequirement
-      traits:
-        - CyberEyes
+    - !type:CharacterLogicOrRequirement
+      requirements:
+        - !type:CharacterTraitRequirement
+          traits:
+            - CyberEyes
+        - !type:CharacterSpeciesRequirement
+          species:
+            - IPC
     - !type:CharacterTraitRequirement
       inverted: true
       traits:
-        - CyberEyesDiagnostic
         - CyberEyesOmni
   functions:
     - !type:TraitAddComponent
       components:
+        - type: SolutionScanner
         - type: ShowHealthBars
           damageContainers:
           - Biological
@@ -751,7 +774,7 @@
 - type: trait
   id: CyberEyesDiagnostic
   category: Physical
-  points: -1
+  points: -2
   requirements:
     - !type:CharacterJobRequirement
       inverted: true
@@ -759,17 +782,22 @@
         - Prisoner # Bionics should be "Confiscated" from long term prisoners.
         - Gladiator # Floof
         - Anomaly
-    - !type:CharacterTraitRequirement
-      traits:
-        - CyberEyes
+    - !type:CharacterLogicOrRequirement
+      requirements:
+        - !type:CharacterTraitRequirement
+          traits:
+            - CyberEyes
+        - !type:CharacterSpeciesRequirement
+          species:
+            - IPC
     - !type:CharacterTraitRequirement
       inverted: true
       traits:
-        - CyberEyesMedical
         - CyberEyesOmni
   functions:
     - !type:TraitAddComponent
       components:
+        - type: EyeProtection
         - type: ShowHealthBars
           damageContainers:
           - Inorganic
@@ -784,9 +812,24 @@
       departments:
         - Security
         - Command
-    - !type:CharacterTraitRequirement
-      traits:
-        - CyberEyes
+    - !type:CharacterLogicOrRequirement
+      requirements:
+        - !type:CharacterDepartmentRequirement
+          departments:
+            - Security
+            - Dignitary
+            - Command
+        #- !type:CharacterTraitRequirement
+        #  traits:
+        #    - RestrictedGear
+    - !type:CharacterLogicOrRequirement
+      requirements:
+        - !type:CharacterTraitRequirement
+          traits:
+            - CyberEyes
+        - !type:CharacterSpeciesRequirement
+          species:
+            - IPC
     - !type:CharacterTraitRequirement
       inverted: true
       traits:
@@ -796,17 +839,20 @@
   functions:
     - !type:TraitAddComponent
       components:
+        - type: SolutionScanner
+        - type: EyeProtection
+        - type: FlashImmunity
         - type: ShowJobIcons
         - type: ShowMindShieldIcons
         - type: ShowCriminalRecordIcons
         - type: ShowHealthIcons
           damageContainers:
           - Biological
-          - BiologicalMetaphysical # Floof - M3739 - #1006
+          - BiologicalMetaphysical
         - type: ShowHealthBars
           damageContainers:
           - Biological
-          - BiologicalMetaphysical # Floof - M3739 - #1006
+          - BiologicalMetaphysical
           - Inorganic
           - Silicon
 
@@ -876,6 +922,10 @@
         - Prisoner # Bionics should be "Confiscated" from long term prisoners.
         - Gladiator # Floof
         - Anomaly
+    - !type:CharacterSpeciesRequirement
+      inverted: true
+      species:
+        - Arachne
   functions:
     - !type:TraitPushDescription
       descriptionExtensions:
@@ -988,3 +1038,15 @@
         - description: examine-bionic-arm-message
           fontSize: 12
           requireDetailRange: true
+
+#- type: trait
+#  id: RestrictedGear
+#  category: Physical
+#  points: -5
+#  requirements:
+#  - !type:CharacterJobRequirement
+#    inverted: true
+#    jobs:
+#      - Prisoner # Smuggling for prisoners = immediate jailbreak.
+#      - Gladiator # Floof
+#      - Anomaly

--- a/Resources/Prototypes/Traits/physical.yml
+++ b/Resources/Prototypes/Traits/physical.yml
@@ -808,10 +808,12 @@
   category: Physical
   points: -3
   requirements:
-    - !type:CharacterDepartmentRequirement
-      departments:
-        - Security
-        - Command
+    - !type:CharacterJobRequirement
+      inverted: true
+      jobs:
+        - Prisoner # Bionics should be "Confiscated" from long term prisoners.
+        - Gladiator # Floof
+        - Anomaly
     - !type:CharacterLogicOrRequirement
       requirements:
         - !type:CharacterDepartmentRequirement
@@ -819,9 +821,9 @@
             - Security
             - Dignitary
             - Command
-        #- !type:CharacterTraitRequirement
-        #  traits:
-        #    - RestrictedGear
+        - !type:CharacterTraitRequirement
+          traits:
+            - RestrictedGear
     - !type:CharacterLogicOrRequirement
       requirements:
         - !type:CharacterTraitRequirement

--- a/Resources/Prototypes/Traits/physical.yml
+++ b/Resources/Prototypes/Traits/physical.yml
@@ -673,25 +673,25 @@
       components:
         - type: Flashable # Effectively, removes any flash-vulnerability species traits.
 
-- type: trait
-  id: FlareShielding
-  category: Physical
-  points: -4
-  requirements:
-    - !type:CharacterJobRequirement
-      inverted: true
-      jobs:
-        - Prisoner # Bionics should be "Confiscated" from long term prisoners.
-        - Gladiator # Floof
-        - Anomaly
-    - !type:CharacterTraitRequirement
-      traits:
-        - CyberEyes
-  functions:
-    - !type:TraitAddComponent
-      components:
-        - type: FlashImmunity
-        - type: EyeProtection
+#- type: trait
+#  id: FlareShielding
+#  category: Physical
+#  points: -4
+#  requirements:
+#    - !type:CharacterJobRequirement
+#      inverted: true
+#      jobs:
+#        - Prisoner # Bionics should be "Confiscated" from long term prisoners.
+#        - Gladiator # Floof
+#        - Anomaly
+#    - !type:CharacterTraitRequirement
+#      traits:
+#        - CyberEyes
+#  functions:
+#    - !type:TraitAddComponent
+#      components:
+#        - type: FlashImmunity
+#        - type: EyeProtection
 
 - type: trait
   id: CyberEyesSecurity

--- a/Resources/Prototypes/Traits/physical.yml
+++ b/Resources/Prototypes/Traits/physical.yml
@@ -850,11 +850,11 @@
         - type: ShowHealthIcons
           damageContainers:
           - Biological
-          - BiologicalMetaphysical
+          - BiologicalMetaphysical # Floof - M3739 - #1006
         - type: ShowHealthBars
           damageContainers:
           - Biological
-          - BiologicalMetaphysical
+          - BiologicalMetaphysical # Floof - M3739 - #1006
           - Inorganic
           - Silicon
 

--- a/Resources/Prototypes/Traits/physical.yml
+++ b/Resources/Prototypes/Traits/physical.yml
@@ -963,9 +963,14 @@
         - Felinid
         - Rodentia
         - Tajaran
-    - !type:CharacterTraitRequirement
-      traits:
-        - CyberEyes
+    - !type:CharacterLogicOrRequirement
+      requirements:
+        - !type:CharacterTraitRequirement
+          traits:
+            - CyberEyes
+        - !type:CharacterSpeciesRequirement
+          species:
+            - IPC
     - !type:CharacterTraitRequirement # Floof added Photophobia as drawback to nightvision
       inverted: true
       traits:
@@ -989,9 +994,14 @@
 #        - Prisoner # Bionics should be "Confiscated" from long term prisoners.
 #        - Gladiator # Floof
 #        - Anomaly
-#    - !type:CharacterTraitRequirement
-#      traits:
-#        - CyberEyes
+#    - !type:CharacterLogicOrRequirement
+#      requirements:
+#        - !type:CharacterTraitRequirement
+#          traits:
+#            - CyberEyes
+#        - !type:CharacterSpeciesRequirement
+#          species:
+#            - IPC
 #  functions:
 #    - !type:TraitAddComponent
 #      components:

--- a/Resources/Prototypes/Traits/physical.yml
+++ b/Resources/Prototypes/Traits/physical.yml
@@ -711,9 +711,9 @@
             - Security
             - Dignitary
             - Command
-        #- !type:CharacterTraitRequirement
-        #  traits:
-        #    - RestrictedGear
+        - !type:CharacterTraitRequirement
+          traits:
+            - RestrictedGear
     - !type:CharacterLogicOrRequirement
       requirements:
         - !type:CharacterTraitRequirement
@@ -1020,6 +1020,9 @@
           - Security
           - Command
           - Engineering # Floofstation - Weird this wasn't upstream
+      - !type:CharacterTraitRequirement
+          traits:
+            - RestrictedGear
     - !type:CharacterTraitRequirement
       inverted: true
       traits:
@@ -1041,14 +1044,14 @@
           fontSize: 12
           requireDetailRange: true
 
-#- type: trait
-#  id: RestrictedGear
-#  category: Physical
-#  points: -5
-#  requirements:
-#  - !type:CharacterJobRequirement
-#    inverted: true
-#    jobs:
-#      - Prisoner # Smuggling for prisoners = immediate jailbreak.
-#      - Gladiator # Floof
-#      - Anomaly
+- type: trait
+  id: RestrictedGear
+  category: Physical
+  points: -5
+  requirements:
+  - !type:CharacterJobRequirement
+    inverted: true
+    jobs:
+      - Prisoner # Smuggling for prisoners = immediate jailbreak.
+      - Gladiator # Floof
+      - Anomaly


### PR DESCRIPTION
# Description
Cyber-Eyes updated to include upstream's components
IPCs can take Cyber Eye Modules without Cyber-Eyes (Because they already have robotic eyes)
Added Restricted Gear Trait, currently doesn't include the C2 loadout items.

Balancing wise, Flare Shielding is gone, and now on the huds, restricted gear trait is now how you'd get flash immunity, which is more expensive.

# Changelog
:cl:
- add: Added Restricted Gear Trait, currently missing C2 loadout items, so it's barebones for a while, will be added later. 
- tweak: Updated Cyber-eyes, new firmware update hit.
