### PR TITLE
Language - Onis

### DIFF
--- a/Resources/Locale/en-US/language/languages.ftl
+++ b/Resources/Locale/en-US/language/languages.ftl
@@ -8,7 +8,7 @@ language-RootSpeak-name = Rootspeak
 language-RootSpeak-description = The strange whistling-style language spoken by the Diona.
 
 language-Nekomimetic-name = Nekomimetic
-language-Nekomimetic-description = To the casual observer, this language is an incomprehensible mess of broken Japanese. To the Felinids and Oni, it's somehow comprehensible.
+language-Nekomimetic-description = To the casual observer, this language is an incomprehensible mess of broken Japanese. To the Felinids, Oni and Kitsune, it's somehow comprehensible.
 
 language-Draconic-name = Sinta'Unathi
 language-Draconic-description =

--- a/Resources/Prototypes/DeltaV/Entities/Mobs/Species/kitsune.yml
+++ b/Resources/Prototypes/DeltaV/Entities/Mobs/Species/kitsune.yml
@@ -57,6 +57,7 @@
     understands:
       - TauCetiBasic
       - Kagebun
+      - Nekomimetic
     naturalLanguage: Kagebun # Floof - M3739 - #937 - Shadow Sentence
   - type: Tag
     tags:

--- a/Resources/Prototypes/Nyanotrasen/Entities/Mobs/Species/Oni.yml
+++ b/Resources/Prototypes/Nyanotrasen/Entities/Mobs/Species/Oni.yml
@@ -48,11 +48,11 @@
   - type: LanguageKnowledge
     speaks:
     - TauCetiBasic
-    - Nekomimetic
+    - Kagebun
     understands:
     - TauCetiBasic
-    - Nekomimetic
-    naturalLanguage: Nekomimetic # Floof: explicitly stated natural languages
+    - Kagebun
+    naturalLanguage: Kagebun # Floof: explicitly stated natural languages
   - type: PotentiaModifier
     potentiaMultiplier: 0.5
 

--- a/Resources/Prototypes/Nyanotrasen/Entities/Mobs/Species/Oni.yml
+++ b/Resources/Prototypes/Nyanotrasen/Entities/Mobs/Species/Oni.yml
@@ -52,6 +52,7 @@
     understands:
     - TauCetiBasic
     - Kagebun
+    - Nekomimetic
     naturalLanguage: Kagebun # Floof: explicitly stated natural languages
   - type: PotentiaModifier
     potentiaMultiplier: 0.5

--- a/Resources/Prototypes/Nyanotrasen/Entities/Mobs/Species/felinid.yml
+++ b/Resources/Prototypes/Nyanotrasen/Entities/Mobs/Species/felinid.yml
@@ -67,11 +67,15 @@
   - type: LanguageKnowledge
     speaks:
     - TauCetiBasic
+    - SolCommon
     - Nekomimetic
     understands:
     - TauCetiBasic
+    - SolCommon
     - Nekomimetic
-    naturalLanguage: Nekomimetic # Floof: explicitly stated natural languages
+    naturalLanguage: 
+    - SolCommon # Floof: explicitly stated natural languages
+    - Nekomimetic
 #  - type: Thieving | Floof - M3739 - #1194 - Removed due to balancing and SoP concerns
 #    ignoreStripHidden: true
 #    stealth: Subtle

--- a/Resources/Prototypes/Nyanotrasen/Entities/Mobs/Species/felinid.yml
+++ b/Resources/Prototypes/Nyanotrasen/Entities/Mobs/Species/felinid.yml
@@ -73,9 +73,7 @@
     - TauCetiBasic
     - SolCommon
     - Nekomimetic
-    naturalLanguage: 
-    - SolCommon # Floof: explicitly stated natural languages
-    - Nekomimetic
+    naturalLanguage: SolCommon # Floof: explicitly stated natural languages
 #  - type: Thieving | Floof - M3739 - #1194 - Removed due to balancing and SoP concerns
 #    ignoreStripHidden: true
 #    stealth: Subtle

--- a/Resources/Prototypes/Traits/languages.yml
+++ b/Resources/Prototypes/Traits/languages.yml
@@ -25,6 +25,7 @@
       inverted: true
       species:
         - Human
+        - Felinid
   functions:
     - !type:TraitModifyLanguages
       languagesSpoken:

--- a/Resources/Prototypes/_Floof/Traits/Languages/natural-languages.yml
+++ b/Resources/Prototypes/_Floof/Traits/Languages/natural-languages.yml
@@ -173,6 +173,7 @@
       species:
         - Human
         - Shadowkin
+        - Felinid
   functions:
     - !type:TraitAddComponent
       components:
@@ -292,7 +293,6 @@
       inverted: true
       species:
         - Felinid
-        - Oni
         - Shadowkin
   functions:
     - !type:TraitAddComponent
@@ -313,6 +313,7 @@
       inverted: true
       species:
         - Kitsune
+        - Oni
         - Shadowkin
   functions:
     - !type:TraitAddComponent


### PR DESCRIPTION
# Description
So, we're changing Oni to speak Kagebun (Lore Reason)
And Felinids which are just Humans to speak Sol Common.

I've done something interesting here where, Felinids can still speak Nekomimetic, which is their weird weeb japanese. But Onis and Kitsune also understand it but can't speak it since it's a bastardized Kagebun. The same way a tourist speaks your native language but really awfully, and you understand them but you don't want to stoop to their level.

# Changelog
:cl:
- tweak: Onis to speak Kagebun and Felinids to speak Sol Common.
