### PR TITLE
Re-Adding Xenoglossy Trait

### DIFF
--- a/Resources/Prototypes/Traits/mental.yml
+++ b/Resources/Prototypes/Traits/mental.yml
@@ -319,7 +319,7 @@
 - type: trait
   id: XenoglossyPower
   category: Mental
-  points: -12
+  points: -8
   requirements:
     - !type:CharacterLogicOrRequirement
       requirements:

--- a/Resources/Prototypes/Traits/mental.yml
+++ b/Resources/Prototypes/Traits/mental.yml
@@ -316,41 +316,39 @@
       psionicPowers:
         - MetapsionicPower
 
-# Floof - this is an extreme invasion of privacy and is basically a way to opt out from languages.
-# As such, this is commented out for now.
-#- type: trait
-#  id: XenoglossyPower
-#  category: Mental
-#  points: -12
-#  requirements:
-#    - !type:CharacterLogicOrRequirement
-#      requirements:
-#        - !type:CharacterTraitRequirement
-#          traits:
-#            - LatentPsychic
-#            - NaturalTelepath
-#        - !type:CharacterJobRequirement
-#          jobs:
-#            - Chaplain
-#            - ResearchDirector
-#            - ForensicMantis
-#    - !type:CharacterLogicOrRequirement
-#      requirements:
-#        - !type:CharacterSpeciesRequirement
-#          inverted: true
-#          species:
-#            - IPC
-#        - !type:CharacterTraitRequirement
-#          traits:
-#            - AnomalousPositronics
-#    - !type:CharacterJobRequirement
-#      inverted: true
-#      jobs:
-#        - Librarian
-#  functions:
-#    - !type:TraitAddPsionics
-#      psionicPowers:
-#        - XenoglossyPower
+- type: trait
+  id: XenoglossyPower
+  category: Mental
+  points: -12
+  requirements:
+    - !type:CharacterLogicOrRequirement
+      requirements:
+        - !type:CharacterTraitRequirement
+          traits:
+            - LatentPsychic
+            - NaturalTelepath
+        - !type:CharacterJobRequirement
+          jobs:
+            - Chaplain
+            - ResearchDirector
+            - ForensicMantis
+    - !type:CharacterLogicOrRequirement
+      requirements:
+        - !type:CharacterSpeciesRequirement
+          inverted: true
+          species:
+            - IPC
+        - !type:CharacterTraitRequirement
+          traits:
+            - AnomalousPositronics
+    - !type:CharacterJobRequirement
+      inverted: true
+      jobs:
+        - Librarian
+  functions:
+    - !type:TraitAddPsionics
+      psionicPowers:
+        - XenoglossyPower
 
 - type: trait
   id: PsychognomyPower


### PR DESCRIPTION
<!--
This is a semi-strict format, you can add/remove sections as needed but the order/format should be kept the same
Remove these comments before submitting
-->

# Description

<!--
Explain this PR in as much detail as applicable

Some example prompts to consider:
How might this affect the game? The codebase?
What might be some alternatives to this?
How/Who does this benefit/hurt [the game/codebase]?
-->

This adds the Xenoglossy trait back as an available trait to Floof. This trait allows you to hear all languages, and you also can speak in a way that is understood by all. 

The reason why this was commented out before are overshadowed in a few ways: 

- First of all, the privacy issue. With the addition of NanoChat, privacy for speaking is easily obtained, and you can also just whisper. Privacy as an excuse to remove the trait is a poor excuse as if you're speaking aloud, anyone that is the same species can possibly understand you anyhow, so saying that people with xenoglossy understanding all languages is privacy-breaking is a poor argument if you're speaking out loud enough in the first place. With NanoChat added, this reason is more mitigated as privacy for speaking to others is much more easily accessible.
- Second, the opting out of the language mechanic. Yes, this does happen if you were to take the language, but I think this offers some RP benefits as well. There is the obvious of being a translator between all groups, which offers a lot of opportunities for xenoglossy'ed individuals. More importantly is consistent characters, having characters who commonly are cataloguers/librarians to keep their xenoglossy as jobs outside of that makes those characters feel more consistent if their character revolves around that job, rather than just only having it when they are in the job in the first place.
- Third, that people can just choose this trait over taking multiple languages if that PR is pulled. While yes, this is true on trait cost alone, the issue is that first, you have to take psionic traits in general to start getting xenoglossy while you can directly take languages without needing psionics, and even so, the downside of this over picking languages directly is that you cannot speak the language directly, so taking the language trait would have that overall benefit both mechanically but mainly RP wise.

In regards to balance, I am willing to move around the trait cost, although going higher than 10 does break the trait. I do think it sits well at 8 since it's just language that it mitigates, which does some some gameplay advantages as communication is incredibly important, so having a high value is normal, but with how little it may come up, I say 8 is a good place to leave it. This is open for discussion, though.

---

# TODO

<!--
A list of everything you have to do before this PR is "complete"
You probably won't have to complete everything before merging but it's good to leave future references
-->

- [X] Uncommented Xenoglossy
- [X] Checked that it works
---

<!--
This is default collapsed, readers click to expand it and see all your media
The PR media section can get very large at times, so this is a good way to keep it clean
The title is written using HTML tags
The title must be within the <summary> tags or you won't see it
-->

<details><summary><h1>Media</h1></summary>
<p>

<img width="218" height="66" alt="Image Showing Xenoglossy Trait" src="https://github.com/user-attachments/assets/e14012cd-c735-46fb-823a-1dd8d6400313" />


</p>
</details>

---

# Changelog

<!--
You can add an author after the `:cl:` to change the name that appears in the changelog (ex: `:cl: Death`)
Leaving it blank will default to your GitHub display name
This includes all available types for the changelog
-->

:cl:
- add: Re-Added Xenoglossy as a Trait
