### PR TITLE
Add Mask to Surgery Bag

### DIFF
--- a/Resources/Prototypes/Catalog/Fills/Backpacks/duffelbag.yml
+++ b/Resources/Prototypes/Catalog/Fills/Backpacks/duffelbag.yml
@@ -14,6 +14,10 @@
       - id: Scalpel
       - id: BoneGel # Shitmed Change
       - id: NitrousOxideTankFilled # DeltaV - add anesthesia
+      - id: ClothingHandsGlovesNitrile # Floof
+      - id: EmergencyRollerBedSpawnFolded
+      - id: ClothingMaskBreathMedical
+      - id: ClothingMaskSterile
 
 - type: entity
   id: ClothingBackpackDuffelCBURNFilled
@@ -50,6 +54,8 @@
       - id: EmergencyRollerBedSpawnFolded
       - id: BoneGel # Shitmed Change
       - id: NitrousOxideTankFilled # DeltaV - add anesthesia
+      - id: ClothingMaskBreathMedical # Floof
+      - id: ClothingMaskSterile
 
 - type: entity
   parent: ClothingBackpackDuffelSyndicateBundle


### PR DESCRIPTION
# Description
Surgery Duffel Bags was lacking a breath mask for the person getting put to sleep, despite having a N2O tank.
So this adds a breath mask, sterile mask, sterile gloves and roller bed to the surgery bag. (Any mask or gloves work but I've added the correct flavor ones)


# Changelog
:cl:
- fix: Added a medical breath mask to the Surgery bag. No more scrambling around looking for one.

