### PR TITLE
Fix/Improve the Unobstructed Con

### DIFF
--- a/Resources/Prototypes/NPCs/utility_queries.yml
+++ b/Resources/Prototypes/NPCs/utility_queries.yml
@@ -161,7 +161,7 @@
     - !type:TargetUnobstructedCon # Floofstation
       curve: !type:QuadraticCurve # y = x, the con returns a score value which doesn't need to be adjusted
         slope: 1
-        exponent: 0
+        exponent: 1
 
 - type: utilityQuery
   id: NearbyGunTargets

--- a/Resources/Prototypes/NPCs/utility_queries.yml
+++ b/Resources/Prototypes/NPCs/utility_queries.yml
@@ -159,7 +159,9 @@
     - !type:TargetInLOSOrCurrentCon
       curve: !type:BoolCurve
     - !type:TargetUnobstructedCon # Floofstation
-      curve: !type:BoolCurve
+      curve: !type:QuadraticCurve # y = x, the con returns a score value which doesn't need to be adjusted
+        slope: 1
+        exponent: 0
 
 - type: utilityQuery
   id: NearbyGunTargets


### PR DESCRIPTION
# Description
I forgot to check if the considered entity can actually collide with the cleanbot. Buh.
Now the consideration also returns a score which indicates how "bad" of an obstruction it is, so unobstructed entities (e.g. on the floor) should be prioritized over obstructed ones (e.g. under an airlock)

<details><summary><h1>Media</h1></summary>
<p>


https://github.com/user-attachments/assets/13722b81-e59d-4441-ac81-db8efa74caa3



</p>
</details>

# Changelog
:cl:
- fix: Cleanbots will now prioritize unobstructed entities over obstructed ones, instead of outright ignoring the latter.
