### PR TITLE
Lead to Chemvend

### DIFF
--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/boozeomat.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/boozeomat.yml
@@ -51,3 +51,4 @@
     DrinkAngobittersBottleFull: 3 # DeltaV - Angostura Bitters Bottle
   emaggedInventory:
     DrinkPoisonWinebottleFull: 2
+    LeadChemistryBottle: 2

--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/chefvend.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/chefvend.yml
@@ -23,3 +23,6 @@
     FoodCheese: 1
     FoodMeat: 6
     LunchboxGenericFilledRandom: 5 # Delta-V Adds Lunchbox
+  emaggedInventory:
+    ToxinChemistryBottle: 1
+    LeadChemistryBottle: 1

--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/chemvend.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/chemvend.yml
@@ -22,8 +22,11 @@
     JugSodium: 2
     JugSugar: 3
     JugSulfur: 1
+  contrabandInventory:
+    LeadChemistryBottle: 2
   emaggedInventory:
     ToxinChemistryBottle: 1
+    VestineChemistryVial: 1
 
 - type: vendingMachineInventory
   id: ChemVendInventorySyndicate


### PR DESCRIPTION
# Description
I noticed there was NO way to obtain Lead in game (only way was the Nuclear Operative Chemvend which requires a full nuke ops to spawn which is impossible). Sure it's a deadly toxin but it's also a Sweetener (used in the Victorian era) and on the periodic table.

So this adds Lead to the Contraband Inventory of the Chemvend, and Vestine to the Emag Inventory (Buff to Chemist Syndies, as Medical has no unique items to buy)
Also adds Lead to the Boozeomat and Chefvend Emag Inventory to assist Bartender and Chef Syndies. 

# Changelog
:cl:
- tweak: Added Lead to Chemvend Contraband Inventory (where you cut the management wire)

