### PR TITLE
Add Evac Vote Results Feedback And Fix Evac Vote Bugs

### DIFF
--- a/Content.Server/RoundEnd/RoundEndSystem.cs
+++ b/Content.Server/RoundEnd/RoundEndSystem.cs
@@ -393,7 +393,19 @@ namespace Content.Server.RoundEnd
 
                 Action act = () =>
                 {
-                    RequestRoundEnd(null, false, "round-end-system-shuttle-auto-called-announcement");
+                    RequestRoundEnd(null, false, "floof-round-end-system-shuttle-autocall-announcement"); // Floof
+                    _autoCalledBefore = true;
+                };
+
+                Action wontact = () =>
+                {
+                    _chatSystem.DispatchGlobalAnnouncement( Loc.GetString("floof-round-end-system-autocall-stay"), "Central Command",true, null, Color.Gold);
+                    _autoCalledBefore = true;
+                };
+                
+                Action cantact = () =>
+                {
+                    RequestRoundEnd(null, false, "floof-round-end-system-autocall-tie");
                     _autoCalledBefore = true;
                 };
 
@@ -418,8 +430,12 @@ namespace Content.Server.RoundEnd
 
                     vote.OnFinished += (_, args) =>
                     {
+                        if (args.Winner == null)
+                            cantact();
                         if (args.Winner is true)
                             act();
+                        if (args.Winner is false)
+                            wontact();
                     };
                 }
 

--- a/Resources/Locale/en-US/_Floof/voting/ui/vote-popup.ftl
+++ b/Resources/Locale/en-US/_Floof/voting/ui/vote-popup.ftl
@@ -1,4 +1,7 @@
 ﻿# Autocall
+floof-round-end-system-shuttle-autocall-announcement = Leaving has won the vote. An automatic crew shift change shuttle has been sent. ETA: {$time} {$units}.
+floof-round-end-system-autocall-stay = Staying has won the vote. The shift has been extended.
+floof-round-end-system-autocall-tie = It's a tie. Station command is expected to conduct an internal vote among themselves to break the tie. Until an outcome is reached, the automatic crew shift change shuttle has been sent. ETA: {$time} {$units}.
 floof-round-end-system-shuttle-call-vote = Stay, or leave?
 ui-vote-autocall-stay =  Stay
 ui-vote-autocall-leave = Leave


### PR DESCRIPTION
<!--
This is a semi-strict format, you can add/remove sections as needed but the order/format should be kept the same
Remove these comments before submitting
-->

# Description

<!--
Explain this PR in as much detail as applicable

Some example prompts to consider:
How might this affect the game? The codebase?
What might be some alternatives to this?
How/Who does this benefit/hurt [the game/codebase]?
-->

This PR aims to add visible feedback regarding the results of the shuttle evac vote in the form of announcements.

It also establishes a tiebreaker protocol, where command is expected to break the tie, where either they recall the shuttle, or simply let it arrive, in a timely manner.

This also addresses a bug where the evac shuttle call stops happening if the first vote is a stay. This is due to the flag that signals to the system to try again another time, `_autoCalledBefore`, not being set as it was coded to only become `true` upon a shuttle being *recalled.*

---
<!--
This is default collapsed, readers click to expand it and see all your media
The PR media section can get very large at times, so this is a good way to keep it clean
The title is written using HTML tags
The title must be within the <summary> tags or you won't see it
-->

<details><summary><h1>Media</h1></summary>
<p>

<img width="303" height="38" alt="image" src="https://github.com/user-attachments/assets/6c8f5780-7021-4d4e-8a10-e2ecf1a40688" />
<img width="306" height="78" alt="image" src="https://github.com/user-attachments/assets/fc7ce8eb-165c-4f07-a1e7-0bc962b9975e" />
<img width="275" height="49" alt="image" src="https://github.com/user-attachments/assets/f400d541-935b-4b01-93f6-5aa02639e98b" />


</p>
</details>

---

# Changelog

<!--
You can add an author after the `:cl:` to change the name that appears in the changelog (ex: `:cl: Death`)
Leaving it blank will default to your GitHub display name
This includes all available types for the changelog
-->

:cl:
- add: The evac shuttle vote now shows feedback showing the results of the vote.
- fix: The evac shuttle vote no longer ceases operations if the first vote's winner is 'stay.'
