### PR TITLE
Restore Yip Message Localization

### DIFF
--- a/Resources/Locale/en-US/_Floof/chat/emotes.ftl
+++ b/Resources/Locale/en-US/_Floof/chat/emotes.ftl
@@ -5,6 +5,7 @@ chat-emote-name-coo = Coo
 chat-emote-name-whimper = Whimper
 chat-emote-name-whine = Whine
 
+floof-chat-emote-msg-yip = yips!
 floof-chat-emote-msg-yap = yaps!
 floof-chat-emote-msg-gekker = gekkers!
 floof-chat-emote-msg-coo = coos.


### PR DESCRIPTION
<!--
This is a semi-strict format, you can add/remove sections as needed but the order/format should be kept the same
Remove these comments before submitting
-->

# Description

<!--
Explain this PR in as much detail as applicable

Some example prompts to consider:
How might this affect the game? The codebase?
What might be some alternatives to this?
How/Who does this benefit/hurt [the game/codebase]?
-->

The yip localized chat message, used when yipping via the emote wheel, was mistakenly removed. This brings it back.

---

# TODO

<!--
A list of everything you have to do before this PR is "complete"
You probably won't have to complete everything before merging but it's good to leave future references
-->

- [x] Re-add yip message US localization
- [x] Verify functionality

---

<!--
This is default collapsed, readers click to expand it and see all your media
The PR media section can get very large at times, so this is a good way to keep it clean
The title is written using HTML tags
The title must be within the <summary> tags or you won't see it
-->

<details><summary><h1>Media</h1></summary>
<p>

<img width="1291" height="567" alt="image" src="https://github.com/user-attachments/assets/7639d7f1-e264-4c01-bdf4-b3d77376c73e" />

</p>
</details>

---

# Changelog

<!--
You can add an author after the `:cl:` to change the name that appears in the changelog (ex: `:cl: Death`)
Leaving it blank will default to your GitHub display name
This includes all available types for the changelog
-->

:cl:
- fix: Yip chat message when using the emote wheel has been restored.

