### PR TITLE
Sever

### DIFF
--- a/Content.Shared/Body/Part/BodyPartComponent.cs
+++ b/Content.Shared/Body/Part/BodyPartComponent.cs
@@ -94,7 +94,7 @@ public sealed partial class BodyPartComponent : Component, ISurgeryToolComponent
     ///     Shitmed Change: How much health to heal on the body part per tick.
     /// </summary>
     [DataField]
-    public float SelfHealingAmount = 1f; // Floof - reduced from 5 due to body part damage nerf. Was 10/min, now 1/min. Reverted.
+    public float SelfHealingAmount = 0.5f; // Floof - reduced from 5 due to body part damage nerf. Was 10/min, now 1/min.
 
     /// <summary>
     ///     Shitmed Change: The name of the container for this body part. Used in insertion surgeries.

--- a/Content.Shared/Body/Part/BodyPartComponent.cs
+++ b/Content.Shared/Body/Part/BodyPartComponent.cs
@@ -94,7 +94,7 @@ public sealed partial class BodyPartComponent : Component, ISurgeryToolComponent
     ///     Shitmed Change: How much health to heal on the body part per tick.
     /// </summary>
     [DataField]
-    public float SelfHealingAmount = 0.5f; // Floof - reduced from 5 due to body part damage nerf. Was 10/min, now 1/min.
+    public float SelfHealingAmount = 1f; // Floof - reduced from 5 due to body part damage nerf. Was 10/min, now 1/min. Reverted.
 
     /// <summary>
     ///     Shitmed Change: The name of the container for this body part. Used in insertion surgeries.
@@ -120,7 +120,7 @@ public sealed partial class BodyPartComponent : Component, ISurgeryToolComponent
     ///     to make possible severing it.
     /// </summary>
     [DataField, AutoNetworkedField]
-    public float SeverIntegrity = 300; // Floof - increased to 300 due to frequent RR
+    public float SeverIntegrity = 100; // Floof - increased to 300 due to frequent RR - Changed to 100, heads will have a higher value to prevent RR
 
     /// <summary>
     ///     Shitmed Change: The ID of the base layer for this body part.

--- a/Resources/Prototypes/Body/Parts/base.yml
+++ b/Resources/Prototypes/Body/Parts/base.yml
@@ -114,6 +114,7 @@
     partType: Head
     toolName: "a head" # Shitmed Change
     vital: true
+    SeverIntegrity: 200 # Floof - Makes it so RR via beheading is harder
   - type: Input
     context: "ghost"
   - type: Tag


### PR DESCRIPTION
# Description

Changes default Sever Integrity to 100 down from impossible to sever 300.
Changes HEAD (base body part) Sever Integrity to 200 so RR via beheading is still very hard.

# Changelog
:cl:
- tweak: Changed Limb Severing Threshold, Delimbing before death is possible again, beheading will still be very hard.