### PR TITLE
Prestige Items - Musician/Janitor

### DIFF
--- a/Resources/Prototypes/CharacterItemGroups/Jobs/Service/janitor.yml
+++ b/Resources/Prototypes/CharacterItemGroups/Jobs/Service/janitor.yml
@@ -35,6 +35,12 @@
       id: LoadoutJanitorEquipmentHoloprojector
     - type: loadout
       id: LoadoutJanitorEquipmentPlunger
+    - type: loadout
+      id: LoadoutJanitorEquipmentAdvMopItem
+    - type: loadout
+      id: LoadoutJanitorEquipmentMegaSprayBottle
+    - type: loadout
+      id: LoadoutJanitorWeaponLauncherCleanade
 # Floof section end
 
 #- type: characterItemGroup

--- a/Resources/Prototypes/CharacterItemGroups/Jobs/Service/musician.yml
+++ b/Resources/Prototypes/CharacterItemGroups/Jobs/Service/musician.yml
@@ -32,6 +32,8 @@
       id: LoadoutItemSeashellInstrumentMusician
     - type: loadout
       id: LoadoutItemBirdToyInstrumentMusician
+    - type: loadout
+      id: LoadoutItemDawInstrumentMusician
   # Percussion
     - type: loadout
       id: LoadoutItemGlockenspielInstrumentMusician

--- a/Resources/Prototypes/_Floof/Entities/Objects/Devices/flatpack.yml
+++ b/Resources/Prototypes/_Floof/Entities/Objects/Devices/flatpack.yml
@@ -28,6 +28,15 @@
       entity: DrumkitInstrument
 
 - type: entity
+  parent: InstrumentFlatpack
+  id: DawFlatpack
+  name: digital audio workstation flatpack
+  description: A flatpack used for constructing a digital audio workstation.
+  components:
+    - type: Flatpack
+      entity: DawInstrument
+
+- type: entity
   parent: BaseFlatpack
   id: TinyFanFlatpack
   name: tiny fan flatpack

--- a/Resources/Prototypes/_Floof/Loadouts/Jobs/Service/janitor.yml
+++ b/Resources/Prototypes/_Floof/Loadouts/Jobs/Service/janitor.yml
@@ -31,6 +31,55 @@
         - Janitor
 
 - type: loadout
+  id: LoadoutJanitorEquipmentAdvMopItem
+  category: JobsServiceJanitor
+  cost: 2
+  items:
+    - AdvMopItem
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: LoadoutJanitorEquipment
+    - !type:CharacterJobRequirement
+      jobs:
+        - Janitor
+    - !type:CharacterPlaytimeRequirement
+      tracker: JobJanitor
+      min: 180000 # 50 hours
+
+- type: loadout
+  id: LoadoutJanitorEquipmentMegaSprayBottle
+  category: JobsServiceJanitor
+  cost: 1
+  items:
+    - MegaSprayBottle
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: LoadoutJanitorEquipment
+    - !type:CharacterJobRequirement
+      jobs:
+        - Janitor
+    - !type:CharacterPlaytimeRequirement
+      tracker: JobJanitor
+      min: 180000 # 50 hours
+
+- type: loadout
+  id: LoadoutJanitorWeaponLauncherCleanade
+  category: JobsServiceJanitor
+  cost: 3
+  items:
+    - WeaponLauncherCleanade
+    - BoxCleanerGrenades
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: LoadoutJanitorEquipment
+    - !type:CharacterJobRequirement
+      jobs:
+        - Janitor
+    - !type:CharacterPlaytimeRequirement
+      tracker: JobJanitor
+      min: 360000  # 100 hours
+
+- type: loadout
   id: LoadoutJanitorEquipmentBoxMousetrap
   category: JobsServiceJanitor
   cost: 0

--- a/Resources/Prototypes/_Floof/Loadouts/Jobs/Service/musician.yml
+++ b/Resources/Prototypes/_Floof/Loadouts/Jobs/Service/musician.yml
@@ -90,7 +90,7 @@
     - DrumKitFlatpack
 
 - type: loadout
-  id: LoadoutItemDrumKitInstrumentMusician
+  id: LoadoutItemDawInstrumentMusician
   category: JobsServiceMusician
   cost: 4
   requirements:

--- a/Resources/Prototypes/_Floof/Loadouts/Jobs/Service/musician.yml
+++ b/Resources/Prototypes/_Floof/Loadouts/Jobs/Service/musician.yml
@@ -65,11 +65,21 @@
 
 # Instrument Flatpacks
 
+- type: loadout # Multitool to open your flatpacks
+  id: LoadoutMusicianFlatpackOpener
+  category: JobsServiceMusician
+  cost: 0
+  requirements:
+  - !type:CharacterJobRequirement
+    jobs:
+    - Musician
+  items:
+    - Multitool
+
 - type: loadout
   id: LoadoutItemDrumKitInstrumentMusician
   category: JobsServiceMusician
   cost: 2 # Is essentially multiple percussion instruments in one.
-  canBeHeirloom: true
   requirements:
     - !type:CharacterItemGroupRequirement
       group: LoadoutMusicianEquipment
@@ -78,3 +88,19 @@
         - Musician
   items:
     - DrumKitFlatpack
+
+- type: loadout
+  id: LoadoutItemDrumKitInstrumentMusician
+  category: JobsServiceMusician
+  cost: 4
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: LoadoutMusicianEquipment
+    - !type:CharacterJobRequirement
+      jobs:
+        - Musician
+    - !type:CharacterPlaytimeRequirement
+     tracker: JobMusician
+     min: 360000 # 100 hours
+  items:
+    - DawFlatpack


### PR DESCRIPTION
# Description
Adds long service rewards for Musician and Janitor.
Adds a Multitool for Musician Loadout.

(The cleanade launcher is the non-recharging one.)

# Changelog
:cl:
- add: Added Prestige items for Musicians and Janitors
