### PR TITLE
Fix Some Shadekin Markings Not Being Colorable.

### DIFF
--- a/Resources/Prototypes/_Floof/Species/shadowkin.yml
+++ b/Resources/Prototypes/_Floof/Species/shadowkin.yml
@@ -26,10 +26,12 @@
     TailBehind: MobHumanoidAnyMarking
     TailOversuit: MobHumanoidAnyMarking
     Head: MobShadowkinHead
-    Snout: MobShadowkinAnyMarkingFollowSkin
-    HeadTop: MobShadowkinAnyMarkingFollowSkin
-    HeadSide: MobShadowkinAnyMarkingFollowSkin
-    Tail: MobShadowkinAnyMarkingFollowSkin
+    # Begin Floof - M3739 - Was originally 'MobShadowkinAnyMarkingFollowSkin'. Changed to allow for proper marking customization.
+    Snout: MobShadowkinAnyMarking
+    HeadTop: MobShadowkinAnyMarking
+    HeadSide: MobShadowkinAnyMarking
+    Tail: MobShadowkinAnyMarking
+    # End Floof - M3739
     Chest: MobShadowkinTorso
     Underwear: MobHumanoidAnyMarking # Floof, add underwear
     Undershirt: MobHumanoidAnyMarking # Floof, add underwear


### PR DESCRIPTION
<!--
This is a semi-strict format, you can add/remove sections as needed but the order/format should be kept the same
Remove these comments before submitting
-->

# Description

<!--
Explain this PR in as much detail as applicable

Some example prompts to consider:
How might this affect the game? The codebase?
What might be some alternatives to this?
How/Who does this benefit/hurt [the game/codebase]?
-->

This PR aims to address a bug with shadekin markings. More specifically, the `HeadTop` and `Tail` markings not being able to be colored properly.

At first glance, it would seem that the intention of #995 in terms of markings was to make the base layer of a marking match the skin color of the shadekin at all times. While it looked good on paper, in practice, it didn't translate to that due to how the code currently handles the `markingsMatchSkin` boolean value of `humanoidBaseSprite`: when it is set to `true`, it applies the skin color to <ins>everything</ins>. And does so in a manner that affects all the layers of a sprite. This can be observed in the [relevant logic](https://github.com/Floof-Station/Floof-Station/blob/2bfde0f26b1cd422e10b8a838c2b13ebce656e16/Content.Client/Humanoid/MarkingPicker.xaml.cs#L507-L528) found in `MarkingPicker.xaml.cs`:

```c#
        if (!_markingManager.MustMatchSkin(_currentSpecies, marking.BodyPart, out var _, _prototypeManager))
        {
            // Do default coloring
            var colors = MarkingColoring.GetMarkingLayerColors(
                marking,
                CurrentSkinColor,
                CurrentEyeColor,
                markingSet
            );
            for (var i = 0; i < colors.Count; i++)
            {
                markingObject.SetColor(i, colors[i]);
            }
        }
        else
        {
            // Color everything in skin color
            for (var i = 0; i < marking.Sprites.Count; i++)
            {
                markingObject.SetColor(i, CurrentSkinColor);
            }
        }
```
As a result, to address this bug, I leveraged the regular `AnyMarking` prototype originating from #1028 to rectify this issue in a timely and least invasive manner. `HeadSide` and `Snout` were given the same treatment in order to future-proof for any possible developments that would leverage those.

Maybe someday, the logic can be improved to where we can be selective about what layers match the skin at all times, but that kind of work is out of my league at the moment.

Note that a handful of markings remain unaffected by this, but were left as is to preserve the inferred design intentions from #995.

---

<!--
This is default collapsed, readers click to expand it and see all your media
The PR media section can get very large at times, so this is a good way to keep it clean
The title is written using HTML tags
The title must be within the <summary> tags or you won't see it
-->

<details><summary><h1>Media</h1></summary>
<p>

<img width="227" height="239" alt="image" src="https://github.com/user-attachments/assets/110decfe-d618-42a5-bf29-19f3856a046c" /> 
<img width="230" height="236" alt="image" src="https://github.com/user-attachments/assets/24e14697-d3d2-45bf-9785-7311b5541572" />
<img width="233" height="234" alt="image" src="https://github.com/user-attachments/assets/49aa5f53-cdbc-4c57-840f-221545b129a7" />
<img width="229" height="232" alt="image" src="https://github.com/user-attachments/assets/4732c96c-5051-4d59-97ee-7aa0d8896a4e" />

*Test shadekin with markings. Note the ears and tails.*

</p>
</details>

---

# Changelog

<!--
You can add an author after the `:cl:` to change the name that appears in the changelog (ex: `:cl: Death`)
Leaving it blank will default to your GitHub display name
This includes all available types for the changelog
-->

:cl:
- fix: Shadekin markings that were intended to be colored, can now be actually colored.
