### PR TITLE
Wings - It Works

### DIFF
--- a/Resources/Locale/en-US/_Floof/traits/traits.ftl
+++ b/Resources/Locale/en-US/_Floof/traits/traits.ftl
@@ -94,3 +94,7 @@ trait-description-OniShooting = Due to an innate skill issue, you can't aim at a
 trait-name-BadShooting = Bad Aim
 trait-description-BadShooting = Due to a lack of training or simply a lack of skill or talent, you can't aim very well.
 
+trait-name-Wings = Wings
+trait-description-Wings =
+    Through mutation, genetic editing, or questionable surgery, your arms have been replaced with wings similar to those of a Harpy.
+    You gain the ability to fly like a Harpy.

--- a/Resources/Prototypes/_Floof/Body/Parts/extra.yml
+++ b/Resources/Prototypes/_Floof/Body/Parts/extra.yml
@@ -1,0 +1,43 @@
+# Extra Limbs that exist to be added via Trait
+- type: entity
+  id: LeftArmHarpyTrait
+  name: "left harpy arm"
+  parent: PartHarpy
+  components:
+  - type: Sprite
+    netsync: false
+    sprite: Mobs/Species/Harpy/parts.rsi
+    state: "l_arm"
+  - type: Icon
+    sprite: Mobs/Species/Harpy/parts.rsi
+    state: "l_arm"
+  - type: BodyPart
+    partType: Arm
+    symmetry: Left
+    toolName: "a left arm" # Shitmed Change
+  - type: GenerateChildPart
+    id: LeftHandHarpy
+
+- type: entity
+  id: RightArmHarpyTrait
+  name: "right harpy arm"
+  parent: PartHarpy
+  components:
+  - type: Sprite
+    netsync: false
+    sprite: Mobs/Species/Harpy/parts.rsi
+    state: "r_arm"
+  - type: Icon
+    sprite: Mobs/Species/Harpy/parts.rsi
+    state: "r_arm"
+  - type: BodyPart
+    partType: Arm
+    symmetry: Right
+    toolName: "a right arm" # Shitmed Change
+    onAdd:
+    - type: Flight
+      isLayerAnimated: true
+      layer: "/Textures/Mobs/Customization/Harpy/harpy_wings.rsi"
+      animationKey: "Flap"
+  - type: GenerateChildPart
+    id: RightHandHarpy

--- a/Resources/Prototypes/_Floof/Traits/physical.yml
+++ b/Resources/Prototypes/_Floof/Traits/physical.yml
@@ -361,10 +361,10 @@
     - !type:TraitCyberneticLimbReplacement
       removeBodyPart: Arm
       partSymmetry: Left
-      protoId: LeftArmHarpy
+      protoId: LeftArmHarpyTrait
       slotId: "left arm"
     - !type:TraitCyberneticLimbReplacement
       removeBodyPart: Arm
       partSymmetry: Right
-      protoId: RightArmHarpy
+      protoId: RightArmHarpyTrait
       slotId: "right arm"

--- a/Resources/Prototypes/_Floof/Traits/physical.yml
+++ b/Resources/Prototypes/_Floof/Traits/physical.yml
@@ -356,6 +356,7 @@
       inverted: true
       species:
         - Harpy
+        - IPC
         # - Xelthia # this would fall off
   functions:
     - !type:TraitCyberneticLimbReplacement

--- a/Resources/Prototypes/_Floof/Traits/physical.yml
+++ b/Resources/Prototypes/_Floof/Traits/physical.yml
@@ -338,3 +338,33 @@
       - type: PlayerAccuracyModifier
         spreadMultiplier: 2.5
         maxSpreadAngle: 90
+
+# The Limb replacement function it uses lacks the functionality to change the wing color, thus will spawn as skin color.
+# In future the function may be changed to allow for it to use hair color or tie it to the marking system.
+# For now simply having wings markings should work fine for coloring em.
+- type: trait 
+  id: Wings
+  category: Physical
+  points: -1
+  requirements:
+    - !type:CharacterTraitRequirement
+      inverted: true
+      traits:
+        - BionicArm
+        - BionicPryArm
+    - !type:CharacterSpeciesRequirement
+      inverted: true
+      species:
+        - Harpy
+        # - Xelthia # this would fall off
+  functions:
+    - !type:TraitCyberneticLimbReplacement
+      removeBodyPart: Arm
+      partSymmetry: Left
+      protoId: LeftArmHarpy
+      slotId: "left arm"
+    - !type:TraitCyberneticLimbReplacement
+      removeBodyPart: Arm
+      partSymmetry: Right
+      protoId: RightArmHarpy
+      slotId: "right arm"


### PR DESCRIPTION
# Description
This PR adds a trait that replaces your arms with harpy wings, which grant flight, however due to unforeseen circumstances, does not change the appearance of your arms to look like harpy wings. Which you can fix by having Wing Markings, also unforeseen, IPCs will appear have no arms or hands. Which I may just disable the trait for IPCs. 

![mightbeatadlong](https://github.com/user-attachments/assets/b9fa3dea-fbcc-4394-9113-ed8346ef8fae)
Picture shows the Flight Icon and my character stam crit from flying too long.

# Changelog
:cl:
- add: Added Wings Trait
