### PR TITLE
Fix the Mini Grav Gen Lathe Recipe

### DIFF
--- a/Resources/Prototypes/Recipes/Lathes/electronics.yml
+++ b/Resources/Prototypes/Recipes/Lathes/electronics.yml
@@ -572,6 +572,7 @@
 - type: latheRecipe
   parent: BaseGoldCircuitboardRecipe
   id: MiniGravityGeneratorCircuitboard
+  result: MiniGravityGeneratorCircuitboard
 
 - type: latheRecipe
   parent: BaseCircuitboardRecipe


### PR DESCRIPTION
# Description
The `result` field was missing. Huh?

# Changelog
:cl:
- fix: The mini-gravity generator circuitboard can once again be printed correctly.
