### PR TITLE
Adds Cane to Medical Techfab & Loadout

### DIFF
--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/medical.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/medical.yml
@@ -11,3 +11,5 @@
     ClothingEyesGlasses: 5
     ClothingEyesHudMedical: 2
     ClothingEyesEyepatchHudMedical: 2
+    Cane: 2
+    WhiteCane: 2

--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/medical.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/medical.yml
@@ -11,5 +11,3 @@
     ClothingEyesGlasses: 5
     ClothingEyesHudMedical: 2
     ClothingEyesEyepatchHudMedical: 2
-    Cane: 2
-    WhiteCane: 2

--- a/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
@@ -1133,7 +1133,7 @@
       - ClothingEyesGlassesChemical
       - BoneGel # Shitmed Change
       - WhiteCane # Floof
-      - Cane
+      - Cane # Floof
       - HandheldGPSBasic # Floof - port to EE
       - HandheldStationMap # Floof - port to EE
       - SterileBag # floof

--- a/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
@@ -1133,6 +1133,7 @@
       - ClothingEyesGlassesChemical
       - BoneGel # Shitmed Change
       - WhiteCane # Floof
+      - Cane
       - HandheldGPSBasic # Floof - port to EE
       - HandheldStationMap # Floof - port to EE
       - SterileBag # floof

--- a/Resources/Prototypes/_Floof/Loadouts/Generic/items.yml
+++ b/Resources/Prototypes/_Floof/Loadouts/Generic/items.yml
@@ -149,6 +149,14 @@
         - AddictionNicotine
 
 - type: loadout
+  id: LoadoutItemCane
+  category: Items
+  cost: 0
+  canBeHeirloom: true
+  items:
+  - Cane
+
+- type: loadout
   id: LoadoutItemCigarBluespace
   category: Items
   cost: 5

--- a/Resources/Prototypes/_Floof/Recipes/Lathes/medical.yml
+++ b/Resources/Prototypes/_Floof/Recipes/Lathes/medical.yml
@@ -17,6 +17,14 @@
     Plastic: 100
 
 - type: latheRecipe
+  id: Cane
+  result: Cane
+  completetime: 2
+  materials:
+    Steel: 100
+    Plastic: 100
+
+- type: latheRecipe
   id: SterileBag
   result: SterileBag
   completetime: 2


### PR DESCRIPTION
Adds the Cane to the Medical Techfab & Loadout.
<!--
This is a semi-strict format, you can add/remove sections as needed but the order/format should be kept the same
Remove these comments before submitting
-->

# Description

<!--
Explain this PR in as much detail as applicable

Some example prompts to consider:
How might this affect the game? The codebase?
What might be some alternatives to this?
How/Who does this benefit/hurt [the game/codebase]?
-->
Adds the Cane as a Loadout item and makes it craftable in the Medical Techfab.

I chose to make it cost 1 plastic and 1 steel in line with the White Cane for ease of accessibility, as wood is not a common material and would likely interfere with anyone printing Canes ever. Also, as someone who owns a few, walking sticks in real life often have metal cores and fake-varnished-wood plastic, so it's accurate enough in my opinion.

Costs 0 in loadout - even if it's only cosmetic at the minute, I'm not putting a price on mobility aids.

---

# TODO

<!--
A list of everything you have to do before this PR is "complete"
You probably won't have to complete everything before merging but it's good to leave future references
-->

- [X] Added Cane to the medical techfab
- [X] Added Cane to Loadout
 

---

<!--
This is default collapsed, readers click to expand it and see all your media
The PR media section can get very large at times, so this is a good way to keep it clean
The title is written using HTML tags
The title must be within the <summary> tags or you won't see it
-->

<details><summary><h1>Media</h1></summary>
<p>

<img width="893" height="77" alt="image" src="https://github.com/user-attachments/assets/cad31ea0-bd9a-4fc9-8ca0-a7b264727c8b" />

<img width="1123" height="382" alt="image" src="https://github.com/user-attachments/assets/06a889f8-242c-40e0-9e5d-d7623c5c8e5b" />
<img width="916" height="191" alt="image" src="https://github.com/user-attachments/assets/0533aa39-3851-4f4a-b091-c908389aa8f2" />
<img width="341" height="334" alt="image" src="https://github.com/user-attachments/assets/43f4ba32-482b-48c6-8cce-e8c6fbd8860d" />


</p>
</details>

---

# Changelog

<!--
You can add an author after the `:cl:` to change the name that appears in the changelog (ex: `:cl: Death`)
Leaving it blank will default to your GitHub display name
This includes all available types for the changelog
-->

:cl:
- add: Added Cane to Loadout
- add: Made Cane craftable in the Medical techfab

