### PR TITLE
AHelp Fix: Add Error Catching on Network Requests (And Very Simple "Retry" Logic?)

### DIFF
--- a/Content.Server/Administration/Systems/BwoinkSystem.cs
+++ b/Content.Server/Administration/Systems/BwoinkSystem.cs
@@ -486,6 +486,7 @@ namespace Content.Server.Administration.Systems
             // Otherwise patch (edit) it
             if (existingEmbed.Id == null)
             {
+                // Floof: Changed to a Try/Catch block to handle network issues and refused connections
                 HttpResponseMessage request;
                 try
                 {
@@ -497,9 +498,10 @@ namespace Content.Server.Administration.Systems
                     _sawmill.Log(LogLevel.Error,
                         $"Webhook POST failed (network / refused) for user {userId}: {ex.Message}\n{ex}");
                     _relayMessages.Remove(userId);
-                    _processingChannels.Remove(userId); // Very Basic "Retry" logic, There might be times were Source or Target have temporarily network issues.
+                    _processingChannels.Remove(userId); // Floof: Very Basic "Retry" logic, There might be times were Source or Target have temporarily network issues.
                     return;
                 }
+                // Floof End
 
                 var content = await request.Content.ReadAsStringAsync();
                 if (!request.IsSuccessStatusCode)
@@ -507,7 +509,7 @@ namespace Content.Server.Administration.Systems
                     _sawmill.Log(LogLevel.Error,
                         $"Discord returned bad status code when posting message (perhaps the message is too long?): {request.StatusCode}\nResponse: {content}");
                     _relayMessages.Remove(userId);
-                    _processingChannels.Remove(userId); // Very Basic "Retry" logic, if post fails we discard the embed and make a new one
+                    _processingChannels.Remove(userId); // Floof: Very Basic "Retry" logic, if post fails we discard the embed and make a new one
                     return;
                 }
 
@@ -524,6 +526,7 @@ namespace Content.Server.Administration.Systems
             }
             else
             {
+                // Floof: Changed to a Try/Catch block to handle network issues and refused connections
                 HttpResponseMessage request;
                 try
                 {
@@ -535,9 +538,10 @@ namespace Content.Server.Administration.Systems
                     _sawmill.Log(LogLevel.Error,
                         $"Webhook PATCH failed (network / refused) for user {userId} (will discard current embed state): {ex.Message}\n{ex}");
                     _relayMessages.Remove(userId);
-                    _processingChannels.Remove(userId); // Very Basic "Retry" logic, There might be times were Source or Target have temporarily network issues.
+                    _processingChannels.Remove(userId); // Floof: Very Basic "Retry" logic, There might be times were Source or Target have temporarily network issues.
                     return;
                 }
+                // Floof End
 
                 if (!request.IsSuccessStatusCode)
                 {
@@ -545,7 +549,7 @@ namespace Content.Server.Administration.Systems
                     _sawmill.Log(LogLevel.Error,
                         $"Discord returned bad status code when patching message (perhaps the message is too long?): {request.StatusCode}\nResponse: {content}");
                     _relayMessages.Remove(userId);
-                    _processingChannels.Remove(userId); // Very Basic "Retry" logic, if patch fails we discard the embed and make a new one
+                    _processingChannels.Remove(userId); // Floof: Very Basic "Retry" logic, if patch fails we discard the embed and make a new one
                     return;
                 }
             }
@@ -574,6 +578,7 @@ namespace Content.Server.Administration.Systems
 
                     payload = GeneratePayload(message.ToString(), existingEmbed.Username, userId, existingEmbed.CharacterName);
 
+                    // Floof: Changed to a Try/Catch block to handle network issues and refused connections
                     HttpResponseMessage request;
                     try
                     {
@@ -587,6 +592,7 @@ namespace Content.Server.Administration.Systems
                         request = null!;
                     }
 
+
                     if (request != null)
                     {
                         var content = await request.Content.ReadAsStringAsync();
@@ -595,6 +601,7 @@ namespace Content.Server.Administration.Systems
                             _sawmill.Log(LogLevel.Error, $"Webhook returned bad status code when posting relay message (perhaps the message is too long?): {request.StatusCode}\nResponse: {content}");
                         }
                     }
+                    // Floof End
                 }
             }
             else

--- a/Content.Server/Administration/Systems/BwoinkSystem.cs
+++ b/Content.Server/Administration/Systems/BwoinkSystem.cs
@@ -486,8 +486,20 @@ namespace Content.Server.Administration.Systems
             // Otherwise patch (edit) it
             if (existingEmbed.Id == null)
             {
-                var request = await _httpClient.PostAsync($"{_webhookUrl}?wait=true",
-                    new StringContent(JsonSerializer.Serialize(payload), Encoding.UTF8, "application/json"));
+                HttpResponseMessage request;
+                try
+                {
+                    request = await _httpClient.PostAsync($"{_webhookUrl}?wait=true",
+                        new StringContent(JsonSerializer.Serialize(payload), Encoding.UTF8, "application/json"));
+                }
+                catch (Exception ex)
+                {
+                    _sawmill.Log(LogLevel.Error,
+                        $"Webhook POST failed (network / refused) for user {userId}: {ex.Message}\n{ex}");
+                    _relayMessages.Remove(userId);
+                    _processingChannels.Remove(userId); // Very Basic "Retry" logic, There might be times were Source or Target have temporarily network issues.
+                    return;
+                }
 
                 var content = await request.Content.ReadAsStringAsync();
                 if (!request.IsSuccessStatusCode)
@@ -495,6 +507,7 @@ namespace Content.Server.Administration.Systems
                     _sawmill.Log(LogLevel.Error,
                         $"Discord returned bad status code when posting message (perhaps the message is too long?): {request.StatusCode}\nResponse: {content}");
                     _relayMessages.Remove(userId);
+                    _processingChannels.Remove(userId); // Very Basic "Retry" logic, if post fails we discard the embed and make a new one
                     return;
                 }
 
@@ -511,8 +524,20 @@ namespace Content.Server.Administration.Systems
             }
             else
             {
-                var request = await _httpClient.PatchAsync($"{_webhookUrl}/messages/{existingEmbed.Id}",
-                    new StringContent(JsonSerializer.Serialize(payload), Encoding.UTF8, "application/json"));
+                HttpResponseMessage request;
+                try
+                {
+                    request = await _httpClient.PatchAsync($"{_webhookUrl}/messages/{existingEmbed.Id}",
+                        new StringContent(JsonSerializer.Serialize(payload), Encoding.UTF8, "application/json"));
+                }
+                catch (Exception ex)
+                {
+                    _sawmill.Log(LogLevel.Error,
+                        $"Webhook PATCH failed (network / refused) for user {userId} (will discard current embed state): {ex.Message}\n{ex}");
+                    _relayMessages.Remove(userId);
+                    _processingChannels.Remove(userId); // Very Basic "Retry" logic, There might be times were Source or Target have temporarily network issues.
+                    return;
+                }
 
                 if (!request.IsSuccessStatusCode)
                 {
@@ -520,6 +545,7 @@ namespace Content.Server.Administration.Systems
                     _sawmill.Log(LogLevel.Error,
                         $"Discord returned bad status code when patching message (perhaps the message is too long?): {request.StatusCode}\nResponse: {content}");
                     _relayMessages.Remove(userId);
+                    _processingChannels.Remove(userId); // Very Basic "Retry" logic, if patch fails we discard the embed and make a new one
                     return;
                 }
             }
@@ -548,13 +574,26 @@ namespace Content.Server.Administration.Systems
 
                     payload = GeneratePayload(message.ToString(), existingEmbed.Username, userId, existingEmbed.CharacterName);
 
-                    var request = await _httpClient.PostAsync($"{_onCallUrl}?wait=true",
-                        new StringContent(JsonSerializer.Serialize(payload), Encoding.UTF8, "application/json"));
-
-                    var content = await request.Content.ReadAsStringAsync();
-                    if (!request.IsSuccessStatusCode)
+                    HttpResponseMessage request;
+                    try
                     {
-                        _sawmill.Log(LogLevel.Error, $"Discord returned bad status code when posting relay message (perhaps the message is too long?): {request.StatusCode}\nResponse: {content}");
+                        request = await _httpClient.PostAsync($"{_onCallUrl}?wait=true",
+                            new StringContent(JsonSerializer.Serialize(payload), Encoding.UTF8, "application/json"));
+                    }
+                    catch (Exception ex)
+                    {
+                        _sawmill.Log(LogLevel.Error,
+                            $"On-call webhook POST failed (network / refused) for user {userId}: {ex.Message}\n{ex}");
+                        request = null!;
+                    }
+
+                    if (request != null)
+                    {
+                        var content = await request.Content.ReadAsStringAsync();
+                        if (!request.IsSuccessStatusCode)
+                        {
+                            _sawmill.Log(LogLevel.Error, $"Webhook returned bad status code when posting relay message (perhaps the message is too long?): {request.StatusCode}\nResponse: {content}");
+                        }
                     }
                 }
             }


### PR DESCRIPTION
<!--
This is a semi-strict format, you can add/remove sections as needed but the order/format should be kept the same
Remove these comments before submitting
-->
# Description

Basicly my Port to FloofStation of https://github.com/new-frontiers-14/frontier-station-14/pull/3924 (Still unreviewd, tought)

I've Put the Network Requests into a Try/Catch Blocks, Which can happen on Network Issues either on the Source or Target Host.
This Basicly adds a VERY Simple "Retry" Logic too as Any AHelp Message in that Channel will Retry it.

Tests have been done with a Test Version of the Live Floof Bot, No Issues where found so Far with this.
(No Tests with Normal Webhooks done yet.)

Why?
Prevents AHelps Getting Eaten by Network Issues or Timeouts on Network Requests.
Simple Retry Logic to Re-send Missed AHelp Messages or on Deleted Messages

_Please tell me if i should done something Different, I'm not that Good at C# but somehow always find a Solution that might not be the best Way._