### PR TITLE
Upstream Merge 39566: Reduce LevelOfParallelism to 2 for Integration Tests

### DIFF
--- a/Content.IntegrationTests/AssemblyInfo.cs
+++ b/Content.IntegrationTests/AssemblyInfo.cs
@@ -5,4 +5,4 @@
 // https://github.com/dotnet/runtime/issues/107197
 // So we can't really parallelize integration tests harder either until the runtime fixes that,
 // *or* we fix serv3 to not spam expression trees.
-[assembly: LevelOfParallelism(3)]
+[assembly: LevelOfParallelism(2)]


### PR DESCRIPTION
Upstream PR: https://github.com/space-wizards/space-station-14/pull/39566



-----

Forks were getting hit by OOM errors.
See https://github.com/space-wizards/space-station-14/pull/39561
I was told this also makes the tests run faster for some unexplained reason, so this I'm trying this out to check how long they take with this setting upstream.