### PR TITLE
New Trait/Loadout Ui Fixes

### DIFF
--- a/Content.Client/_Floof/LoadoutsAndTraits/AbstractLoadoutTreeCharacterPage.xaml.cs
+++ b/Content.Client/_Floof/LoadoutsAndTraits/AbstractLoadoutTreeCharacterPage.xaml.cs
@@ -469,7 +469,9 @@ public abstract partial class AbstractLoadoutTreeCharacterPage<TProto, TCategory
         _characterRequirements ??= IoCManager.Resolve<IEntitySystemManager>().GetEntitySystem<CharacterRequirementsSystem>();
         _fallbackJob ??= ProtoMan.Index(_fallbackJobId);
 
-        var playtimes = _jobRequirementsManager.GetPlayTimes();
+        // !!! landmine: make sure to use GetRawPlayTime trackers, as this is what the loadout system was made to rely on.
+        // GetPlayTimes would return a Dictionary<ProtoId<Job>, TimeSpan>, whereas this returns a Dictionary<ProtoId<PlayTimeTracker>, TimeSpan>, but neither of them are typed properly
+        var playtimes = _jobRequirementsManager.GetRawPlayTimeTrackers();
         // EE used to create a new empty JobPrototype here, which would cause certain checks to fail. I have no words.
         profile ??= HumanoidCharacterProfile.DefaultWithSpecies();
         highJob ??= _fallbackJob;

--- a/Content.Client/_Floof/LoadoutsAndTraits/Loadouts/LoadoutTreeCharacterPage.cs
+++ b/Content.Client/_Floof/LoadoutsAndTraits/Loadouts/LoadoutTreeCharacterPage.cs
@@ -31,6 +31,7 @@ public sealed class LoadoutTreeCharacterPage : AbstractLoadoutTreeCharacterPage<
         _profileProvider = profileProvider;
 
         Counters.Add(new("loadout-point-counter", proto => proto.Cost, () => MaxPoints));
+        UpdateCounters();
     }
 
     ~LoadoutTreeCharacterPage()

--- a/Content.Client/_Floof/LoadoutsAndTraits/Traits/TraitTreeCharacterPage.cs
+++ b/Content.Client/_Floof/LoadoutsAndTraits/Traits/TraitTreeCharacterPage.cs
@@ -31,6 +31,7 @@ public sealed class TraitTreeCharacterPage : AbstractLoadoutTreeCharacterPage<Tr
         // 0. fucking. consistency.
         Counters.Add(new("loadout-point-counter", proto => -proto.Points, () => MaxPoints));
         Counters.Add(new("loadout-selection-counter", proto => proto.Slots, () => MaxSelections));
+        UpdateCounters();
     }
 
     ~TraitTreeCharacterPage()

--- a/Content.Client/_Floof/LoadoutsAndTraits/Traits/TraitTreeCharacterPage.cs
+++ b/Content.Client/_Floof/LoadoutsAndTraits/Traits/TraitTreeCharacterPage.cs
@@ -30,7 +30,7 @@ public sealed class TraitTreeCharacterPage : AbstractLoadoutTreeCharacterPage<Tr
         // This weird system expresses loadout cost as "how many points this takes", but trait cost as "how many points this GIVES"
         // 0. fucking. consistency.
         Counters.Add(new("loadout-point-counter", proto => -proto.Points, () => MaxPoints));
-        Counters.Add(new("loadout-selection-counter", proto => proto.Slots, () => MaxPoints));
+        Counters.Add(new("loadout-selection-counter", proto => proto.Slots, () => MaxSelections));
     }
 
     ~TraitTreeCharacterPage()

--- a/Content.Server/Traits/TraitSystem.cs
+++ b/Content.Server/Traits/TraitSystem.cs
@@ -80,7 +80,7 @@ public sealed class TraitSystem : EntitySystem
                 continue;
 
             // Floof - early exit if we are over the trait limit or points limit
-            if (pointsTotal + traitPrototype.Points < 0 || traitSelections <= 0)
+            if (pointsTotal + traitPrototype.Points < 0 || traitSelections - traitPrototype.Slots < 0)
                 continue;
 
             pointsTotal += traitPrototype.Points;

--- a/Content.Server/Traits/TraitSystem.cs
+++ b/Content.Server/Traits/TraitSystem.cs
@@ -84,7 +84,7 @@ public sealed class TraitSystem : EntitySystem
                 continue;
 
             pointsTotal += traitPrototype.Points;
-            --traitSelections;
+            traitSelections -= traitPrototype.Slots;
 
             AddTrait(args.Mob, traitPrototype);
         }


### PR DESCRIPTION
# Description
Oopsie.

# Changelog
:cl:
- fix: The trait selections counter no longer shows the same max value as the trait points counter, the loadouts ui now correctly fetches your playtimes when checking if a loadout is usable, and the server now correctly keeps track of trait slots.
