### PR TITLE
Warden Gloves Traitor Target

### DIFF
--- a/Resources/Prototypes/Objectives/objectiveGroups.yml
+++ b/Resources/Prototypes/Objectives/objectiveGroups.yml
@@ -25,6 +25,7 @@
     LOLuckyBillStealObjective: 0.5 # DeltaV - LO steal objective, see Resources/Prototypes/DeltaV/Objectives/traitor.yml
     HoPBookIanDossierStealObjective: 1 # DeltaV - HoP steal objective, see Resources/Prototypes/DeltaV/Objectives/traitor.yml
     HoSGunStealObjective: 0.5
+    WardenGlovesStealObjective: 0.5 #Floof - Warden Krav Maga Gloves steal objective, see Resources/Prototypes/_Floof/Objectives/traitor.yml
     StealSupermatterSliverObjective: 0.5
     EnergyShotgunStealObjective: 0.5
 

--- a/Resources/Prototypes/_Floof/Loadouts/Jobs/Security/warden.yml
+++ b/Resources/Prototypes/_Floof/Loadouts/Jobs/Security/warden.yml
@@ -9,19 +9,19 @@
 
 # Eyes
 
-# Gloves
-- type: loadout
-  id: LoadoutClothingHandsKravMaga
-  category: JobsSecurityWarden
-  cost: 0
-  requirements:
-    - !type:CharacterItemGroupRequirement
-      group: LoadoutWardenGloves
-    - !type:CharacterJobRequirement
-      jobs:
-        - Warden
-  items:
-    - ClothingHandsGlovesKravMaga
+# Gloves // Removed Krav Maga from Loadout for Warden to only have one set on station //
+#- type: loadout
+#  id: LoadoutClothingHandsKravMaga
+#  category: JobsSecurityWarden
+#  cost: 0
+#  requirements:
+#    - !type:CharacterItemGroupRequirement
+#      group: LoadoutWardenGloves
+#    - !type:CharacterJobRequirement
+#      jobs:
+#        - Warden
+#  items:
+#    - ClothingHandsGlovesKravMaga
 
 # Head
 - type: loadout

--- a/Resources/Prototypes/_Floof/Objectives/stealTargetGroups.yml
+++ b/Resources/Prototypes/_Floof/Objectives/stealTargetGroups.yml
@@ -1,0 +1,6 @@
+﻿- type: stealTargetGroup
+  id: ClothingHandsGlovesKravMaga
+  name: Krav Maga gloves
+  sprite:
+    sprite: _Goobstation/Clothing/Hands/Gloves/kravgloves.rsi
+    state: icon

--- a/Resources/Prototypes/_Floof/Objectives/traitor.yml
+++ b/Resources/Prototypes/_Floof/Objectives/traitor.yml
@@ -11,3 +11,13 @@
   - type: PickRandomHead
   - type: TeachLessonCondition
 
+- type: entity # Warden Gloves Steal Objective
+  categories: [HideSpawnMenu]
+  parent: BaseTraitorStealObjective
+  id: WardenGlovesStealObjective
+  components:
+  - type: StealCondition
+    stealGroup: ClothingHandsGlovesKravMaga
+    owner: job-name-warden
+  - type: Objective
+    difficulty: 1


### PR DESCRIPTION
# Description

This PR does two things:

- Remove the warden's Krav Maga gloves from the loadout for the Warden. This means that there can only be one pair of Krav Maga gloves per map instead of having wardens spawn with one and one being spare in the locker and getting loose.

- Adds the warden's Krav Maga gloves to the steal objective pool for agent traitors. 

<summary><h1>Media</h1></summary>
<img width="361" height="73" alt="wardengloves" src="https://github.com/user-attachments/assets/381a624d-bd88-4ac0-8076-db3054e73ef4" />


---

# Changelog

<!--
You can add an author after the `:cl:` to change the name that appears in the changelog (ex: `:cl: Death`)
Leaving it blank will default to your GitHub display name
This includes all available types for the changelog
-->

:cl:
- add: Added a steal objective for Krav Maga gloves for traitors.
- remove: Krav Maga gloves can no longer be obtained via loadouts as the Warden locker already contains a pair.
