### PR TITLE
Makes It so Arachne Can Wear the Atmos Fire Suit

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/suits.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/suits.yml
@@ -119,7 +119,6 @@
       slots: WITHOUT_POCKET
     - type: Tag
       tags:
-        - FullBodyOuter
         - WhitelistChameleon
         # HidesHarpyWings floof
 


### PR DESCRIPTION
# Description
Makes it so Arachne can wear the Atmos Fire Suit. 

This is a problem. Either accept we gotta let em wear some work hardsuits or race ban Arachne from Engineering, they're a walking OSHA violation.

# Changelog
:cl:
- tweak: Arachne can now wear the Atmos Fire Suit. Their ass might be a bit toasty tho.
