### PR TITLE
Fix Vox Displacements

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/Species/vox.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/vox.yml
@@ -16,6 +16,42 @@
     #- type: VoxAccent # Not yet coded
   - type: Inventory
     speciesId: vox
+    displacements: #start of floof station fix
+        jumpsuit:
+          sizeMaps:
+            32:
+              sprite: Mobs/Species/Vox/displacement.rsi
+              state: jumpsuit
+        eyes:
+          sizeMaps:
+            32:
+              sprite: Mobs/Species/Vox/displacement.rsi
+              state: eyes
+        gloves:
+          sizeMaps:
+            32:
+              sprite: Mobs/Species/Vox/displacement.rsi
+              state: hand
+        head:
+          sizeMaps:
+            32:
+              sprite: Mobs/Species/Vox/displacement.rsi
+              state: head
+        back:
+          sizeMaps:
+            32:
+              sprite: Mobs/Species/Vox/displacement.rsi
+              state: back
+        ears:
+          sizeMaps:
+            32:
+              sprite: Mobs/Species/Vox/displacement.rsi
+              state: ears
+        shoes:
+          sizeMaps:
+            32:
+              sprite: Mobs/Species/Vox/displacement.rsi
+              state: shoes #end of fixes
   - type: Speech
     speechVerb: Vox
     speechSounds: Vox


### PR DESCRIPTION
<!--
This is a semi-strict format, you can add/remove sections as needed but the order/format should be kept the same
Remove these comments before submitting
-->

# Description

EE is a magical code base with no problems at all
no seriously why the fuck is the displacements on the character creator dummy entity and not on the in game player entity

---

# TODO

<!--
A list of everything you have to do before this PR is "complete"
You probably won't have to complete everything before merging but it's good to leave future references
-->

- [ ] Possibly find out why colored clothes break as well (if its even possible remember EE is a magical code base with no problems at all)

if you find a fix for the above problem PLEASE TELL ME
---

<!--
This is default collapsed, readers click to expand it and see all your media
The PR media section can get very large at times, so this is a good way to keep it clean
The title is written using HTML tags
The title must be within the <summary> tags or you won't see it
-->

<details><summary><h1>Media</h1></summary>
<p>

<img width="395" height="446" alt="image" src="https://github.com/user-attachments/assets/8ec89ca6-42bf-4867-abd9-4eb0672b163a" />
<img width="335" height="428" alt="image" src="https://github.com/user-attachments/assets/76acdaf0-60bd-41e8-b18a-cc9a1ff8b06e" />
<img width="330" height="347" alt="image" src="https://github.com/user-attachments/assets/78a9dc59-a3e4-4952-8bd8-863777055a24" />
<img width="500" height="408" alt="image" src="https://github.com/user-attachments/assets/56f3059c-d7f3-4d96-b4e4-d0e1aee3240e" />
(colored clothes still broken for some god forsaken reason)

</p>
</details>

---

# Changelog

<!--
You can add an author after the `:cl:` to change the name that appears in the changelog (ex: `:cl: Death`)
Leaving it blank will default to your GitHub display name
This includes all available types for the changelog
-->

:cl:
- fix: vox displacement maps now appear in game

