### PR TITLE
The Veterinarian Update.

### DIFF
--- a/Resources/Prototypes/DeltaV/Entities/Mobs/NPCs/pets.yml
+++ b/Resources/Prototypes/DeltaV/Entities/Mobs/NPCs/pets.yml
@@ -18,6 +18,12 @@
     tags:
     - CannotSuicide
     - VimPilot
+  - type: SurgeryTarget
+  - type: UserInterface
+    interfaces:
+      enum.SurgeryUIKey.Key:
+        type: SurgeryBui
+
 
 - type: entity
   name: Laika
@@ -55,3 +61,8 @@
     - CannotSuicide
     - VimPilot
     - DoorBumpOpener
+  - type: SurgeryTarget
+  - type: UserInterface
+    interfaces:
+      enum.SurgeryUIKey.Key:
+        type: SurgeryBui

--- a/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
@@ -888,6 +888,11 @@
     barkMultiplier: 3
   - type: LeashAnchor # Floofstation
     kind: Intrinsic
+  - type: SurgeryTarget
+  - type: UserInterface
+    interfaces:
+      enum.SurgeryUIKey.Key:
+        type: SurgeryBui
 
 
 - type: entity
@@ -1206,6 +1211,11 @@
       task: SimpleHostileCompound
   - type: LeashAnchor # Floofstation
     kind: Intrinsic
+  - type: SurgeryTarget
+  - type: UserInterface
+    interfaces:
+      enum.SurgeryUIKey.Key:
+        type: SurgeryBui
 
 - type: entity
   name: boxing kangaroo
@@ -2334,6 +2344,12 @@
   - type: LanguageKnowledge
     speaks: [Hissing]
     understands: [Hissing]
+  - type: Body
+    prototype: Animal
+  - type: UserInterface
+    interfaces:
+      enum.SurgeryUIKey.Key:
+        type: SurgeryBui
 
 # Code unique spider prototypes or combine them all into one spider and get a
 # random sprite state when you spawn it.
@@ -2658,6 +2674,11 @@
     kind: Intrinsic
   - type: RandomBark
     barkType: possum
+  - type: SurgeryTarget
+  - type: UserInterface
+    interfaces:
+      enum.SurgeryUIKey.Key:
+        type: SurgeryBui
 
 - type: entity
   name: possum
@@ -2738,6 +2759,11 @@
     kind: Intrinsic
   - type: RandomBark
     barkType: raccoon
+  - type: SurgeryTarget
+  - type: UserInterface
+    interfaces:
+      enum.SurgeryUIKey.Key:
+        type: SurgeryBui
 
 - type: entity
   name: fox
@@ -2830,6 +2856,13 @@
   - type: RandomBark
     barkType: fox
     barkMultiplier: 0.5 # Talkative <3
+  - type: Body
+    prototype: Animal
+  - type: SurgeryTarget
+  - type: UserInterface
+    interfaces:
+      enum.SurgeryUIKey.Key:
+        type: SurgeryBui
 
 - type: entity
   name: corgi
@@ -2901,6 +2934,13 @@
     barkType: dog
   - type: LeashAnchor # Floofstation
     kind: Intrinsic
+  - type: Body
+    prototype: Animal
+  - type: SurgeryTarget
+  - type: UserInterface
+    interfaces:
+      enum.SurgeryUIKey.Key:
+        type: SurgeryBui
 
 - type: entity
   name: corrupted corgi
@@ -3063,6 +3103,13 @@
     barkType: cat
   - type: LeashAnchor # Floofstation
     kind: Intrinsic
+  - type: Body
+    prototype: Animal
+  - type: SurgeryTarget
+  - type: UserInterface
+    interfaces:
+      enum.SurgeryUIKey.Key:
+        type: SurgeryBui
 
 - type: entity
   name: calico cat
@@ -3302,6 +3349,11 @@
     - Hissing
     understands:
     - Hissing
+  - type: SurgeryTarget
+  - type: UserInterface
+    interfaces:
+      enum.SurgeryUIKey.Key:
+        type: SurgeryBui
 
 - type: entity
   name: ferret
@@ -3362,6 +3414,11 @@
     - Hissing
   - type: LeashAnchor # Floofstation
     kind: Intrinsic
+  - type: SurgeryTarget
+  - type: UserInterface
+    interfaces:
+      enum.SurgeryUIKey.Key:
+        type: SurgeryBui
 
 - type: entity
   name: hamster
@@ -3513,6 +3570,11 @@
     normalState: Mouse_burning
   - type: LeashAnchor # Floofstation
     kind: Intrinsic
+  - type: SurgeryTarget
+  - type: UserInterface
+    interfaces:
+      enum.SurgeryUIKey.Key:
+        type: SurgeryBui
 
 - type: entity
   parent: MobHamster
@@ -3598,6 +3660,11 @@
   - type: NpcFactionMember
     factions:
     - Passive
+  - type: SurgeryTarget
+  - type: UserInterface
+    interfaces:
+      enum.SurgeryUIKey.Key:
+        type: SurgeryBui
 
 - type: entity
   name: diona nymph

--- a/Resources/Prototypes/Entities/Mobs/NPCs/pets.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/pets.yml
@@ -42,6 +42,11 @@
     understands:
     - TauCetiBasic
     - Dog
+  - type: SurgeryTarget
+  - type: UserInterface
+    interfaces:
+      enum.SurgeryUIKey.Key: # For some reason, childs wont inherit the surgery interface if the parent is not on the same YAML file. In this case, Ian is not taking the Surgery interface from MobCorgi. I hate this, but it works.
+        type: SurgeryBui
 
 - type: entity
   name: Old Ian
@@ -133,6 +138,11 @@
     understands:
     - TauCetiBasic
     - Cat
+  - type: SurgeryTarget
+  - type: UserInterface
+    interfaces:
+      enum.SurgeryUIKey.Key:
+        type: SurgeryBui
 
 - type: entity
   name: Exception
@@ -157,6 +167,11 @@
     understands:
     - TauCetiBasic
     - Cat
+  - type: SurgeryTarget
+  - type: UserInterface
+    interfaces:
+      enum.SurgeryUIKey.Key:
+        type: SurgeryBui
 
 - type: entity
   name: Floppa
@@ -182,6 +197,11 @@
     tags:
     - CannotSuicide
     - VimPilot
+  - type: SurgeryTarget
+  - type: UserInterface
+    interfaces:
+      enum.SurgeryUIKey.Key:
+        type: SurgeryBui
 
 - type: entity
   name: Bandito
@@ -197,6 +217,11 @@
     tags:
     - CannotSuicide
     - VimPilot
+  - type: SurgeryTarget
+  - type: UserInterface
+    interfaces:
+      enum.SurgeryUIKey.Key:
+        type: SurgeryBui
 
 - type: entity
   name: Bingus
@@ -254,6 +279,11 @@
     - VimPilot
   - type: StealTarget
     stealGroup: AnimalBingus
+  - type: SurgeryTarget
+  - type: UserInterface
+    interfaces:
+      enum.SurgeryUIKey.Key:
+        type: SurgeryBui
 
 - type: entity
   name: McGriff
@@ -320,6 +350,11 @@
   - type: RandomBark
     barkType: dog
     barkMultiplier: 1.3
+  - type: SurgeryTarget
+  - type: UserInterface
+    interfaces:
+      enum.SurgeryUIKey.Key:
+        type: SurgeryBui
 
 - type: entity
   name: Paperwork
@@ -354,6 +389,11 @@
     attributes:
       proper: true
       gender: male
+  - type: SurgeryTarget
+  - type: UserInterface
+    interfaces:
+      enum.SurgeryUIKey.Key:
+        type: SurgeryBui
 
 - type: entity
   name: Walter
@@ -420,6 +460,11 @@
   - type: RandomBark
     barkType: dog
     barkMultiplier: 1.1
+  - type: SurgeryTarget
+  - type: UserInterface
+    interfaces:
+      enum.SurgeryUIKey.Key:
+        type: SurgeryBui
 
 - type: entity
   name: Morty
@@ -444,6 +489,11 @@
     - VimPilot
   - type: StealTarget
     stealGroup: AnimalMorty
+  - type: SurgeryTarget
+  - type: UserInterface
+    interfaces:
+      enum.SurgeryUIKey.Key:
+        type: SurgeryBui
 
 - type: entity
   name: Morty
@@ -508,6 +558,11 @@
     tags:
     - CannotSuicide
     - VimPilot
+  - type: SurgeryTarget
+  - type: UserInterface
+    interfaces:
+      enum.SurgeryUIKey.Key:
+        type: SurgeryBui
 
 - type: entity
   name: Alexander
@@ -530,6 +585,11 @@
     tags:
     - CannotSuicide
     - VimPilot
+  - type: SurgeryTarget
+  - type: UserInterface
+    interfaces:
+      enum.SurgeryUIKey.Key:
+        type: SurgeryBui
 
 - type: entity
   name: Renault
@@ -566,6 +626,10 @@
     understands:
     - TauCetiBasic
     - Fox
+  - type: UserInterface
+    interfaces:
+      enum.SurgeryUIKey.Key:
+        type: SurgeryBui
 
 - type: entity
   name: Hamlet
@@ -620,6 +684,11 @@
     understands:
     - TauCetiBasic
     - Mouse
+  - type: SurgeryTarget
+  - type: UserInterface
+    interfaces:
+      enum.SurgeryUIKey.Key:
+        type: SurgeryBui
 
 - type: entity
   name: Shiva
@@ -724,6 +793,11 @@
   - type: GhostTakeoverAvailable
   - type: Loadout
     prototypes: [ BoxingKangarooGear ]
+  - type: SurgeryTarget
+  - type: UserInterface
+    interfaces:
+      enum.SurgeryUIKey.Key:
+        type: SurgeryBui
 
 - type: entity
   name: Smile

--- a/Resources/Prototypes/Nyanotrasen/Entities/Mobs/NPCs/animals.yml
+++ b/Resources/Prototypes/Nyanotrasen/Entities/Mobs/NPCs/animals.yml
@@ -9,3 +9,8 @@
     layers:
     - map: ["enum.DamageStateVisualLayers.Base"]
       state: ferret
+  - type: SurgeryTarget
+  - type: UserInterface
+    interfaces:
+      enum.SurgeryUIKey.Key:
+        type: SurgeryBui

--- a/Resources/Prototypes/_Floof/Entities/Mobs/NPCs/pets.yml
+++ b/Resources/Prototypes/_Floof/Entities/Mobs/NPCs/pets.yml
@@ -18,6 +18,10 @@
     tags:
     - CannotSuicide
     - VimPilot
+  - type: UserInterface
+    interfaces:
+      enum.SurgeryUIKey.Key:
+        type: SurgeryBui
 
 - type: entity
   name: pet spider


### PR DESCRIPTION
Now most animals and station pets are valid targets for surgery.

List of affected animals and station pets:

Station pets affected:

Ian
Old Ian
Lisa
Puppy Ian
Runtime
Exception
Floppa
Bandito
Bingus
McGriff
Paperwork
Morty (Both new and old)
Poppy
Morticia
Alexander
Renault
Hamlet
Laika
Siobhan

Animals affected (not station pets):

Ferrets
Corgis
Cats (Including syndiecats, I dont know why someone would try this)
Ferrets
Sloths
Possums
Raccoons
Pigs
Cows
Hamsters
Kangaroos


-----------------------------

This is my first PR, first of many.

Explanation on changes:

Using common sense, one would think, "Just add surgery target to all the parent mobs from the station pets," and that's true. The problem is that, apparently, childs don't inherit the surgery interface if they are not sharing the same YAML file, so almost all station pets needed the surgery interface hard-coded in them, with some exceptions like IAN and all his variants.
