### PR TITLE
Both Barrels

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Shotguns/shotguns.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Shotguns/shotguns.yml
@@ -165,8 +165,14 @@
     sprite: Objects/Weapons/Guns/Shotguns/db_shotgun_inhands_64x.rsi
   - type: GunRequiresWield #remove when inaccuracy on spreads is fixed
   - type: Gun
-    fireRate: 2
+    fireRate: 4
     fireOnDropChance: 0.5
+    selectedMode: SemiAuto
+    shotsPerBurst: 2
+    burstFireRate: 30 # Floof
+    availableModes:
+    - SemiAuto
+    - Burst # Floof - Both Barrels
   - type: Wieldable
   - type: BallisticAmmoProvider
     capacity: 2
@@ -261,6 +267,12 @@
   - type: Gun
     fireRate: 4
     fireOnDropChance: 0.5
+    selectedMode: SemiAuto
+    burstFireRate: 30 # Floof
+    shotsPerBurst: 2
+    availableModes:
+    - SemiAuto
+    - Burst # Floof - Both Barrels
   - type: BallisticAmmoProvider
     capacity: 2
   - type: Construction
@@ -276,7 +288,7 @@
     staminaCost: 6
 
 - type: entity
-  name: sawn-off shogun
+  name: sawn-off shotgun
   parent: WeaponShotgunSawn
   id: WeaponShotgunSawnEmpty
   description: Groovy! Uses .50 shotgun shells.


### PR DESCRIPTION
# Description
https://discord.com/channels/1255902263667331193/1255992182880473269/1430992882583605318
(Video)

Adds a Burst Fire option for the Double Barrel shotgun, and the sawn off shotgun which builds out of a double barrel.
It's intended to simulate firing both barrels at once.

# Changelog

:cl:
- add: Added Burst Fire to Double Barrel Shotgun

