### PR TITLE
Sec Energy Revolver Removal

### DIFF
--- a/Resources/Prototypes/CharacterItemGroups/Jobs/Security/uncategorized.yml
+++ b/Resources/Prototypes/CharacterItemGroups/Jobs/Security/uncategorized.yml
@@ -137,7 +137,7 @@
       id: LoadoutSecurityDisablerSMG
     - type: loadout # Floofstation - Wardens need a little love
       id: LoadoutSecurityWeaponEnergyShotgun
-    - type: loadout
+    - type: loadout # Floofstation - BSO Energy Revolver
       id: LoadoutSecurityEnergyRevolver
 
 - type: characterItemGroup

--- a/Resources/Prototypes/CharacterItemGroups/Jobs/Security/uncategorized.yml
+++ b/Resources/Prototypes/CharacterItemGroups/Jobs/Security/uncategorized.yml
@@ -137,6 +137,8 @@
       id: LoadoutSecurityDisablerSMG
     - type: loadout # Floofstation - Wardens need a little love
       id: LoadoutSecurityWeaponEnergyShotgun
+    - type: loadout
+      id: LoadoutSecurityEnergyRevolver
 
 - type: characterItemGroup
   id: LoadoutSecurityEyes

--- a/Resources/Prototypes/Loadouts/Jobs/Security/weapons.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Security/weapons.yml
@@ -1045,7 +1045,7 @@
   requirements:
   - !type:CharacterItemGroupRequirement
     group: LoadoutSecurityWeapons
-  # - !type:CharacterDepartmentTimeRequirement
+  # - !type:CharacterDepartmentTimeRequirement # Floofstation - Remove Energy Revolver from Security's Loadouts
   #   department: Security
   #   min: 259200 # 3 days
   # - !type:CharacterLogicOrRequirement

--- a/Resources/Prototypes/Loadouts/Jobs/Security/weapons.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Security/weapons.yml
@@ -1045,17 +1045,17 @@
   requirements:
   - !type:CharacterItemGroupRequirement
     group: LoadoutSecurityWeapons
-  - !type:CharacterDepartmentTimeRequirement
-    department: Security
-    min: 259200 # 3 days
-  - !type:CharacterLogicOrRequirement
-    requirements:
-    - !type:CharacterDepartmentRequirement
-      departments:
-      - Security
-    - !type:CharacterJobRequirement
-      jobs:
-      - BlueshieldOfficer
+  # - !type:CharacterDepartmentTimeRequirement
+  #   department: Security
+  #   min: 259200 # 3 days
+  # - !type:CharacterLogicOrRequirement
+  #   requirements:
+  #   - !type:CharacterDepartmentRequirement
+  #     departments:
+  #     - Security
+  - !type:CharacterJobRequirement
+    jobs:
+    - BlueshieldOfficer
   items:
   - WeaponEnergyRevolverSecurity
 


### PR DESCRIPTION
# Description

This PR removes Security's ability to take the Energy Revolver. It also fixes the LoadoutSecurityWeapons for the Energy Revolver for BSO.

---

<details><summary><h1>Security</h1></summary>
<p>

<img width="1569" height="767" alt="Security" src="https://github.com/user-attachments/assets/1cabd64b-2417-4069-9ac4-2528a2e75009" />

</p>
</details>

<details><summary><h1>Blueshield</h1></summary>
<p>

<img width="1575" height="781" alt="BlueShield" src="https://github.com/user-attachments/assets/809c9f23-f56c-4ae9-92ec-8c80a50ee5a6" />

</p>
</details>

---

# Changelog

:cl:
- remove: Removed Energy Revolver from Security's Loadout