### PR TITLE
Katana Buff

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/sword.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/sword.yml
@@ -90,12 +90,20 @@
     heavyStaminaCost: 15
     maxTargets: 1
     angle: 20
+  - type: Wieldable # Floof - Banzai!
+  - type: IncreaseDamageOnWield
+    damage:
+      types:
+        Slash: 8
   - type: DamageOtherOnHit
     staminaCost: 10
   - type: EmbeddableProjectile
   - type: EmbedPassiveDamage
   - type: ThrowingAngle
     angle: 225
+  - type: Reflect # Floof - Just Parry 4head
+    reflectProb: .1
+    spread: 90
   - type: Item
     size: Normal
     sprite: DeltaV/Objects/Weapons/Melee/katana.rsi #DeltaV


### PR DESCRIPTION
# Description
Makes Katanas 2 hand-able, and adds a very low chance to parry projectiles (probability wise, you will die before you reflect a single bullet). How practical this will be, is not very.

Banzai!

# Changelog
:cl:
- tweak: Katanas are now 2 hand-able.

