### PR TITLE
Tweak Security Loadout

### DIFF
--- a/Resources/Prototypes/Loadouts/Jobs/Security/weapons.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Security/weapons.yml
@@ -85,14 +85,14 @@
     min: 259200 # 3 days
   - !type:CharacterItemGroupRequirement
     group: LoadoutSecurityWeapons
-  - !type:CharacterJobRequirement
-    jobs:
-    - BlueshieldOfficer
-    - SeniorOfficer
-    - Warden
-  - !type:CharacterSpeciesRequirement
-    species:
-    - Oni
+  - !type:CharacterLogicOrRequirement
+    requirements:
+    - !type:CharacterDepartmentRequirement
+      departments:
+      - Security
+    - !type:CharacterJobRequirement
+      jobs:
+      - BlueshieldOfficer
   items:
     - ClothingBeltKatanaSheathFilled
 


### PR DESCRIPTION
# Description
Removed the Oni Only and Senior Officer/Warden Restriction from Katanas.

This should allow more Onis and other races like Kitsune and weebs to take it. It's arguably still worse then a Judo or Sec Belt.

# Changelog
:cl:
- tweak: Removed Restrictions for Security Katanas.

