### PR TITLE
Kill the Raise Glimmer Objective

### DIFF
--- a/Resources/Prototypes/Nyanotrasen/Objectives/traitor.yml
+++ b/Resources/Prototypes/Nyanotrasen/Objectives/traitor.yml
@@ -30,18 +30,18 @@
 #      - BecomePsionicCondition
 #  - type: BecomeGolemCondition
 
-- type: entity
-  id: RaiseGlimmerObjective
-  parent: BaseTraitorObjective
-  categories: [ HideSpawnMenu ]
-  name: Raise Glimmer.
-  description: Get the glimmer above the specified amount.
-  components:
-  - type: Objective
-    difficulty: 2.5
+# type: entity
+#  id: RaiseGlimmerObjective
+#  parent: BaseTraitorObjective
+#  categories: [ HideSpawnMenu ]
+#  name: Raise Glimmer.
+#  description: Get the glimmer above the specified amount.
+#  components:
+#  - type: Objective
+#    difficulty: 2.5
     #unique: false
-    icon:
-      sprite: Nyanotrasen/Icons/psi.rsi
-      state: psi
-  - type: RaiseGlimmerCondition
-    target: 500
+#    icon:
+#      sprite: Nyanotrasen/Icons/psi.rsi
+#      state: psi
+#  - type: RaiseGlimmerCondition
+#    target: 500


### PR DESCRIPTION
<!--
This is a semi-strict format, you can add/remove sections as needed but the order/format should be kept the same
Remove these comments before submitting
-->

# Description

<!--
Explain this PR in as much detail as applicable

Some example prompts to consider:
How might this affect the game? The codebase?
What might be some alternatives to this?
How/Who does this benefit/hurt [the game/codebase]?
-->

Kills the Raise Glimmer to 500 objective. The objective is either not played at all or it is done by spamming glimmers/powers in an incredibly little to no RP manner. While the aftermath does call rp potentially, it still does too much disruption for the small amount of RP provided.
---

# Changelog

<!--
You can add an author after the `:cl:` to change the name that appears in the changelog (ex: `:cl: Death`)
Leaving it blank will default to your GitHub display name
This includes all available types for the changelog
-->

:cl:
- remove: Removed Raise Glimmer objective (pending rework)
