### PR TITLE
Change Listplayers Command Permissions to Require the PII Flag (Wizden #40324)

### DIFF
--- a/Resources/engineCommandPerms.yml
+++ b/Resources/engineCommandPerms.yml
@@ -17,7 +17,6 @@
   - inrangeunoccluded
   - lsgrid
   - lsmap
-  - listplayers
   - loc
   - mem
   - netaudit
@@ -70,7 +69,6 @@
   - pvs_override_info
   - merge_grids
 
-
 - Flags: MAPPING
   Commands:
   - addmap
@@ -92,12 +90,15 @@
   Commands:
   - delete
   - kick
-  - listplayers
   - tp
   - tpto
   - respawn
   - tippy
   - tip
+    
+- Flags: PII
+  Commands:
+    - listplayers
 
 - Flags: SERVER
   Commands:


### PR DESCRIPTION
<!--
This is a semi-strict format, you can add/remove sections as needed but the order/format should be kept the same
Remove these comments before submitting
-->

# Description

<!--
Explain this PR in as much detail as applicable

Some example prompts to consider:
How might this affect the game? The codebase?
What might be some alternatives to this?
How/Who does this benefit/hurt [the game/codebase]?
-->

I don't think I even need to supply a explanation nor justification for this cherry-pick.

But for the uninitiated, the `listplayers` command also displays the player's IP address alongside their name, currently without needing PII perms. You can connect the dots to know why that is horrible.

---

No CL is needed.