### PR TITLE
Fix Silly Resomi Plushie Having a 100% Drop Chance

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Fun/prizeticket.yml
+++ b/Resources/Prototypes/Entities/Objects/Fun/prizeticket.yml
@@ -433,6 +433,8 @@
         prob: 0.50
         orGroup: Prize
       - id: PlushieSillyResomi
+        prob: 0.50
+        orGroup: Prize
       - id: PlushieAvianMysta
         prob: 0.50
         orGroup: Prize


### PR DESCRIPTION
This isn't even worth describing.

:cl:
- fix: The silly resomi plushie will no longer drop from every prize ball.