### PR TITLE
Candy Bowl Freedom

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
@@ -1100,6 +1100,7 @@
       - HandLabeler
       - Defibrillator
       - HandheldHealthAnalyzer
+      - CandyBowl
       - ClothingHandsGlovesLatex
       - ClothingHandsGlovesNitrile
       - ClothingMaskSterile
@@ -2008,7 +2009,7 @@
       - PlushieElectricIPC
       - PlushieCuddlyIPC
       - PlushieFluffyVulpkanin
-      - PlushieSecurityTank      
+      - PlushieSecurityTank
       #Floof Plushies - End
   - type: EmagLatheRecipes
     emagStaticRecipes:

--- a/Resources/Prototypes/Recipes/Lathes/medical.yml
+++ b/Resources/Prototypes/Recipes/Lathes/medical.yml
@@ -97,6 +97,13 @@
     Steel: 500
 
 - type: latheRecipe
+  id: CandyBowl
+  result: CandyBowl
+  completetime: 2
+  materials:
+    Glass: 200
+
+- type: latheRecipe
   id: ClothingHandsGlovesLatex
   result: ClothingHandsGlovesLatex
   completetime: 2


### PR DESCRIPTION
Adds the Candy Bowl to the Medical Techfab.

<!--
This is a semi-strict format, you can add/remove sections as needed but the order/format should be kept the same
Remove these comments before submitting
-->

# Description

<!--
Explain this PR in as much detail as applicable

Some example prompts to consider:
How might this affect the game? The codebase?
What might be some alternatives to this?
How/Who does this benefit/hurt [the game/codebase]?
-->

Makes the Candy Bowl craftable in the Medical Techfab, for when it isn't mapped in or gets destroyed.
Costs 2 glass to craft.

---

# TODO

<!--
A list of everything you have to do before this PR is "complete"
You probably won't have to complete everything before merging but it's good to leave future references
-->

- [x] Added Candy Bowl recipe
- [x] Added Candy Bowl recipe to the Medical Techfab

---

<!--
This is default collapsed, readers click to expand it and see all your media
The PR media section can get very large at times, so this is a good way to keep it clean
The title is written using HTML tags
The title must be within the <summary> tags or you won't see it
-->

<details><summary><h1>Media</h1></summary>
<p>

<img width="1699" height="685" alt="image" src="https://github.com/user-attachments/assets/90c3a2fb-51b7-423d-b8cd-be39eea773b5" />
<img width="934" height="351" alt="image" src="https://github.com/user-attachments/assets/d81c8fba-f1ec-4453-937e-5ebfa6d7dc7f" />
<img width="632" height="396" alt="image" src="https://github.com/user-attachments/assets/0b2f7919-ed09-458e-9c7a-8dae97eb374d" />


</p>
</details>

---

# Changelog

<!--
You can add an author after the `:cl:` to change the name that appears in the changelog (ex: `:cl: Death`)
Leaving it blank will default to your GitHub display name
This includes all available types for the changelog
-->

:cl:
- add: Candybowl recipe to Medical Techfab
