### PR TITLE
Cant Aim

### DIFF
--- a/Resources/Locale/en-US/_Floof/traits/traits.ftl
+++ b/Resources/Locale/en-US/_Floof/traits/traits.ftl
@@ -88,3 +88,9 @@ trait-name-TraitorTeachTarget = Marked for Death
 trait-description-TraitorTeachTarget = Someone or something wants you taught a lesson. Traitors can recieve orders to kill you.
 # Target Consent Traits: End
 
+trait-name-OniShooting = Can't Aim
+trait-description-OniShooting = Due to an innate skill issue, you can't aim at all.
+
+trait-name-BadShooting = Bad Aim
+trait-description-BadShooting = Due to an lack of training or simply a lack of skill, you can't aim very well.
+

--- a/Resources/Locale/en-US/_Floof/traits/traits.ftl
+++ b/Resources/Locale/en-US/_Floof/traits/traits.ftl
@@ -92,5 +92,5 @@ trait-name-OniShooting = Can't Aim
 trait-description-OniShooting = Due to an innate skill issue, you can't aim at all.
 
 trait-name-BadShooting = Bad Aim
-trait-description-BadShooting = Due to an lack of training or simply a lack of skill, you can't aim very well.
+trait-description-BadShooting = Due to a lack of training or simply a lack of skill or talent, you can't aim very well.
 

--- a/Resources/Prototypes/_Floof/Traits/physical.yml
+++ b/Resources/Prototypes/_Floof/Traits/physical.yml
@@ -288,3 +288,53 @@
   - !type:TraitModifySilicon
     batteryDrainModifier: -0.25 # Floof - M3739 - #1209 - Roughly 32 minutes on a medium capacity power cell.
     
+- type: trait # This just adds the Oni shooting malcus to anyone 
+  id: OniShooting
+  category: Physical
+  points: 6
+  requirements:
+    - !type:CharacterSpeciesRequirement 
+      inverted: true
+      species:
+      - Oni # already defaultly has this
+    - !type:CharacterJobRequirement
+      inverted: true
+      jobs:
+      - Borg
+      - MedicalBorg
+    - !type:CharacterTraitRequirement
+      inverted: true
+      traits:
+      - BadShooting
+  functions:
+    - !type:TraitAddComponent
+      components:
+      - type: PlayerAccuracyModifier
+        spreadMultiplier: 15
+        maxSpreadAngle: 180
+
+- type: trait
+  id: BadShooting
+  category: Physical
+  points: 2
+  slots: 0 # for flavor
+  requirements:
+    - !type:CharacterSpeciesRequirement 
+      inverted: true
+      species:
+      - Oni # already defaultly has this
+    - !type:CharacterJobRequirement
+      inverted: true
+      jobs:
+      - Borg
+      - MedicalBorg
+    - !type:CharacterTraitRequirement
+      inverted: true
+      traits:
+      - OniShooting
+  functions:
+    - !type:TraitAddComponent
+      components:
+      - type: PlayerAccuracyModifier
+        spreadMultiplier: 7.5
+        maxSpreadAngle: 90

--- a/Resources/Prototypes/_Floof/Traits/physical.yml
+++ b/Resources/Prototypes/_Floof/Traits/physical.yml
@@ -288,7 +288,7 @@
   - !type:TraitModifySilicon
     batteryDrainModifier: -0.25 # Floof - M3739 - #1209 - Roughly 32 minutes on a medium capacity power cell.
     
-- type: trait # This just adds the Oni shooting malcus to anyone 
+- type: trait # This just adds the Oni shooting malcus to anyone  
   id: OniShooting
   category: Physical
   points: 6

--- a/Resources/Prototypes/_Floof/Traits/physical.yml
+++ b/Resources/Prototypes/_Floof/Traits/physical.yml
@@ -310,8 +310,8 @@
     - !type:TraitAddComponent
       components:
       - type: PlayerAccuracyModifier
-        spreadMultiplier: 15
-        maxSpreadAngle: 180
+        spreadMultiplier: 7.5
+        maxSpreadAngle: 90
 
 - type: trait
   id: BadShooting

--- a/Resources/Prototypes/_Floof/Traits/physical.yml
+++ b/Resources/Prototypes/_Floof/Traits/physical.yml
@@ -336,5 +336,5 @@
     - !type:TraitAddComponent
       components:
       - type: PlayerAccuracyModifier
-        spreadMultiplier: 7.5
+        spreadMultiplier: 2.5
         maxSpreadAngle: 90


### PR DESCRIPTION
# Description
You ever want to shoot like an Oni? Yeah me neither.
Anyway, I've turned the Oni Shooting debuff into a trait with a tuned down one to go with it.

For the most part the second tuned down Oni shooting, is flavor for people who haven't trained to use a gun, so they can't shoot near perfectly.

[https://cdn.discordapp.com/attachments/1255992182880473269/1423225467191693333/CantAimPR.mp4?ex=68df8981&is=68de3801&hm=a00bc077d92849e09e7c03eaa515ddfd5a0453bb943f4f8cbe2a0610f32b2373&](url)


# Changelog
:cl:
- add: You ever want to shoot like an Oni? Yeah, me neither but I turned it into a trait you can take.
