### PR TITLE
Fixes Bionic Limbs

### DIFF
--- a/Resources/Prototypes/Traits/physical.yml
+++ b/Resources/Prototypes/Traits/physical.yml
@@ -902,15 +902,15 @@
       protoId: SpeedLeftLeg
       slotId: "left leg"
     - !type:TraitCyberneticLimbReplacement
-      removeBodyPart: Foot
-      partSymmetry: Left
-      protoId: LeftFootCybernetic
-      slotId: "left foot"
-    - !type:TraitCyberneticLimbReplacement
       removeBodyPart: Leg
       partSymmetry: Right
       protoId: SpeedRightLeg
       slotId: "right leg"
+    - !type:TraitCyberneticLimbReplacement
+      removeBodyPart: Foot
+      partSymmetry: Left
+      protoId: LeftFootCybernetic
+      slotId: "left foot"
     - !type:TraitCyberneticLimbReplacement
       removeBodyPart: Foot
       partSymmetry: Right

--- a/Resources/Prototypes/Traits/physical.yml
+++ b/Resources/Prototypes/Traits/physical.yml
@@ -544,10 +544,20 @@
       protoId: CrowbarLeftArm
       slotId: "left arm"
     - !type:TraitCyberneticLimbReplacement
+      removeBodyPart: Hand
+      partSymmetry: Left
+      protoId: LeftHandCybernetic
+      slotId: "left hand"
+    - !type:TraitCyberneticLimbReplacement
       removeBodyPart: Arm
       partSymmetry: Right
       protoId: CrowbarRightArm
       slotId: "right arm"
+    - !type:TraitCyberneticLimbReplacement
+      removeBodyPart: Hand
+      partSymmetry: Right
+      protoId: RightHandCybernetic
+      slotId: "right hand"
     - !type:TraitPushDescription
       descriptionExtensions:
         - description: examine-pry-arm-message
@@ -876,6 +886,10 @@
         - Prisoner # Bionics should be "Confiscated" from long term prisoners.
         - Gladiator # Floof
         - Anomaly
+    - !type:CharacterSpeciesRequirement
+      inverted: true
+      species:
+        - Arachne # Doesn't work
   functions:
     - !type:TraitPushDescription
       descriptionExtensions:
@@ -888,10 +902,20 @@
       protoId: SpeedLeftLeg
       slotId: "left leg"
     - !type:TraitCyberneticLimbReplacement
+      removeBodyPart: Foot
+      partSymmetry: Left
+      protoId: LeftFootCybernetic
+      slotId: "left foot"
+    - !type:TraitCyberneticLimbReplacement
       removeBodyPart: Leg
       partSymmetry: Right
       protoId: SpeedRightLeg
       slotId: "right leg"
+    - !type:TraitCyberneticLimbReplacement
+      removeBodyPart: Foot
+      partSymmetry: Right
+      protoId: RightFootCybernetic
+      slotId: "right foot"
 
 - type: trait
   id: LightAmplification
@@ -979,10 +1003,20 @@
       protoId: JawsOfLifeLeftArm
       slotId: "left arm"
     - !type:TraitCyberneticLimbReplacement
+      removeBodyPart: Hand
+      partSymmetry: Left
+      protoId: LeftHandCybernetic
+      slotId: "left hand"
+    - !type:TraitCyberneticLimbReplacement
       removeBodyPart: Arm
       partSymmetry: Right
       protoId: JawsOfLifeRightArm
       slotId: "right arm"
+    - !type:TraitCyberneticLimbReplacement
+      removeBodyPart: Hand
+      partSymmetry: Right
+      protoId: RightHandCybernetic
+      slotId: "right hand"
     - !type:TraitPushDescription
       descriptionExtensions:
         - description: examine-bionic-arm-message


### PR DESCRIPTION
# Description
This PR adds bionic hands and feet to the respective arm and leg replacement traits, it's very weird that you would have a flesh hand at the end of a bionic arm and this PR fixes that. Installing cybernetics in round already adds the hand and foot.

This PR also disables Bionic Legs for Arachne as it simply does not work due to how the legs are labeled. IE left leg (second).

# Changelog
:cl:
- tweak: Bionic Legs disabled for Arachne as it simply did not work
- fix: Added bionic hands and feet to bionic arms and legs, it didn't make sense you would have a flesh bit attached to the end.

