### PR TITLE
Nerf Spam-Eating/Drinking

### DIFF
--- a/Content.Server/Nutrition/EntitySystems/DrinkSystem.cs
+++ b/Content.Server/Nutrition/EntitySystems/DrinkSystem.cs
@@ -223,6 +223,9 @@ public sealed class DrinkSystem : SharedDrinkSystem
             BreakOnDamage = true,
             MovementThreshold = 0.01f,
             DistanceThreshold = 1.0f,
+            // Floof: stop people from drinking nine puddles of blood at once
+            BlockDuplicate = true,
+            DuplicateCondition = DuplicateConditions.SameEvent,
             // Mice and the like can eat without hands.
             // TODO maybe set this based on some CanEatWithoutHands event or component?
             NeedHand = forceDrink,

--- a/Content.Server/Nutrition/EntitySystems/FoodSystem.cs
+++ b/Content.Server/Nutrition/EntitySystems/FoodSystem.cs
@@ -205,6 +205,9 @@ public sealed class FoodSystem : EntitySystem
             BreakOnDamage = true,
             MovementThreshold = 0.01f,
             DistanceThreshold = MaxFeedDistance,
+            // Floof: stop people from stuffing seventeen hamburgers in their mouth at once
+            BlockDuplicate = true,
+            DuplicateCondition = DuplicateConditions.SameEvent,
             // Mice and the like can eat without hands.
             // TODO maybe set this based on some CanEatWithoutHands event or component?
             NeedHand = forceFeed


### PR DESCRIPTION
<!--
This is a semi-strict format, you can add/remove sections as needed but the order/format should be kept the same
Remove these comments before submitting
-->

# Description

<!--
Explain this PR in as much detail as applicable

Some example prompts to consider:
How might this affect the game? The codebase?
What might be some alternatives to this?
How/Who does this benefit/hurt [the game/codebase]?
-->

Solves a longstanding issue where players could consume an unlimited number of food or drinks simultaneously, which looked nasty, made no mechanical sense, and made the chef's life miserable (particularly when the player in question was controlling a mouse, and abusing this mechanic to powergame).

---

<!--
This is default collapsed, readers click to expand it and see all your media
The PR media section can get very large at times, so this is a good way to keep it clean
The title is written using HTML tags
The title must be within the <summary> tags or you won't see it
-->

<details><summary><h1>Media</h1></summary>
<p>

https://github.com/user-attachments/assets/f4ca1195-28ce-4dc4-8dfb-15fe877f99b3

</p>
</details>

---

# Changelog

<!--
You can add an author after the `:cl:` to change the name that appears in the changelog (ex: `:cl: Death`)
Leaving it blank will default to your GitHub display name
This includes all available types for the changelog
-->

:cl:
- tweak: Players are now limited to stuffing one thing in their face hole at a time.
