### PR TITLE
Non-Native Language Update

### DIFF
--- a/Resources/Locale/en-US/_Floof/traits/categories.ftl
+++ b/Resources/Locale/en-US/_Floof/traits/categories.ftl
@@ -1,1 +1,2 @@
 trait-category-Marked = Marked
+trait-category-TraitsSpeechNatural= Natural

--- a/Resources/Locale/en-US/_Floof/traits/language-traits.ftl
+++ b/Resources/Locale/en-US/_Floof/traits/language-traits.ftl
@@ -1,17 +1,17 @@
 trait-name-FoxLanguage = {language-Fox-name}
-trait-description-FoxLanguage = {language-Fox-description} You speak it natively.
+trait-description-FoxLanguage = {language-Fox-description}
 
 trait-name-DogLanguage = {language-Dog-name}
-trait-description-DogLanguage = {language-Dog-description} You speak it natively.
+trait-description-DogLanguage = {language-Dog-description}
 
 trait-name-CatLanguage = {language-Cat-name}
-trait-description-CatLanguage = {language-Cat-description} You speak it natively.
+trait-description-CatLanguage = {language-Cat-description}
 
 trait-name-MonkeyLanguage = {language-Monkey-name}
-trait-description-MonkeyLanguage = {language-Monkey-description} You speak it natively.
+trait-description-MonkeyLanguage = {language-Monkey-description}
 
 trait-name-KoboldLanguage = {language-Kobold-name}
-trait-description-KoboldLanguage = {language-Kobold-description} You speak it natively.
+trait-description-KoboldLanguage = {language-Kobold-description}
 
 
 trait-name-Ratvarian = Ratvarian
@@ -24,21 +24,41 @@ trait-description-NaturalRatvarian =
     The language of the cult of Ratvar. Enigmatic, guttural, and difficult to pronounce.
         You speak this instead of your species's usual natural language.
 
+trait-name-Chittin = Chittin
+trait-description-Chittin =
+    A language consisting of clicks, buzzes, and some variety of harsh insect sounds.
+        Most of what makes up their speech comes from their antennae, making it a near-impossible language for those without to learn.
+        Through some adaptation, augmentation or clever workaround, you speak this.
+
 trait-name-NaturalChittin = Natural Chittin Speaker
 trait-description-NaturalChittin =
     A language consisting of clicks, buzzes, and some variety of harsh insect sounds.
         Most of what makes up their speech comes from their antennae, making it a near-impossible language for those without to learn.
         Through some adaptation, augmentation or clever workaround, you speak this instead of your species's usual natural language.
 
+trait-name-Nehina = Nehina
+trait-description-Nehina =
+    A language spoken by the Feroxi, well adapted to speaking under the waters of ocean planets.
+
 trait-name-NaturalNehina = Natural Nehina Speaker
 trait-description-NaturalNehina =
     A language spoken by the Feroxi, well adapted to speaking under the waters of ocean planets.
         Through some adaptation, augmentation or clever workaround, you speak this instead of your species's usual natural language.
 
+trait-name-Mouse = Mouse
+trait-description-Mouse =
+    A squeaky language known by the Rodentia, many other rodent based species and standard mice, it is comprised of short and sharp squeaks.
+
 trait-name-NaturalMouse = Natural Mouse Speaker
 trait-description-NaturalMouse =
     A squeaky language known by the Rodentia, many other rodent based species and standard mice, it is comprised of short and sharp squeaks.
         Through some adaptation, augmentation or clever workaround, you speak this instead of your species's usual natural language.
+
+trait-name-Canilunzt = Canilunzt
+trait-description-Canilunzt =
+    The guttural language spoken and utilized by the inhabitants of the Vazzend system,
+        composed of growls, barks, yaps, and heavy utilization of ears and tail movements. Vulpkanin speak this language with ease.
+        Through some adaptation, augmentation or clever workaround, you speak this.
 
 trait-name-NaturalCanilunzt = Natural Canilunzt Speaker
 trait-description-NaturalCanilunzt =
@@ -46,15 +66,28 @@ trait-description-NaturalCanilunzt =
         composed of growls, barks, yaps, and heavy utilization of ears and tail movements. Vulpkanin speak this language with ease.
         Through some adaptation, augmentation or clever workaround, you speak this instead of your species's usual natural language.
 
+trait-name-RobotTalk = Robot
+trait-description-RobotTalk =
+    A language consisting of harsh binary chirps, whistles, hisses, and whines. Organic tongues cannot speak it without aid from special translators.
+        Through some adaptation, augmentation or clever workaround, you speak this.
+
 trait-name-NaturalRobotTalk = Natural Robot Speaker
 trait-description-NaturalRobotTalk =
     A language consisting of harsh binary chirps, whistles, hisses, and whines. Organic tongues cannot speak it without aid from special translators.
         Through some adaptation, augmentation or clever workaround, you speak this instead of your species's usual natural language.
 
+trait-name-Arachnic = Arachnic
+trait-description-Arachnic =
+    The language of arachnids is composed of mostly clicks and hisses, it almost has a rhythmic character to it at times.
+
 trait-name-NaturalArachnic = Natural Arachnic Speaker
 trait-description-NaturalArachnic =
     The language of arachnids is composed of mostly clicks and hisses, it almost has a rhythmic character to it at times.
         Through some adaptation, augmentation or clever workaround, you speak this instead of your species's usual natural language.
+
+trait-name-RootSpeak = RootSpeak
+trait-description-RootSpeak =
+    The strange whistling-style language spoken by the Diona.
 
 trait-name-NaturalRootSpeak = Natural RootSpeak Speaker
 trait-description-NaturalRootSpeak =
@@ -73,30 +106,57 @@ trait-description-NaturalValyrianStandard =
         Its speakers are those who wish to uphold the traditions and beliefs of ancient peoples from before the colonial era.
         Through some adaptation, augmentation or clever workaround, you speak this instead of your species's usual natural language.
 
+trait-name-Moffic = Moffic
+trait-description-Moffic =
+    The language of the mothpeople, it borders on complete unintelligibility.
+
 trait-name-NaturalMoffic = Natural Moffic Speaker
 trait-description-NaturalMoffic =
     The language of the mothpeople, it borders on complete unintelligibility.
         Through some adaptation, augmentation or clever workaround, you speak this instead of your species's usual natural language.
+
+trait-name-Draconic = Sinta'Unathi
+trait-description-Draconic =
+    The language of Moghes, natively spoken by the Unathi, composed of sibilant hisses and rattles.
 
 trait-name-NaturalDraconic = Natural Sinta'Unathi Speaker
 trait-description-NaturalDraconic =
     The language of Moghes, natively spoken by the Unathi, composed of sibilant hisses and rattles.
         Through some adaptation, augmentation or clever workaround, you speak this instead of your species's usual natural language.
 
+trait-name-Bubblish = Bubblish
+trait-description-Bubblish =
+    The language of Slimes. Being a mixture of bubbling noises and pops it's very difficult to speak for humans without the use of mechanical aids.
+        Through some adaptation, augmentation or clever workaround, you speak this.
+
 trait-name-NaturalBubblish = Natural Bubblish Speaker
 trait-description-NaturalBubblish =
     The language of Slimes. Being a mixture of bubbling noises and pops it's very difficult to speak for humans without the use of mechanical aids.
         Through some adaptation, augmentation or clever workaround, you speak this instead of your species's usual natural language.
+
+trait-name-Schechi = Schechi
+trait-description-Schechi =
+    The language of Resomi, primarily featuring frontal sounds made without rounding. Fluent speakers sound quite close to birdsong.
 
 trait-name-NaturalSchechi = Natural Schechi Speaker
 trait-description-NaturalSchechi =
     The language of Resomi, primarily featuring frontal sounds made without rounding. Fluent speakers sound quite close to birdsong.
         Through some adaptation, augmentation or clever workaround, you speak this instead of your species's usual natural language.
 
+trait-name-Nekomimetic = Nekomimetic
+trait-description-Nekomimetic =
+    To the casual observer, this language is an incomprehensible mess of broken Japanese. To the Felinids and Oni, it's somehow comprehensible.
+
 trait-name-NaturalNekomimetic = Natural Nekomimetic Speaker
 trait-description-NaturalNekomimetic =
     To the casual observer, this language is an incomprehensible mess of broken Japanese. To the Felinids and Oni, it's somehow comprehensible.
         Through some adaptation, augmentation or clever workaround, you speak this instead of your species's usual natural language.
+
+trait-name-Kagebun = Kagebun
+trait-description-Kagebun =
+    An ancient language primarily used by the yōkai, originating from their supernatural roots.
+        To the uninitiated, it is a chorus of sounds ranging from eerie whispers to ritualistic chanting.
+        To those who speak it, it is a living tongue that links them to the spirit world and their ancient pacts.
 
 trait-name-NaturalKagebun = Natural Kagebun Speaker
 trait-description-NaturalKagebun =

--- a/Resources/Prototypes/Traits/categories.yml
+++ b/Resources/Prototypes/Traits/categories.yml
@@ -23,6 +23,7 @@
     - TraitsSpeechUncategorized
     - TraitsSpeechAccents
     - TraitsSpeechLanguages
+    - TraitsSpeechNatural #Floof
 
 - type: traitCategory
   id: TraitsSpeechUncategorized
@@ -32,6 +33,9 @@
 
 - type: traitCategory
   id: TraitsSpeechLanguages
+
+- type: traitCategory #Floof
+  id: TraitsSpeechNatural #Floof
 
 - type: traitCategory
   id: Visual

--- a/Resources/Prototypes/_Floof/Traits/Languages/additional-languages.yml
+++ b/Resources/Prototypes/_Floof/Traits/Languages/additional-languages.yml
@@ -63,7 +63,7 @@
   - !type:CharacterSpeciesRequirement
     species:
     - Felinid
-  #    - Tajaran # one day...
+    - Tajaran
   functions:
   - !type:TraitModifyLanguages
     languagesSpoken:

--- a/Resources/Prototypes/_Floof/Traits/Languages/natural-languages.yml
+++ b/Resources/Prototypes/_Floof/Traits/Languages/natural-languages.yml
@@ -1,7 +1,7 @@
 # Note: these languages REPLACE your species' natural language, hence they take no slots.
 - type: trait
   id: NaturalRatvarian
-  category: TraitsSpeechLanguages
+  category: TraitsSpeechNatural
   points: -1
   slots: 0
   priority: -1
@@ -20,7 +20,7 @@
 
 - type: trait
   id: NaturalChittin
-  category: TraitsSpeechLanguages
+  category: TraitsSpeechNatural
   points: -1
   slots: 0
   priority: -1
@@ -40,7 +40,7 @@
 
 - type: trait
   id: NaturalNehina
-  category: TraitsSpeechLanguages
+  category: TraitsSpeechNatural
   points: -1
   slots: 0
   priority: -1
@@ -60,7 +60,7 @@
 
 - type: trait
   id: NaturalMouse
-  category: TraitsSpeechLanguages
+  category: TraitsSpeechNatural
   points: -1
   slots: 0
   priority: -1
@@ -80,7 +80,7 @@
 
 - type: trait
   id: NaturalCanilunzt
-  category: TraitsSpeechLanguages
+  category: TraitsSpeechNatural
   points: -1
   slots: 0
   priority: -1
@@ -100,7 +100,7 @@
 
 - type: trait
   id: NaturalRobotTalk
-  category: TraitsSpeechLanguages
+  category: TraitsSpeechNatural
   points: -1
   slots: 0
   priority: -1
@@ -120,7 +120,7 @@
 
 - type: trait
   id: NaturalArachnic
-  category: TraitsSpeechLanguages
+  category: TraitsSpeechNatural
   points: -1
   slots: 0
   priority: -1
@@ -141,7 +141,7 @@
 
 - type: trait
   id: NaturalRootSpeak
-  category: TraitsSpeechLanguages
+  category: TraitsSpeechNatural
   points: -1
   slots: 0
   priority: -1
@@ -161,7 +161,7 @@
 
 - type: trait
   id: NaturalSolCommon
-  category: TraitsSpeechLanguages
+  category: TraitsSpeechNatural
   points: -1
   slots: 0
   priority: -1
@@ -181,7 +181,7 @@
 
 - type: trait
   id: NaturalValyrianStandard
-  category: TraitsSpeechLanguages
+  category: TraitsSpeechNatural
   points: -1
   slots: 0
   priority: -1
@@ -201,7 +201,7 @@
 
 - type: trait
   id: NaturalMoffic
-  category: TraitsSpeechLanguages
+  category: TraitsSpeechNatural
   points: -1
   slots: 0
   priority: -1
@@ -221,7 +221,7 @@
 
 - type: trait
   id: NaturalDraconic
-  category: TraitsSpeechLanguages
+  category: TraitsSpeechNatural
   points: -1
   slots: 0
   priority: -1
@@ -241,7 +241,7 @@
 
 - type: trait
   id: NaturalBubblish
-  category: TraitsSpeechLanguages
+  category: TraitsSpeechNatural
   points: -1
   slots: 0
   priority: -1
@@ -261,7 +261,7 @@
 
 - type: trait
   id: NaturalSchechi
-  category: TraitsSpeechLanguages
+  category: TraitsSpeechNatural
   points: -1
   slots: 0
   priority: -1
@@ -281,7 +281,7 @@
 
 - type: trait
   id: NaturalNekomimetic
-  category: TraitsSpeechLanguages
+  category: TraitsSpeechNatural
   points: -1
   slots: 0
   priority: -1
@@ -302,7 +302,7 @@
 
 - type: trait
   id: NaturalKagebun
-  category: TraitsSpeechLanguages
+  category: TraitsSpeechNatural
   points: -1
   slots: 0
   priority: -1

--- a/Resources/Prototypes/_Floof/Traits/Languages/non-natural-languages.yml
+++ b/Resources/Prototypes/_Floof/Traits/Languages/non-natural-languages.yml
@@ -38,6 +38,25 @@
       languagesUnderstood:
         - Nehina
 
+- type: trait
+  id: Mouse
+  category: TraitsSpeechLanguages
+  points: 0
+  slots: 0
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: TraitsLanguagesBasic
+    - !type:CharacterSpeciesRequirement
+      inverted: true
+      species:
+        - Rodentia
+        - Shadowkin
+  functions:
+    - !type:TraitModifyLanguages
+      languagesSpoken:
+        - Mouse
+      languagesUnderstood:
+        - Mouse
 
 - type: trait
   id: Canilunzt

--- a/Resources/Prototypes/_Floof/Traits/Languages/non-natural-languages.yml
+++ b/Resources/Prototypes/_Floof/Traits/Languages/non-natural-languages.yml
@@ -1,0 +1,222 @@
+- type: trait
+  id: Chittin
+  category: TraitsSpeechLanguages
+  points: 0
+  slots: 0
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: TraitsLanguagesBasic
+    - !type:CharacterSpeciesRequirement
+      inverted: true
+      species:
+        - Chitinid
+        - Shadowkin
+  functions:
+    - !type:TraitModifyLanguages
+      languagesSpoken:
+        - Chittin
+      languagesUnderstood:
+        - Chittin
+
+- type: trait
+  id: Nehina
+  category: TraitsSpeechLanguages
+  points: 0
+  slots: 0
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: TraitsLanguagesBasic
+    - !type:CharacterSpeciesRequirement
+      inverted: true
+      species:
+        - Feroxi
+        - Shadowkin
+  functions:
+    - !type:TraitModifyLanguages
+      languagesSpoken:
+        - Nehina
+      languagesUnderstood:
+        - Nehina
+
+
+- type: trait
+  id: Canilunzt
+  category: TraitsSpeechLanguages
+  points: 0
+  slots: 0
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: TraitsLanguagesBasic
+    - !type:CharacterSpeciesRequirement
+      inverted: true
+      species:
+        - Vulpkanin
+        - Shadowkin
+  functions:
+    - !type:TraitModifyLanguages
+      languagesSpoken:
+        - Canilunzt
+      languagesUnderstood:
+        - Canilunzt
+
+- type: trait
+  id: RobotTalk
+  category: TraitsSpeechLanguages
+  points: 0
+  slots: 0
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: TraitsLanguagesBasic
+    - !type:CharacterSpeciesRequirement
+      inverted: true
+      species:
+        - IPC
+        - Shadowkin
+  functions:
+    - !type:TraitModifyLanguages
+      languagesSpoken:
+        - RobotTalk
+      languagesUnderstood:
+        - RobotTalk
+
+- type: trait
+  id: Arachnic
+  category: TraitsSpeechLanguages
+  points: 0
+  slots: 0
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: TraitsLanguagesBasic
+    - !type:CharacterSpeciesRequirement
+      inverted: true
+      species:
+        # Arachne they dont speak Arachind
+        - Arachnid
+        - Shadowkin
+  functions:
+    - !type:TraitModifyLanguages
+      languagesSpoken:
+        - Arachnic
+      languagesUnderstood:
+        - Arachnic
+
+- type: trait
+  id: RootSpeak
+  category: TraitsSpeechLanguages
+  points: 0
+  slots: 0
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: TraitsLanguagesBasic
+    - !type:CharacterSpeciesRequirement
+      inverted: true
+      species:
+        - Diona
+        - Shadowkin
+  functions:
+    - !type:TraitModifyLanguages
+      languagesSpoken:
+        - RootSpeak
+      languagesUnderstood:
+        - RootSpeak
+
+- type: trait
+  id: Moffic
+  category: TraitsSpeechLanguages
+  points: 0
+  slots: 0
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: TraitsLanguagesBasic
+    - !type:CharacterSpeciesRequirement
+      inverted: true
+      species:
+        - Moth
+        - Shadowkin
+  functions:
+    - !type:TraitModifyLanguages
+      languagesSpoken:
+        - Moffic
+      languagesUnderstood:
+        - Moffic
+
+- type: trait
+  id: Bubblish
+  category: TraitsSpeechLanguages
+  points: 0
+  slots: 0
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: TraitsLanguagesBasic
+    - !type:CharacterSpeciesRequirement
+      inverted: true
+      species:
+        - SlimePerson
+        - Shadowkin
+  functions:
+    - !type:TraitModifyLanguages
+      languagesSpoken:
+        - Bubblish
+      languagesUnderstood:
+        - Bubblish
+
+- type: trait
+  id: Schechi
+  category: TraitsSpeechLanguages
+  points: 0
+  slots: 0
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: TraitsLanguagesBasic
+    - !type:CharacterSpeciesRequirement
+      inverted: true
+      species:
+        - Resomi
+        - Shadowkin
+  functions:
+    - !type:TraitModifyLanguages
+      languagesSpoken:
+        - Schechi
+      languagesUnderstood:
+        - Schechi
+
+- type: trait
+  id: Nekomimetic
+  category: TraitsSpeechLanguages
+  points: 0
+  slots: 0
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: TraitsLanguagesBasic
+    - !type:CharacterSpeciesRequirement
+      inverted: true
+      species:
+        - Felinid
+        - Oni
+        - Shadowkin
+  functions:
+    - !type:TraitModifyLanguages
+      languagesSpoken:
+        - Nekomimetic
+      languagesUnderstood:
+        - Nekomimetic
+
+- type: trait
+  id: Kagebun
+  category: TraitsSpeechLanguages
+  points: 0
+  slots: 0
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: TraitsLanguagesBasic
+    - !type:CharacterSpeciesRequirement
+      inverted: true
+      species:
+        - Kitsune
+        - Shadowkin
+  functions:
+    - !type:TraitModifyLanguages
+      languagesSpoken:
+        - Kagebun
+      languagesUnderstood:
+        - Kagebun


### PR DESCRIPTION
# Description

Removed the comment mark from a line to let Tajara take Felidae.

Clarified that animal languages do not replace your starting language by removing a line from their descriptions.

Added non-native language traits for:
- Arachnic
- Bubblish
- Canilunzt
- Chittin
- Sinta'Unathi
- Kagebun
- Moffic
- Mouse
- Nehina
- Nekomimetic
- Robot
- Rodentia
- RootSpeak
- Schechi

Splits the Natural Speech replacement traits into their own sub-category.

---

<details><summary><h1>Media</h1></summary>
<p>

<img width="735" height="140" alt="image" src="https://github.com/user-attachments/assets/4123e1c3-ccb7-4509-af9f-1296550a94e1" />
<img width="1049" height="184" alt="image" src="https://github.com/user-attachments/assets/da08fcb7-ffc4-4ab4-98fd-6468fc48a94e" />
<img width="491" height="402" alt="image" src="https://github.com/user-attachments/assets/83ca1709-5135-45c0-a2f0-deca0dcbfa3f" />
<img width="963" height="616" alt="image" src="https://github.com/user-attachments/assets/321ce486-32d3-48a3-8cdd-45c31f9779cb" />

</p>
</details>

---

# Changelog

:cl: sprkl
- add: More languages are now available to learn