### PR TITLE
Event Stuff

### DIFF
--- a/Resources/Prototypes/DeltaV/GameRules/events.yml
+++ b/Resources/Prototypes/DeltaV/GameRules/events.yml
@@ -1,6 +1,6 @@
 - type: entity
   id: XenoVents
-  parent: BaseGameRule
+  parent: BaseGameRuleSecurityRequirement
   categories: [ HideSpawnMenu ]
   components:
   - type: StationEvent

--- a/Resources/Prototypes/GameRules/events.yml
+++ b/Resources/Prototypes/GameRules/events.yml
@@ -115,7 +115,7 @@
     prototype: MobSkeletonCloset
 
 - type: entity
-  parent: BaseGameRuleSecurityRequirement # Floof - changed parent
+  parent: BaseGameRuleSecurityRequirementHigh # Floof - changed parent
   id: DragonSpawn
   categories: [ HideSpawnMenu ]
   components:
@@ -129,7 +129,7 @@
     prototype: SpawnPointGhostDragon
 
 - type: entity
-  parent: BaseGameRuleSecurityRequirement # Floof - changed parent
+  parent: BaseGameRuleSecurityRequirementHigh # Floof - changed parent
   id: NinjaSpawn
   categories: [ HideSpawnMenu ]
   components:
@@ -178,7 +178,7 @@
         prototype: SpaceNinja
 
 - type: entity
-  parent: BaseGameRule
+  parent: BaseGameRuleSecurityRequirement
   id: RevenantSpawn
   categories: [ HideSpawnMenu ]
   components:
@@ -380,7 +380,7 @@
     - Security
     - Service
     - Supply
-    extraCount: 2
+    extraCount: 5
     lightBreakChancePerSecond: 0.0003
     doorToggleChancePerSecond: 0.001
 
@@ -400,7 +400,7 @@
 
 - type: entity
   id: SlimesSpawn
-  parent:  [VentCrittersBase, BaseGameRule] # Floof - reparented
+  parent:  [VentCrittersBase, BaseGameRuleSecurityRequirement] # Floof - reparented
   categories: [ HideSpawnMenu ]
   components:
   - type: StationEvent
@@ -421,7 +421,7 @@
 
 - type: entity
   id: SpiderSpawn
-  parent: [VentCrittersBase, BaseGameRule] # Floof - reparented
+  parent: [VentCrittersBase, BaseGameRuleSecurityRequirement] # Floof - reparented
   categories: [ HideSpawnMenu ]
   components:
   - type: StationEvent
@@ -438,7 +438,7 @@
 
 - type: entity
   id: SpiderClownSpawn
-  parent: [VentCrittersBase, BaseGameRule] # Floof - reparented
+  parent: [VentCrittersBase, BaseGameRuleSecurityRequirement] # Floof - reparented
   categories: [ HideSpawnMenu ]
   components:
   - type: StationEvent
@@ -494,7 +494,7 @@
 
 - type: entity
   id: LoneOpsSpawn
-  parent: BaseGameRuleSecurityRequirement # Floof - changed parent
+  parent: BaseGameRuleSecurityRequirementHigh # Floof - changed parent
   categories: [ HideSpawnMenu ]
   components:
   - type: StationEvent
@@ -596,13 +596,13 @@
 
 - type: entity
   id: MimicVendorRule
-  parent: BaseGameRule
+  parent: BaseGameRuleSecurityRequirement
   categories: [ HideSpawnMenu ]
   components:
     - type: StationEvent
       earliestStart: 20 # Floof
       minimumPlayers: 20
-      maxOccurrences: 1 # this event has diminishing returns on interesting-ness, so we cap it
+      maxOccurrences: 2 # this event has diminishing returns on interesting-ness, so we cap it
       weight: 5
     - type: MobReplacementRule
 

--- a/Resources/Prototypes/_Floof/Gamerules/Events.yml
+++ b/Resources/Prototypes/_Floof/Gamerules/Events.yml
@@ -1,6 +1,6 @@
 - type: entity
   id: ArgocyteVents
-  parent: [VentCrittersBase, BaseGameRule]
+  parent: [VentCrittersBase, BaseGameRuleSecurityRequirement]
   categories: [ HideSpawnMenu ]
   components:
   - type: StationEvent
@@ -39,7 +39,7 @@
 
 - type: entity
   id: TickVents
-  parent: [VentCrittersBase, BaseGameRule]
+  parent: [VentCrittersBase, BaseGameRuleSecurityRequirement]
   categories: [ HideSpawnMenu ]
   components:
   - type: StationEvent
@@ -56,7 +56,7 @@
 
 - type: entity
   id: CarpVents
-  parent: [VentCrittersBase, BaseGameRule]
+  parent: [VentCrittersBase, BaseGameRuleSecurityRequirement]
   categories: [ HideSpawnMenu ]
   components:
   - type: StationEvent
@@ -83,7 +83,7 @@
 
 - type: entity
   id: SpaceVents
-  parent: [VentCrittersBase, BaseGameRule]
+  parent: [VentCrittersBase, BaseGameRuleSecurityRequirement]
   categories: [ HideSpawnMenu ]
   components:
   - type: StationEvent
@@ -106,7 +106,7 @@
       
 - type: entity
   id: reagentslimeVents
-  parent: BaseGameRule
+  parent: BaseGameRuleSecurityRequirement
   categories: [ HideSpawnMenu ]
   components:
   - type: StationEvent

--- a/Resources/Prototypes/_Floof/Gamerules/base.yml
+++ b/Resources/Prototypes/_Floof/Gamerules/base.yml
@@ -9,3 +9,14 @@
     - !type:DepartmentCountCondition
       department: Security
       range: {min: 2}
+
+- type: entity
+  id: BaseGameRuleSecurityRequirementHigh
+  parent: BaseGameRule
+  abstract: true
+  components:
+  - type: StationEvent
+    conditions:
+    - !type:DepartmentCountCondition
+      department: Security
+      range: {min: 4}


### PR DESCRIPTION
# Description
Makes it so hostile mob events can't spawn without 2 security personnel and upped higher risk events to require 4. 

# Changelog
:cl:
- tweak: Safety Inspector came by and checked the vents. There's nothing in there.
