### PR TITLE
Re-Add Vapes to Shady Cig Vendor

### DIFF
--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/cigs.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/cigs.yml
@@ -8,7 +8,7 @@
     CigPackMixed: 2
     CigarCase: 1
     SmokingPipeFilledTobacco: 1
-    # Vape: 1 # DeltaV - Disable the Vape
+    Vape: 2 # Floofstation
     Matchbox: 5
     PackPaperRollingFilters: 3
     CheapLighter: 4


### PR DESCRIPTION
# Description
---

Re-enable vapes in the shady cigs vendor since Delta-V disabled them.

<details><summary><h1>Vending Machine Images</h1></summary>
<p>

<img width="298" height="582" alt="re-added" src="https://github.com/user-attachments/assets/1fc9609c-1a63-4f5a-9e94-d2f78bff544b" />


</p>
</details>

---

:cl:
- tweak: Re-add vapes to the shady cigs vendor. 
