### PR TITLE
Increases Vox Minimum Width and Height.

### DIFF
--- a/Resources/Prototypes/Species/vox.yml
+++ b/Resources/Prototypes/Species/vox.yml
@@ -12,10 +12,10 @@
   femaleFirstNames: names_vox
   naming: First
 
-  minHeight: 0.45
+  minHeight: 0.65 # Floof - Changed from 0.45, too small.
   #defaultHeight: 0.8 Floofstation - disabled due to upstream bug, this is broken for any value other than 1.
   maxHeight: 1.04
-  minWidth: 0.4
+  minWidth: 0.6 # Floof - changed from 0.4, too small.
   #defaultWidth: 0.8 Floofstation - disabled due to upstream bug, this is broken for any value other than 1.
   maxWidth: 1.1
 


### PR DESCRIPTION
# Description

Simple PR that increases the minimum height and width for Vox to match other species.

Width: From 0.4 to 0.6
Height: From 0.45 to 0.65

This is due to the minimum size of the Vox allowing for small traitors like ninjas

---

# TODO

- [x] Media - Before/After

---

<details><summary><h1>Media</h1></summary>
Example of small Ninja.
<p><img width="116" height="120" alt="Screenshot_2025-09-21_103046" src="https://github.com/user-attachments/assets/c2239b63-5128-4308-8e5a-b15c97dadffe" />
</p>

Before Changes
<p><img width="239" height="209" alt="image_2025-09-23_120404491" src="https://github.com/user-attachments/assets/f598f1f1-ae5b-46f8-8b65-0ad4fd018603" />
</p>

After Changes
<p><img width="444" height="388" alt="AfterChangess" src="https://github.com/user-attachments/assets/7da4ea2c-4a48-4a7c-8605-f80b22951755" />
</p>
</details>

---

# Changelog

:cl:
- tweak: Increased minimum width and height for Vox.
