### PR TITLE
Fixed Mining Drill Attack Speed

### DIFF
--- a/Resources/Prototypes/_Goobstation/Entities/Objects/Specific/Mech/Weapons/Melee/industrial.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Objects/Specific/Mech/Weapons/Melee/industrial.yml
@@ -45,7 +45,7 @@
       wideAnimationRotation: -90
       soundHit:
         path: "/Audio/Items/drill_hit.ogg"
-      attackRate: 4 # Should be better then a normal drill not worse
+      attackRate: 4 # Should be better then a normal drill not worse # Floofstation - this is in hertz, not seoconds
       damage:
         groups:
           Brute: 24

--- a/Resources/Prototypes/_Goobstation/Entities/Objects/Specific/Mech/Weapons/Melee/industrial.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Objects/Specific/Mech/Weapons/Melee/industrial.yml
@@ -18,7 +18,7 @@
       wideAnimationRotation: -90
       soundHit:
         path: "/Audio/Items/drill_hit.ogg"
-      attackRate: 4 # Should be better then a normal drill not worse # Floofstation - this is in hertz, not seoconds
+      attackRate: 4 # Should be better then a normal drill not worse # Floofstation - this is in hertz, not seconds
       damage:
         groups:
           Brute: 12 # Giant fucking mech drill
@@ -45,7 +45,7 @@
       wideAnimationRotation: -90
       soundHit:
         path: "/Audio/Items/drill_hit.ogg"
-      attackRate: 4 # Should be better then a normal drill not worse # Floofstation - this is in hertz, not seoconds
+      attackRate: 4 # Should be better then a normal drill not worse # Floofstation - this is in hertz, not seconds
       damage:
         groups:
           Brute: 24

--- a/Resources/Prototypes/_Goobstation/Entities/Objects/Specific/Mech/Weapons/Melee/industrial.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Objects/Specific/Mech/Weapons/Melee/industrial.yml
@@ -18,7 +18,7 @@
       wideAnimationRotation: -90
       soundHit:
         path: "/Audio/Items/drill_hit.ogg"
-      attackRate: 0.25 # Should be better then a normal drill not worse
+      attackRate: 4 # Should be better then a normal drill not worse
       damage:
         groups:
           Brute: 12 # Giant fucking mech drill
@@ -45,7 +45,7 @@
       wideAnimationRotation: -90
       soundHit:
         path: "/Audio/Items/drill_hit.ogg"
-      attackRate: 0.25 # Should be better then a normal drill not worse
+      attackRate: 4 # Should be better then a normal drill not worse
       damage:
         groups:
           Brute: 24

--- a/Resources/Prototypes/_Goobstation/Entities/Objects/Specific/Mech/Weapons/Melee/industrial.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Objects/Specific/Mech/Weapons/Melee/industrial.yml
@@ -18,7 +18,7 @@
       wideAnimationRotation: -90
       soundHit:
         path: "/Audio/Items/drill_hit.ogg"
-      attackRate: 4 # Should be better then a normal drill not worse
+      attackRate: 4 # Should be better then a normal drill not worse # Floofstation - this is in hertz, not seoconds
       damage:
         groups:
           Brute: 12 # Giant fucking mech drill


### PR DESCRIPTION
# Description
Mech Drill was set to seconds per swing instead of swings per second.

# Changelog
:cl:
- fix: Fixed Mech Drill attack speed
