### PR TITLE
Increased EG-4 Required Time From 3 Days to 2 Weeks

### DIFF
--- a/Resources/Prototypes/Loadouts/Jobs/Security/weapons.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Security/weapons.yml
@@ -1047,7 +1047,7 @@
     group: LoadoutSecurityWeapons
   - !type:CharacterDepartmentTimeRequirement
     department: Security
-    min: 259200 # 3 days
+    min: 1209600 # 14 days
   - !type:CharacterLogicOrRequirement
     requirements:
     - !type:CharacterDepartmentRequirement


### PR DESCRIPTION
# Description
Apparently the EG-4 has been problematic as every security officer has just been taking it, even tho really it's supposed to be a nice reward unlocked through long service. Which then asks the question, do our security simply play 12 hours everyday as security like a real ass job or is that just edge cases.

Anyway this PR changes the required hours to take an EG-4 from 72 hours to 336 hours or 2 weeks. If the EG-4 is still a problem, I'm going pump it to a month.

# Changelog
:cl:
- tweak: Increased the hours required to take an EG-4