### PR TITLE
Allow Binding Verb Invocation to Keys

### DIFF
--- a/Content.Client/_Floof/Commands/ExpandCommand.cs
+++ b/Content.Client/_Floof/Commands/ExpandCommand.cs
@@ -1,0 +1,68 @@
+using Content.Client.ContextMenu.UI;
+using Content.Client.Gameplay;
+using Content.Client.Viewport;
+using Content.Shared.Administration;
+using Robust.Client.Input;
+using Robust.Client.State;
+using Robust.Client.UserInterface;
+using Robust.Client.UserInterface.CustomControls;
+using Robust.Shared.Console;
+
+namespace Content.Client._Floof.Commands;
+
+[AnyCommand]
+internal sealed class ExpandCommand : LocalizedCommands
+{
+    private const string Hovered = "$HOVERED";
+
+    public override string Command => "expand";
+
+    public override string Help => LocalizationManager.GetString($"cmd-{Command}-help", ("command", Command));
+
+    public override void Execute(IConsoleShell shell, string argStr, string[] args)
+    {
+        // Not sure which, but if we use these as dependencies we get a cycle,
+        // so let's just resolve all of them at execution time.
+        var inputManager = IoCManager.Resolve<IInputManager>();
+        var uiManager = IoCManager.Resolve<IUserInterfaceManager>();
+        var stateManager = IoCManager.Resolve<IStateManager>();
+        var entityManager = IoCManager.Resolve<IEntityManager>();
+
+        if (args.Length < 2)
+        {
+            shell.WriteError(Loc.GetString("cmd-invalid-arg-number-error"));
+            return;
+        }
+
+        argStr = argStr.Remove(0, Command.Length + 1);
+
+        if (argStr.Contains(Hovered))
+        {
+            if (stateManager.CurrentState is not GameplayStateBase screen)
+                return;
+
+            EntityUid? hoveredEntity = null;
+            if (uiManager.CurrentlyHovered is IViewportControl vp
+                && inputManager.MouseScreenPosition.IsValid)
+            {
+                var mousePosWorld = vp.PixelToMap(inputManager.MouseScreenPosition.Position);
+                if (vp is ScalingViewport svp)
+                    hoveredEntity = screen.GetClickedEntity(mousePosWorld, svp.Eye);
+                else
+                    hoveredEntity = screen.GetClickedEntity(mousePosWorld);
+            }
+            else if (uiManager.CurrentlyHovered is EntityMenuElement element)
+                hoveredEntity = element.Entity;
+
+            if (entityManager.GetNetEntity(hoveredEntity) is not {} netEntity)
+            {
+                shell.WriteLine(Loc.GetString($"cmd-{Command}-error-no-value", ("variable", Hovered)));
+                return;
+            }
+
+            argStr = argStr.Replace(Hovered, netEntity.Id.ToString());
+        }
+
+        shell.ExecuteCommand(argStr);
+    }
+}

--- a/Content.Server/Verbs/Commands/InvokeVerbCommand.cs
+++ b/Content.Server/Verbs/Commands/InvokeVerbCommand.cs
@@ -1,15 +1,17 @@
 using System.Linq;
-using Content.Server.Administration;
+using Content.Server.Administration.Managers;
 using Content.Shared.Administration;
 using Content.Shared.Verbs;
 using Robust.Shared.Console;
 
 namespace Content.Server.Verbs.Commands
 {
-    [AdminCommand(AdminFlags.Admin)]
+    // Floof: allow `invokeverb self` as any user.
+    [AnyCommand]
     public sealed class InvokeVerbCommand : IConsoleCommand
     {
         [Dependency] private readonly IEntityManager _entManager = default!;
+        [Dependency] private readonly IAdminManager _adminManager = default!; // Floof
 
         public string Command => "invokeverb";
         public string Description => Loc.GetString("invoke-verb-command-description");
@@ -41,6 +43,13 @@ namespace Content.Server.Verbs.Commands
             }
             else
             {
+                // Floof: allow `invokeverb self` as any user.
+                if (shell.Player is not null && (_adminManager.GetAdminData(shell.Player)?.Flags & AdminFlags.Admin) != AdminFlags.Admin)
+                {
+                    shell.WriteError(Loc.GetString("invoke-verb-command-no-perms"));
+                    return;
+                }
+
                 _entManager.TryGetEntity(new NetEntity(intPlayerUid), out playerEntity);
             }
 

--- a/Content.Server/Verbs/Commands/ListVerbsCommand.cs
+++ b/Content.Server/Verbs/Commands/ListVerbsCommand.cs
@@ -1,14 +1,16 @@
-using Content.Server.Administration;
+using Content.Server.Administration.Managers;
 using Content.Shared.Administration;
 using Content.Shared.Verbs;
 using Robust.Shared.Console;
 
 namespace Content.Server.Verbs.Commands
 {
-    [AdminCommand(AdminFlags.Admin)]
+    // Floof: allow `invokeverb self` as any user.
+    [AnyCommand]
     public sealed class ListVerbsCommand : IConsoleCommand
     {
         [Dependency] private readonly IEntityManager _entManager = default!;
+        [Dependency] private readonly IAdminManager _adminManager = default!; // Floof
 
         public string Command => "listverbs";
         public string Description => Loc.GetString("list-verbs-command-description");
@@ -41,6 +43,13 @@ namespace Content.Server.Verbs.Commands
             }
             else
             {
+                // Floof: allow `listverb self` as any user.
+                if (shell.Player is not null && (_adminManager.GetAdminData(shell.Player)?.Flags & AdminFlags.Admin) != AdminFlags.Admin)
+                {
+                    shell.WriteError(Loc.GetString("invoke-verb-command-no-perms"));
+                    return;
+                }
+
                 _entManager.TryGetEntity(new NetEntity(intPlayerUid), out playerEntity);
             }
 

--- a/Content.Server/Verbs/Commands/ListVerbsCommand.cs
+++ b/Content.Server/Verbs/Commands/ListVerbsCommand.cs
@@ -46,7 +46,7 @@ namespace Content.Server.Verbs.Commands
                 // Floof: allow `listverb self` as any user.
                 if (shell.Player is not null && (_adminManager.GetAdminData(shell.Player)?.Flags & AdminFlags.Admin) != AdminFlags.Admin)
                 {
-                    shell.WriteError(Loc.GetString("invoke-verb-command-no-perms"));
+                    shell.WriteError(Loc.GetString("list-verbs-command-no-perms"));
                     return;
                 }
 

--- a/Resources/Locale/en-US/_Floof/commands/expand-command.ftl
+++ b/Resources/Locale/en-US/_Floof/commands/expand-command.ftl
@@ -1,0 +1,6 @@
+cmd-expand-desc = Executes a command while expanding variables inline.
+cmd-expand-help =
+    Usage: {$command} <command> args...
+    Supported variables:
+        $HOVERED - NetEntityID of currently hovered entity
+cmd-expand-error-no-value = Failed to expand command: no value for {$variable}.

--- a/Resources/Locale/en-US/verbs/invoke-verb-command.ftl
+++ b/Resources/Locale/en-US/verbs/invoke-verb-command.ftl
@@ -9,6 +9,9 @@ invoke-verb-command-invalid-args = invokeverb takes 2 arguments.
 invoke-verb-command-invalid-player-uid = Player uid could not be parsed, or "self" was not passed.
 invoke-verb-command-invalid-target-uid = Target uid could not be parsed.
 
+# Floof: allow `invokeverb self` as normal player.
+invoke-verb-command-no-perms = Must be admin to invoke verbs as UID other than "self".
+
 invoke-verb-command-invalid-player-entity = Player uid given does not correspond to a valid entity.
 invoke-verb-command-invalid-target-entity = Target uid given does not correspond to a valid entity.
 

--- a/Resources/Locale/en-US/verbs/list-verbs-command.ftl
+++ b/Resources/Locale/en-US/verbs/list-verbs-command.ftl
@@ -10,7 +10,7 @@ list-verbs-command-invalid-player-uid = Player uid could not be parsed, or "self
 list-verbs-command-invalid-target-uid = Target uid could not be parsed.
 
 # Floof: allow `listverbs self` as normal player.
-invoke-verb-command-no-perms = Must be admin to list verbs as UID other than "self".
+list-verbs-command-no-perms = Must be admin to list verbs as UID other than "self".
 
 list-verbs-command-invalid-player-entity = Player uid given does not correspond to a valid entity.
 list-verbs-command-invalid-target-entity = Target uid given does not correspond to a valid entity.

--- a/Resources/Locale/en-US/verbs/list-verbs-command.ftl
+++ b/Resources/Locale/en-US/verbs/list-verbs-command.ftl
@@ -9,6 +9,9 @@ list-verbs-command-invalid-args = listverbs takes 2 arguments.
 list-verbs-command-invalid-player-uid = Player uid could not be parsed, or "self" was not passed.
 list-verbs-command-invalid-target-uid = Target uid could not be parsed.
 
+# Floof: allow `listverbs self` as normal player.
+invoke-verb-command-no-perms = Must be admin to list verbs as UID other than "self".
+
 list-verbs-command-invalid-player-entity = Player uid given does not correspond to a valid entity.
 list-verbs-command-invalid-target-entity = Target uid given does not correspond to a valid entity.
 


### PR DESCRIPTION
# Description

Allow `invokeverb self` to be used as a non-admin for bindings.
Add `expand` client-side command to expand certain variables in a command (currently only `$HOVERED`).

Example usage:
```
bind MouseMiddle Command "expand invokeverb self $HOVERED \"Look at\""
```

---

# TODO

- [ ] Should this take a single string arg instead? I wanted to avoid introducing more layers of quoting for no reason.

---

<details><summary><h1>Media</h1></summary>
<p>

<img width="1157" height="556" alt="image" src="https://github.com/user-attachments/assets/b8df07c4-79d4-49d6-ba8c-e4091c33fcd1" />

</p>
</details>

---

# Changelog

:cl:
- add: Emote keybind users rejoice! You can now bind right-click verbs to keybinds that will activate on the hovered entity.