### PR TITLE
Stealthy Syndi Key

### DIFF
--- a/Content.Shared/Radio/EntitySystems/EncryptionKeySystem.cs
+++ b/Content.Shared/Radio/EntitySystems/EncryptionKeySystem.cs
@@ -241,6 +241,14 @@ public sealed partial class EncryptionKeySystem : EntitySystem
         {
             proto = _protoManager.Index<RadioChannelPrototype>(id);
 
+            //Floof - Hide Syndicate key from examine
+            if (proto.ID == "Syndicate")
+            {
+                return;
+            }
+            ;
+            //Floof - End
+
             var key = id == SharedChatSystem.CommonChannel
                 ? SharedChatSystem.RadioCommonPrefix.ToString()
                 : $"{SharedChatSystem.RadioChannelPrefix}{proto.KeyCode}";

--- a/Content.Shared/Radio/EntitySystems/EncryptionKeySystem.cs
+++ b/Content.Shared/Radio/EntitySystems/EncryptionKeySystem.cs
@@ -242,11 +242,10 @@ public sealed partial class EncryptionKeySystem : EntitySystem
             proto = _protoManager.Index<RadioChannelPrototype>(id);
 
             //Floof - Hide Syndicate key from examine
-            if (proto.ID == "Syndicate")
+            if (proto.ID == "Syndicate" & !HasComp<EncryptionKeyComponent>(examineEvent.Examined))
             {
-                return;
+                continue;
             }
-            ;
             //Floof - End
 
             var key = id == SharedChatSystem.CommonChannel
@@ -264,6 +263,12 @@ public sealed partial class EncryptionKeySystem : EntitySystem
         {
             if (HasComp<HeadsetComponent>(examineEvent.Examined))
             {
+                //Floof - Hide Syndicate key from examine
+                if (defaultChannel == "Syndicate")
+                {
+                    return;
+                }
+                //Floof - End
                 var msg = Loc.GetString("examine-headset-default-channel",
                 ("prefix", SharedChatSystem.DefaultChannelPrefix),
                 ("channel", defaultChannel),


### PR DESCRIPTION
# Description

Syndicate key can't be found by glancing at someone's headset. This will help encourage agents to actually use them without fear of someone outing them with two button presses.

The media is from when the default channel text was being eaten on all keys. That issue has been fixed.

---

<details><summary><h1>Media</h1></summary>
<p>

Med headset without syndi key:
<img width="480" height="377" alt="image" src="https://github.com/user-attachments/assets/59c75b0a-3195-49f2-9c20-576ecabe6543" />
Syndi headset with key inserted:
<img width="465" height="278" alt="image" src="https://github.com/user-attachments/assets/8a3b7d8f-9324-42d7-906a-c7c151e05126" />
Moving the key to the med headset:
<img width="134" height="110" alt="image" src="https://github.com/user-attachments/assets/a078c429-2776-4383-8fb0-17464d56b9e4" />
Med headset with syndi key inserted:
<img width="298" height="263" alt="image" src="https://github.com/user-attachments/assets/33402eba-8686-45f9-9364-5cf8d767178e" />


</p>
</details>

---

# Changelog

:cl: Sprkl
- tweak: Syndicate keys are no longer visible while in a headset.
