### PR TITLE
Artifact Effect Tweaks

### DIFF
--- a/Resources/Prototypes/_Floof/XenoArch/Effects/normal_effects.yml
+++ b/Resources/Prototypes/_Floof/XenoArch/Effects/normal_effects.yml
@@ -4,7 +4,7 @@
   effectHint: artifact-effect-hint-creation
   components:
   - type: SpawnArtifact
-    maxSpawns: 20
+    maxSpawns: 10
     spawns:
     - id: LewdLootSpawnerToys
       amount: 1
@@ -24,7 +24,7 @@
   effectHint: artifact-effect-hint-creation
   components:
   - type: SpawnArtifact
-    maxSpawns: 20
+    maxSpawns: 10
     spawns:
     - id: LewdLootSpawnerKinky
       amount: 1
@@ -108,7 +108,7 @@
 
 - type: artifactEffect
   id: EffectCashSpawnHigh
-  targetDepth: 4
+  targetDepth: 5
   effectHint: artifact-effect-hint-creation
   components:
   - type: SpawnArtifact
@@ -127,7 +127,7 @@
 
 - type: artifactEffect # Floof - A little radioactive gift
   id: EffectSupermatterSliver
-  targetDepth: 5
+  targetDepth: 6
   effectHint: artifact-effect-hint-creation
   components:
   - type: SpawnArtifact
@@ -137,7 +137,7 @@
 
 - type: artifactEffect
   id: EffectHellspawn
-  targetDepth: 4
+  targetDepth: 5
   effectHint: artifact-effect-hint-displacement # Floof - Yeah, it's displacing a demon from hell
   components:
   - type: SpawnArtifact
@@ -147,7 +147,7 @@
 
 - type: artifactEffect # Floof - A Supermatter is still safer then a Singulo or a Tesla
   id: EffectSupermatter
-  targetDepth: 8 
+  targetDepth: 8
   effectHint: artifact-effect-hint-destruction
   components:
   - type: SpawnArtifact

--- a/Resources/Prototypes/_Floof/XenoArch/Effects/utility_effects.yml
+++ b/Resources/Prototypes/_Floof/XenoArch/Effects/utility_effects.yml
@@ -1,6 +1,6 @@
 - type: artifactEffect # Floof - Eh Silly
   id: EffectHugeIron
-  targetDepth: 4
+  targetDepth: 6
   effectHint: artifact-effect-hint-gun
   whitelist:
     components:
@@ -23,9 +23,8 @@
       path: /Audio/Weapons/Guns/MagIn/revolver_magin.ogg
   - type: Gun
     selectedMode: SemiAuto
-    fireRate: 2
+    fireRate: 0.4
     availableModes:
     - SemiAuto
-    - FullAuto # no alien revolver in buildings
     soundGunshot:
       path: /Audio/Weapons/Guns/Gunshots/mateba.ogg


### PR DESCRIPTION
# Description
That wasn't very well balanced.

- Changes the max spawns of lewd effects to 10 (from 20)
- Moves high cash and hellspawn to depth 5 (from 4)
- Moves supermatter sliver and huge iron to depth 6 (from 5 and 4 respectively)
- Lowers the fire rate of huge iron from 2/s to 0.4/s 

# Changelog
:cl:
- tweak: Nerfed some of the new artifact effects.
