### PR TITLE
Magic Candles Box for Loadout

### DIFF
--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/chapel.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/chapel.yml
@@ -26,6 +26,7 @@
     #ClothingHeadsetService: 2 # Delta-V - Chaplain is no longer service dept
     BoxCandle: 2
     BoxCandleSmall: 2
+    BoxCandleInfinite: 1
     Urn: 5
   emaggedInventory:
     ClothingOuterArmorCult: 1

--- a/Resources/Prototypes/Entities/Objects/Misc/candles.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/candles.yml
@@ -288,6 +288,9 @@
     color: "#e39c40"
     radius: 2.5
     power: 10
+  - type: Tag
+    tags:
+    - Candle
 
 - type: entity
   name: magic red candle

--- a/Resources/Prototypes/Loadouts/Generic/items.yml
+++ b/Resources/Prototypes/Loadouts/Generic/items.yml
@@ -1050,3 +1050,10 @@
       group: LoadoutPets
   functions:
     - !type:LoadoutMakeFollower
+    
+- type: loadout # Floof - Mood Lighting for LONG ERP sessions
+  id: LoadoutItemBoxCandleInfinite
+  category: Items
+  cost: 1
+  items:
+    - BoxCandleInfinite

--- a/Resources/Prototypes/_Floof/Catalog/Fills/Boxes/general.yml
+++ b/Resources/Prototypes/_Floof/Catalog/Fills/Boxes/general.yml
@@ -108,3 +108,22 @@
     whitelist:
       components:
       - LightBulb
+
+- type: entity
+  name: magic candle box
+  parent: BoxCandle
+  id: BoxCandleInfinite
+  description: This box is specifically moulded to only carry magic non-scented candles.
+  components:
+  - type: StorageFill
+    contents:
+      - id: CandleInfinite
+        amount: 4
+      - id: CandleBlueInfinite
+        amount: 2
+      - id: CandleRedInfinite
+        amount: 2
+      - id: CandleGreenInfinite
+        amount: 2
+      - id: CandlePurpleInfinite
+        amount: 2


### PR DESCRIPTION
# Description
Adds a magic candle box for loadout. For those long romantic encounters where normal candles will burn out long before you're done.

![Candle](https://github.com/user-attachments/assets/35e452ba-f658-4f9f-9c4b-d8c54fd97876)


# Changelog
:cl:
- add: Added Magic Candles Box to Loadout
