### PR TITLE
Fix Footstep Heisentest

### DIFF
--- a/Content.Server/FootPrint/FootPrintsSystem.cs
+++ b/Content.Server/FootPrint/FootPrintsSystem.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics;
 using System.Linq;
 using Content.Server.Atmos.Components;
 using Content.Server.Gravity;
@@ -50,6 +51,9 @@ public sealed class FootPrintsSystem : EntitySystem
 
     private void OnMove(EntityUid uid, FootPrintsComponent component, ref MoveEvent args)
     {
+        #if DEBUG // Floof - do not create footprints on debug, nor in CI tests
+        return;
+        #endif
         if (component.ContainedSolution.Volume <= 0
             || TryComp<PhysicsComponent>(uid, out var physics) && physics.BodyStatus != BodyStatus.OnGround // Floof: do not create footprints if the entity is flying
             || args.Entity.Comp1.GridUid is not {} gridUid)

--- a/Content.Server/FootPrint/FootPrintsSystem.cs
+++ b/Content.Server/FootPrint/FootPrintsSystem.cs
@@ -1,4 +1,3 @@
-using System.Diagnostics;
 using System.Linq;
 using Content.Server.Atmos.Components;
 using Content.Server.Gravity;


### PR DESCRIPTION
<!--
This is a semi-strict format, you can add/remove sections as needed but the order/format should be kept the same
Remove these comments before submitting
-->

# Description

<!--
Explain this PR in as much detail as applicable

Some example prompts to consider:
How might this affect the game? The codebase?
What might be some alternatives to this?
How/Who does this benefit/hurt [the game/codebase]?
-->

The `SpawnAndDeleteAllEntitiesInTheSameSpot` test, according to what I can garner, is one of two tests that are done to ensure the stability of the testing system altogether.

However, with #1390 and #1386, it caused non-stop heisentests relating to to footsteps.

At the advice and recommendation of Mnemo, I have implemented a "conditional compilation directive" as it's apparently called, that will make the `OnMove` method of the `FootPrintsSystem` not be run if the build configuration is found to be `DEBUG`. This will also make it where CI tests will no longer invoke this method, which led to issues seen in the two aforementioned PRs.

Finally, I can be free of this development hell relating to these two PRs.

---

No CL as this is a backend change.
