### PR TITLE
Revert "Change Around some Rodentia Sounds"

### DIFF
--- a/Resources/Prototypes/DeltaV/Voice/speech_emote_sounds.yml
+++ b/Resources/Prototypes/DeltaV/Voice/speech_emote_sounds.yml
@@ -195,7 +195,7 @@
     Weh:
       collection: Weh
     Squeak:
-      path: /Audio/Animals/fox_squeak.ogg # Floof
+      path: /Audio/Animals/mouse_squeak.ogg
 
 - type: emoteSounds
   id: FemaleRodentia
@@ -225,7 +225,7 @@
     Weh:
       collection: Weh
     Squeak:
-      path: /Audio/Animals/fox_squeak.ogg # Floof
+      path: /Audio/Animals/mouse_squeak.ogg
 
 - type: emoteSounds
   id: UnisexChitinid

--- a/Resources/Prototypes/Voice/speech_sounds.yml
+++ b/Resources/Prototypes/Voice/speech_sounds.yml
@@ -37,11 +37,9 @@
 - type: speechSounds
   id: Squeak
   saySound:
-    path: /Audio/Items/Toys/mousesqueek.ogg # Floof - calmer mice
+    path: /Audio/Animals/mouse_squeak.ogg
   askSound:
-    path: /Audio/Items/Toys/mousesqueek.ogg # Floof - calmer mice
-    params: # Floof
-      pitch: 0.95 # the variation is still there but we want it to sound questioney
+    path: /Audio/Animals/mouse_squeak.ogg
   exclaimSound:
     path: /Audio/Animals/mouse_squeak.ogg
 


### PR DESCRIPTION
Reverts Floof-Station/Floof-Station#1430

<!--
This is a semi-strict format, you can add/remove sections as needed but the order/format should be kept the same
Remove these comments before submitting
-->

# Description

<!--
Explain this PR in as much detail as applicable

Some example prompts to consider:
How might this affect the game? The codebase?
What might be some alternatives to this?
How/Who does this benefit/hurt [the game/codebase]?
-->

I spend a lot of time as a Rodentia and the new sounds are not quite it.

The changed Rodentia sounds are, in my opinion, too squeaky and artificial sounding for the sounds of actual living creatures. The squeak in particular reminds me a great deal of the clown hammer, and is also high pitched enough to hurt my ears somewhat. I have had this opinion echoed to me by others, even in this short time.

I would like to return to the sounds we had before. I see the value in striving for sound variety, but find myself feeling like this PR took away more than it supplied.

---

# TODO

<!--
A list of everything you have to do before this PR is "complete"
You probably won't have to complete everything before merging but it's good to leave future references
-->

- [x] Revert Floof-Station/Floof-Station#1430


---

# Changelog

<!--
You can add an author after the `:cl:` to change the name that appears in the changelog (ex: `:cl: Death`)
Leaving it blank will default to your GitHub display name
This includes all available types for the changelog
-->

:cl:
- tweak: Changed rodentia sounds back to the original.