### PR TITLE
Chefvend & Kitchen QoL

### DIFF
--- a/Resources/Prototypes/Catalog/Cargo/cargo_vending.yml
+++ b/Resources/Prototypes/Catalog/Cargo/cargo_vending.yml
@@ -23,7 +23,7 @@
     sprite: Objects/Specific/Service/vending_machine_restock.rsi
     state: base
   product: CrateVendingMachineRestockChefvendFilled
-  cost: 680
+  cost: 800
   category: cargoproduct-category-name-service
   group: market
 

--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/chefvend.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/chefvend.yml
@@ -11,12 +11,16 @@
     FoodCondimentBottleKetchup: 1
     FoodCondimentBottleBBQ: 1
     FoodCondimentBottleVinegar: 2
+    ReagentContainerHoney: 2 # Floof
     ReagentContainerOliveoil: 2
     ReagentContainerMayo: 1
+    OilJarCorn: 2 # Floof
+    OilJarOlive: 2 # Floof
     VariantCubeBox: 1
-    FoodContainerEgg: 1
+    FoodContainerEgg: 2 # Floof
+    DrinkCreamCarton: 1 # Floof
     DrinkMilkCarton: 2
-    DrinkSoyMilkCarton: 1
+    DrinkSoyMilkCarton: 2 # Floof
     BoxChocolateBar: 2 # Floof
     BoxRaisins: 2 # Floof
     FoodButter: 4

--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/ingredients.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/ingredients.yml
@@ -92,10 +92,10 @@
   - type: SolutionContainerManager
     solutions:
       food:
-        maxVol: 50
+        maxVol: 100
         reagents:
         - ReagentId: Flour
-          Quantity: 50
+          Quantity: 100
 
 - type: entity
   parent: [ReagentPacketBase, ItemHeftyBase]
@@ -124,9 +124,10 @@
   - type: SolutionContainerManager
     solutions:
       food:
+        maxVol: 100
         reagents:
         - ReagentId: Cornmeal
-          Quantity: 50
+          Quantity: 100
 
 - type: entity
   parent: ReagentPacketBase
@@ -155,9 +156,10 @@
   - type: SolutionContainerManager
     solutions:
       food:
+        maxVol: 100
         reagents:
         - ReagentId: Rice
-          Quantity: 50
+          Quantity: 100
 
 - type: entity
   parent: ReagentPacketBase
@@ -186,9 +188,10 @@
   - type: SolutionContainerManager
     solutions:
       food:
+        maxVol: 100
         reagents:
         - ReagentId: Sugar
-          Quantity: 50
+          Quantity: 100
 
 - type: entity
   parent: ReagentPacketBase


### PR DESCRIPTION
Makes some QoL additions and tweaks to the Chefvend inventory and also increases the amount of Flour, Cornmeal, Rice, and Sugar per bag.

<!--
This is a semi-strict format, you can add/remove sections as needed but the order/format should be kept the same
Remove these comments before submitting
-->

# Description

<!--
Explain this PR in as much detail as applicable

Some example prompts to consider:
How might this affect the game? The codebase?
What might be some alternatives to this?
How/Who does this benefit/hurt [the game/codebase]?
-->

Increases the contents of Flour, Cornmeal. Sugar, and Rice bags from 50u to 100u.
Increases the amount of Egg and Soy Milk Cartons in the Chefvend from 1 to 2.
Adds large jugs of Olive and Corn Oil to the chefvend, making them availiable outside of being mapped in.
Added one carton of cream to the Chefvend, as the Chef cannot make it without obtaining a shaker from the Bartender.
Adds two bottles of Honey, as I saw they were recently added by https://github.com/Floof-Station/Floof-Station/pull/1245 and were missing.
Adjusts the price of the Chefvend Restock Crate from 680 -> 800.

I made these changes for three main reasons.
1. To make some items accessible outside of mapping.
2. To improve the kitchen's resource management loop by ensuring some ingredients don't run out long before others.
3. To free both the botanist and chef from the large and often near impossible amount of time and space required to produce enough oil and grains for a kitchen, and allow them to both commit to producing and using a greater variety of ingredients and recipes.

---

# TODO

<!--
A list of everything you have to do before this PR is "complete"
You probably won't have to complete everything before merging but it's good to leave future references
-->

- [x] Increase amounts of Flour, Cornmeal, Rice, and Sugar per bag.
- [x] Make Chefvend addtions and tweaks
- [x] Adjust Chefvend restock price.

---

<!--
This is default collapsed, readers click to expand it and see all your media
The PR media section can get very large at times, so this is a good way to keep it clean
The title is written using HTML tags
The title must be within the <summary> tags or you won't see it
-->

<details><summary><h1>Media</h1></summary>
<p>

<img width="864" height="1983" alt="image" src="https://github.com/user-attachments/assets/928d70f8-2388-41c2-bd06-98464f385440" />
<img width="740" height="593" alt="image" src="https://github.com/user-attachments/assets/1266a0d0-767c-4169-97ff-cdbf2eaf6851" />
<img width="752" height="538" alt="image" src="https://github.com/user-attachments/assets/63b92503-0547-4a6a-9b94-42a81725df66" />
<img width="748" height="569" alt="image" src="https://github.com/user-attachments/assets/feddcc5e-426a-48bd-83dc-490e15b76481" />
<img width="745" height="575" alt="image" src="https://github.com/user-attachments/assets/a9c7f225-31db-43f4-ba0f-65c673077390" />
<img width="1475" height="64" alt="image" src="https://github.com/user-attachments/assets/eb03d73b-d06c-467f-8f06-a633337dcda8" />

</p>
</details>

---

# Changelog

<!--
You can add an author after the `:cl:` to change the name that appears in the changelog (ex: `:cl: Death`)
Leaving it blank will default to your GitHub display name
This includes all available types for the changelog
-->

:cl:
- add: Added Honey, Corn Oil, Olive Oil (Large), and Cream to the Chefvend.
- tweak: Increased Flour, Rice, Cornmeal, and Sugar per bag from 50->100
- tweak: Increased Egg Carton & Soy Milk quantities in Chefvend
- tweak: Increased Chefvend restock price from 680->800 spesos.

