### PR TITLE
N14 Tile Fix for Weather and Prying

### DIFF
--- a/Resources/Prototypes/_Nuclear14/Tiles/floors.yml
+++ b/Resources/Prototypes/_Nuclear14/Tiles/floors.yml
@@ -3,7 +3,7 @@
   id: FloorMetalBlue
   name: metal blue
   sprite: /Textures/_Nuclear14/Tiles/metalblue.png
-  baseTurf: FloorWasteland
+  baseTurf: Plating #Floofstation
   isSubfloor: false
   deconstructTools: [ Prying ]
   footstepSounds:
@@ -12,13 +12,13 @@
   itemDrop: FloorTileItemMetalBlue
   thermalConductivity: 0.04
   heatCapacity: 10000
-  weather: true
+  weather: false #floofstation
 
 - type: tile
   id: FloorMetalBlueSolid
   name: metal blue solid
   sprite: /Textures/_Nuclear14/Tiles/metalbluesolid.png
-  baseTurf: FloorWasteland
+  baseTurf: Plating #Floofstation
   isSubfloor: false
   deconstructTools: [ Prying ]
   footstepSounds:
@@ -27,13 +27,13 @@
   itemDrop: FloorTileItemMetalBlueSolid
   thermalConductivity: 0.04
   heatCapacity: 10000
-  weather: true
+  weather: false #floofstation
 
 - type: tile
   id: FloorMetalGreen
   name: metal green
   sprite: /Textures/_Nuclear14/Tiles/metalgreen.png
-  baseTurf: FloorWasteland
+  baseTurf: Plating #Floofstation
   isSubfloor: false
   deconstructTools: [ Prying ]
   footstepSounds:
@@ -42,13 +42,13 @@
   itemDrop: FloorTileItemMetalGreen
   thermalConductivity: 0.04
   heatCapacity: 10000
-  weather: true
+  weather: false #floofstation
 
 - type: tile
   id: FloorMetalGreenSolid
   name: metal green solid
   sprite: /Textures/_Nuclear14/Tiles/metalgreensolid.png
-  baseTurf: FloorWasteland
+  baseTurf: Plating #Floofstation
   isSubfloor: false
   deconstructTools: [ Prying ]
   footstepSounds:
@@ -57,13 +57,13 @@
   itemDrop: FloorTileItemMetalGreenSolid
   thermalConductivity: 0.04
   heatCapacity: 10000
-  weather: true
+  weather: false #floofstation
 
 - type: tile
   id: FloorMetalGrey
   name: metal grey
   sprite: /Textures/_Nuclear14/Tiles/metalgrey.png
-  baseTurf: FloorWasteland
+  baseTurf: Plating #Floofstation
   isSubfloor: false
   deconstructTools: [ Prying ]
   footstepSounds:
@@ -72,13 +72,13 @@
   itemDrop: FloorTileItemMetalGrey
   thermalConductivity: 0.04
   heatCapacity: 10000
-  weather: true
+  weather: false #floofstation
 
 - type: tile
   id: FloorMetalGreySolid
   name: metal grey solid
   sprite: /Textures/_Nuclear14/Tiles/metalgreysolid.png
-  baseTurf: FloorWasteland
+  baseTurf: Plating #Floofstation
   isSubfloor: false
   deconstructTools: [ Prying ]
   footstepSounds:
@@ -87,13 +87,13 @@
   itemDrop: FloorTileItemMetalGreySolid
   thermalConductivity: 0.04
   heatCapacity: 10000
-  weather: true
+  weather: false #floofstation
 
 - type: tile
   id: FloorMetalGreyDark
   name: metal grey dark
   sprite: /Textures/_Nuclear14/Tiles/metalgreydark.png
-  baseTurf: FloorWasteland
+  baseTurf: Plating #Floofstation
   isSubfloor: false
   deconstructTools: [ Prying ]
   footstepSounds:
@@ -102,13 +102,13 @@
   itemDrop: FloorTileItemMetalGreyDark
   thermalConductivity: 0.04
   heatCapacity: 10000
-  weather: true
+  weather: false #floofstation
 
 - type: tile
   id: FloorMetalGreyDarkSolid
   name: metal grey dark solid
   sprite: /Textures/_Nuclear14/Tiles/metalgreydarksolid.png
-  baseTurf: FloorWasteland
+  baseTurf: Plating #Floofstation
   isSubfloor: false
   deconstructTools: [ Prying ]
   footstepSounds:
@@ -117,13 +117,13 @@
   itemDrop: FloorTileItemMetalGreyDarkSolid
   thermalConductivity: 0.04
   heatCapacity: 10000
-  weather: true
+  weather: false #floofstation
 
 - type: tile
   id: FloorMetalPurple
   name: metal purple
   sprite: /Textures/_Nuclear14/Tiles/metalpurple.png
-  baseTurf: FloorWasteland
+  baseTurf: Plating #Floofstation
   isSubfloor: false
   deconstructTools: [ Prying ]
   footstepSounds:
@@ -132,13 +132,13 @@
   itemDrop: FloorTileItemMetalPurple
   thermalConductivity: 0.04
   heatCapacity: 10000
-  weather: true
+  weather: false #floofstation
 
 - type: tile
   id: FloorMetalPurpleSolid
   name: metal purple solid
   sprite: /Textures/_Nuclear14/Tiles/metalpurplesolid.png
-  baseTurf: FloorWasteland
+  baseTurf: Plating #Floofstation
   isSubfloor: false
   deconstructTools: [ Prying ]
   footstepSounds:
@@ -147,13 +147,13 @@
   itemDrop: FloorTileItemMetalPurpleSolid
   thermalConductivity: 0.04
   heatCapacity: 10000
-  weather: true
+  weather: false #floofstation
 
 - type: tile
   id: FloorMetalRed
   name: metal red
   sprite: /Textures/_Nuclear14/Tiles/metalred.png
-  baseTurf: FloorWasteland
+  baseTurf: Plating #Floofstation
   isSubfloor: false
   deconstructTools: [ Prying ]
   footstepSounds:
@@ -162,13 +162,13 @@
   itemDrop: FloorTileItemMetalRed
   thermalConductivity: 0.04
   heatCapacity: 10000
-  weather: true
+  weather: false #floofstation
 
 - type: tile
   id: FloorMetalRedSolid
   name: metal red solid
   sprite: /Textures/_Nuclear14/Tiles/metalredsolid.png
-  baseTurf: FloorWasteland
+  baseTurf: Plating #Floofstation
   isSubfloor: false
   deconstructTools: [ Prying ]
   footstepSounds:
@@ -177,13 +177,13 @@
   itemDrop: FloorTileItemMetalRedSolid
   thermalConductivity: 0.04
   heatCapacity: 10000
-  weather: true
+  weather: false #floofstation
 
 - type: tile
   id: FloorMetalTeal
   name: metal teal
   sprite: /Textures/_Nuclear14/Tiles/metalteal.png
-  baseTurf: FloorWasteland
+  baseTurf: Plating #Floofstation
   isSubfloor: false
   deconstructTools: [ Prying ]
   footstepSounds:
@@ -192,13 +192,13 @@
   itemDrop: FloorTileItemMetalTeal
   thermalConductivity: 0.04
   heatCapacity: 10000
-  weather: true
+  weather: false #floofstation
 
 - type: tile
   id: FloorMetalTealSolid
   name: metal teal solid
   sprite: /Textures/_Nuclear14/Tiles/metaltealsolid.png
-  baseTurf: FloorWasteland
+  baseTurf: Plating #Floofstation
   isSubfloor: false
   deconstructTools: [ Prying ]
   footstepSounds:
@@ -207,13 +207,13 @@
   itemDrop: FloorTileItemMetalTealSolid
   thermalConductivity: 0.04
   heatCapacity: 10000
-  weather: true
+  weather: false #floofstation
 
 - type: tile
   id: FloorMetalWhite
   name: metal white
   sprite: /Textures/_Nuclear14/Tiles/metalwhite.png
-  baseTurf: FloorWasteland
+  baseTurf: Plating #Floofstation
   isSubfloor: false
   deconstructTools: [ Prying ]
   footstepSounds:
@@ -222,13 +222,13 @@
   itemDrop: FloorTileItemMetalWhite
   thermalConductivity: 0.04
   heatCapacity: 10000
-  weather: true
+  weather: false #floofstation
 
 - type: tile
   id: FloorMetalWhiteSolid
   name: metal white solid
   sprite: /Textures/_Nuclear14/Tiles/metalwhitesolid.png
-  baseTurf: FloorWasteland
+  baseTurf: Plating #Floofstation
   isSubfloor: false
   deconstructTools: [ Prying ]
   footstepSounds:
@@ -237,13 +237,13 @@
   itemDrop: FloorTileItemMetalWhiteSolid
   thermalConductivity: 0.04
   heatCapacity: 10000
-  weather: true
+  weather: false #floofstation
 
 - type: tile
   id: FloorMetalYellow
   name: metal yellow
   sprite: /Textures/_Nuclear14/Tiles/metalyellow.png
-  baseTurf: FloorWasteland
+  baseTurf: Plating #Floofstation
   isSubfloor: false
   deconstructTools: [ Prying ]
   footstepSounds:
@@ -252,13 +252,13 @@
   itemDrop: FloorTileItemMetalYellow
   thermalConductivity: 0.04
   heatCapacity: 10000
-  weather: true
+  weather: false #floofstation
 
 - type: tile
   id: FloorMetalYellowSolid
   name: metal yellow solid
   sprite: /Textures/_Nuclear14/Tiles/metalyellowsolid.png
-  baseTurf: FloorWasteland
+  baseTurf: Plating #Floofstation
   isSubfloor: false
   deconstructTools: [ Prying ]
   footstepSounds:
@@ -267,13 +267,13 @@
   itemDrop: FloorTileItemMetalYellowSolid
   thermalConductivity: 0.04
   heatCapacity: 10000
-  weather: true
+  weather: false #floofstation
 
 - type: tile
   id: FloorMetalFreezer
   name: metal freezer
   sprite: /Textures/_Nuclear14/Tiles/metalfreezer.png
-  baseTurf: FloorWasteland
+  baseTurf: Plating #Floofstation
   isSubfloor: false
   deconstructTools: [ Prying ]
   footstepSounds:
@@ -282,13 +282,13 @@
   itemDrop: FloorTileItemMetalFreezer
   thermalConductivity: 0.04
   heatCapacity: 10000
-  weather: true
+  weather: false #floofstation
 
 - type: tile
   id: FloorMetalTunnel
   name: tunnel floor
   sprite: /Textures/_Nuclear14/Tiles/tunnelintact.png
-  baseTurf: FloorWasteland
+  baseTurf: Plating #Floofstation
   isSubfloor: true
   deconstructTools: [ Prying ]
   footstepSounds:
@@ -296,13 +296,13 @@
   friction: 0.30
   thermalConductivity: 0.04
   heatCapacity: 10000
-  weather: true
+  weather: false #floofstation
 
 - type: tile
   id: FloorMetalTunnelRusty
   name: rusty tunnel floor
   sprite: /Textures/_Nuclear14/Tiles/tunnelrusty.png
-  baseTurf: FloorWasteland
+  baseTurf: Plating #Floofstation
   isSubfloor: true
   deconstructTools: [ Prying ]
   footstepSounds:
@@ -310,7 +310,7 @@
   friction: 0.30
   thermalConductivity: 0.04
   heatCapacity: 10000
-  weather: true
+  weather: false #floofstation
 
 - type: tile
   id: FloorMetalTunnelWasteland
@@ -318,7 +318,7 @@
   sprite: /Textures/_Nuclear14/Tiles/tunnelwasteland.png
   variants: 11
   placementVariants: [0, 1, 2, 3, 5, 6, 7, 8, 9, 10]
-  baseTurf: FloorWasteland
+  baseTurf: Plating #Floofstation
   isSubfloor: true
   deconstructTools: [ Prying ]
   footstepSounds:
@@ -326,7 +326,7 @@
   friction: 0.30
   thermalConductivity: 0.04
   heatCapacity: 10000
-  weather: true
+  weather: false #floofstation
 
 # MS13 Metal Tiles
 - type: tile
@@ -335,7 +335,7 @@
   sprite: /Textures/_Nuclear14/Tiles/ms13/Steel/steel_industrial.png
   variants: 8
   placementVariants: [0, 1, 2, 3, 4, 5, 6, 7]
-  baseTurf: FloorWasteland
+  baseTurf: Plating #Floofstation
   isSubfloor: false
   deconstructTools: [ Prying ]
   itemDrop: FloorTileItemMetalIndustrial
@@ -344,7 +344,7 @@
   friction: 0.30
   thermalConductivity: 0.04
   heatCapacity: 10000
-  weather: true
+  weather: false #floofstation
 
 - type: tile
   id: FloorMS13MetalTile
@@ -352,7 +352,7 @@
   sprite: /Textures/_Nuclear14/Tiles/ms13/Steel/steel_tiles.png
   variants: 8
   placementVariants: [0, 1, 2, 3, 4, 5, 6, 7]
-  baseTurf: FloorWasteland
+  baseTurf: Plating #Floofstation
   isSubfloor: false
   deconstructTools: [ Prying ]
   itemDrop: FloorTileItemMetalMS13
@@ -361,7 +361,7 @@
   friction: 0.30
   thermalConductivity: 0.04
   heatCapacity: 10000
-  weather: true
+  weather: false #floofstation
 
 - type: tile
   id: FloorMS13MetalGrate
@@ -369,7 +369,7 @@
   sprite: /Textures/_Nuclear14/Tiles/ms13/Steel/steel_grate.png
   variants: 8
   placementVariants: [0, 1, 2, 3, 4, 5, 6, 7]
-  baseTurf: FloorWasteland
+  baseTurf: Plating #Floofstation
   isSubfloor: false
   deconstructTools: [ Prying ]
   itemDrop: FloorTileItemMetalGrate
@@ -378,7 +378,7 @@
   friction: 0.30
   thermalConductivity: 0.04
   heatCapacity: 10000
-  weather: true
+  weather: false #floofstation
 
 - type: tile
   id: FloorMS13MetalSolid
@@ -386,7 +386,7 @@
   sprite: /Textures/_Nuclear14/Tiles/ms13/Steel/steel_solid.png
   variants: 4
   placementVariants: [0, 1, 2, 3]
-  baseTurf: FloorWasteland
+  baseTurf: Plating #Floofstation
   isSubfloor: false
   deconstructTools: [ Prying ]
   itemDrop: FloorTileItemMetalSolid
@@ -395,7 +395,7 @@
   friction: 0.30
   thermalConductivity: 0.04
   heatCapacity: 10000
-  weather: true
+  weather: false #floofstation
 
 # Interior
 - type: tile
@@ -404,7 +404,7 @@
   sprite: /Textures/_Nuclear14/Tiles/oak.png
   variants: 4
   placementVariants: [0, 1, 2, 3]
-  baseTurf: FloorWasteland
+  baseTurf: Plating #Floofstation
   isSubfloor: false
   deconstructTools: [ Prying ]
   footstepSounds:
@@ -421,7 +421,7 @@
   sprite: /Textures/_Nuclear14/Tiles/oakbroken.png
   variants: 4
   placementVariants: [0, 1, 2, 3]
-  baseTurf: FloorWasteland
+  baseTurf: Plating #Floofstation
   isSubfloor: false
   deconstructTools: [ Prying ]
   footstepSounds:
@@ -429,7 +429,7 @@
   friction: 0.30
   thermalConductivity: 0.04
   heatCapacity: 10000
-  weather: true # We allow weather here because it's a broken tile
+  weather: false #floofstation # We allow weather here because it's a broken tile
 
 - type: tile
   id: FloorWoodHouse
@@ -437,7 +437,7 @@
   sprite: /Textures/_Nuclear14/Tiles/woodhouse.png
   variants: 4
   placementVariants: [0, 1, 2, 3]
-  baseTurf: FloorWasteland
+  baseTurf: Plating #Floofstation
   isSubfloor: false
   deconstructTools: [ Prying ]
   footstepSounds:
@@ -454,7 +454,7 @@
   sprite: /Textures/_Nuclear14/Tiles/woodhousebroken.png
   variants: 2
   placementVariants: [0, 1]
-  baseTurf: FloorWasteland
+  baseTurf: Plating #Floofstation
   isSubfloor: false
   deconstructTools: [ Prying ]
   footstepSounds:
@@ -462,7 +462,7 @@
   friction: 0.30
   thermalConductivity: 0.04
   heatCapacity: 10000
-  weather: true
+  weather: false #floofstation
 
 - type: tile
   id: FloorWoodBurntBroken
@@ -470,7 +470,7 @@
   sprite: /Textures/_Nuclear14/Tiles/woodburntbroken.png
   variants: 7
   placementVariants: [0, 1, 2, 3, 4, 5, 6]
-  baseTurf: FloorWasteland
+  baseTurf: Plating #Floofstation
   isSubfloor: false
   deconstructTools: [ Prying ]
   footstepSounds:
@@ -478,7 +478,7 @@
   friction: 0.30
   thermalConductivity: 0.04
   heatCapacity: 10000
-  weather: true
+  weather: false #floofstation
 
 - type: tile
   id: FloorWoodMaple
@@ -486,7 +486,7 @@
   sprite: /Textures/_Nuclear14/Tiles/maple.png
   variants: 4
   placementVariants: [0, 1, 2, 3]
-  baseTurf: FloorWasteland
+  baseTurf: Plating #Floofstation
   isSubfloor: false
   deconstructTools: [ Prying ]
   footstepSounds:
@@ -504,7 +504,7 @@
   sprite: /Textures/_Nuclear14/Tiles/ms13/Wood/wood_common.png
   variants: 4
   placementVariants: [0, 1, 2, 3]
-  baseTurf: FloorWasteland
+  baseTurf: Plating #Floofstation
   isSubfloor: false
   deconstructTools: [ Prying ]
   footstepSounds:
@@ -521,7 +521,7 @@
   sprite: /Textures/_Nuclear14/Tiles/ms13/Wood/wood_common_damaged.png
   variants: 4
   placementVariants: [0, 1, 2, 3]
-  baseTurf: FloorWasteland
+  baseTurf: Plating #Floofstation
   isSubfloor: false
   deconstructTools: [ Prying ]
   footstepSounds:
@@ -530,7 +530,7 @@
   # itemDrop: FloorTileItemWoodMaple
   thermalConductivity: 0.04
   heatCapacity: 10000
-  weather: true # We allow weather here because it's a damaged tile
+  weather: false #floofstation # We allow weather here because it's a damaged tile
 
 - type: tile
   id: FloorMS13WoodFancy
@@ -538,7 +538,7 @@
   sprite: /Textures/_Nuclear14/Tiles/ms13/Wood/wood_fancy.png
   variants: 4
   placementVariants: [0, 1, 2, 3]
-  baseTurf: FloorWasteland
+  baseTurf: Plating #Floofstation
   isSubfloor: false
   deconstructTools: [ Prying ]
   footstepSounds:
@@ -555,7 +555,7 @@
   sprite: /Textures/_Nuclear14/Tiles/ms13/Wood/wood_fancy_damaged.png
   variants: 4
   placementVariants: [0, 1, 2, 3]
-  baseTurf: FloorWasteland
+  baseTurf: Plating #Floofstation
   isSubfloor: false
   deconstructTools: [ Prying ]
   footstepSounds:
@@ -564,7 +564,7 @@
   # itemDrop: FloorTileItemWoodMaple
   thermalConductivity: 0.04
   heatCapacity: 10000
-  weather: true
+  weather: false #floofstation
 
 - type: tile
   id: FloorMS13WoodMosaic
@@ -572,7 +572,7 @@
   sprite: /Textures/_Nuclear14/Tiles/ms13/Wood/wood_mosaic.png
   variants: 4
   placementVariants: [0, 1, 2, 3]
-  baseTurf: FloorWasteland
+  baseTurf: Plating #Floofstation
   isSubfloor: false
   deconstructTools: [ Prying ]
   footstepSounds:
@@ -589,7 +589,7 @@
   sprite: /Textures/_Nuclear14/Tiles/ms13/Wood/wood_mosaic_damaged.png
   variants: 4
   placementVariants: [0, 1, 2, 3]
-  baseTurf: FloorWasteland
+  baseTurf: Plating #Floofstation
   isSubfloor: false
   deconstructTools: [ Prying ]
   footstepSounds:
@@ -598,7 +598,7 @@
   # itemDrop: FloorTileItemWoodMaple
   thermalConductivity: 0.04
   heatCapacity: 10000
-  weather: true
+  weather: false #floofstation
 
 - type: tile
   id: FloorMS13WoodWide
@@ -606,7 +606,7 @@
   sprite: /Textures/_Nuclear14/Tiles/ms13/Wood/wood_wide.png
   variants: 4
   placementVariants: [0, 1, 2, 3]
-  baseTurf: FloorWasteland
+  baseTurf: Plating #Floofstation
   isSubfloor: false
   deconstructTools: [ Prying ]
   footstepSounds:
@@ -615,7 +615,7 @@
   # itemDrop: FloorTileItemWoodMaple
   thermalConductivity: 0.04
   heatCapacity: 10000
-  weather: true
+  weather: false #floofstation
 
 - type: tile
   id: FloorMS13WoodWideDamaged
@@ -623,7 +623,7 @@
   sprite: /Textures/_Nuclear14/Tiles/ms13/Wood/wood_wide_damaged.png
   variants: 4
   placementVariants: [0, 1, 2, 3]
-  baseTurf: FloorWasteland
+  baseTurf: Plating #Floofstation
   isSubfloor: false
   deconstructTools: [ Prying ]
   footstepSounds:
@@ -632,14 +632,14 @@
   # itemDrop: FloorTileItemWoodMaple
   thermalConductivity: 0.04
   heatCapacity: 10000
-  weather: true
+  weather: false #floofstation
 
 # Carpet
 - type: tile
   id: FloorCarpetRed
   name: carpet red
   sprite: /Textures/_Nuclear14/Tiles/carpet.png
-  baseTurf: FloorWasteland
+  baseTurf: Plating #Floofstation
   isSubfloor: false
   deconstructTools: [ Prying ]
   footstepSounds:
@@ -655,7 +655,7 @@
   id: FloorMS13CarpetRed
   name: ms13 carpet red
   sprite: /Textures/_Nuclear14/Tiles/ms13/Carpet/carpet_red.png
-  baseTurf: FloorWasteland
+  baseTurf: Plating #Floofstation
   isSubfloor: false
   deconstructTools: [ Prying ]
   footstepSounds:
@@ -664,13 +664,13 @@
   # itemDrop: FloorTileItemCarpetRed
   thermalConductivity: 0.04
   heatCapacity: 10000
-  weather: true
+  weather: false #floofstation
 
 - type: tile
   id: FloorMS13CarpetFancyRed
   name: ms13 carpet fancy red
   sprite: /Textures/_Nuclear14/Tiles/ms13/Carpet/carpet_fancy_red.png
-  baseTurf: FloorWasteland
+  baseTurf: Plating #Floofstation
   isSubfloor: false
   deconstructTools: [ Prying ]
   footstepSounds:
@@ -679,13 +679,13 @@
   # itemDrop: FloorTileItemCarpetRed
   thermalConductivity: 0.04
   heatCapacity: 10000
-  weather: true
+  weather: false #floofstation
 
 - type: tile
   id: FloorMS13CarpetBlue
   name: ms13 carpet blue
   sprite: /Textures/_Nuclear14/Tiles/ms13/Carpet/carpet_blue.png
-  baseTurf: FloorWasteland
+  baseTurf: Plating #Floofstation
   isSubfloor: false
   deconstructTools: [ Prying ]
   footstepSounds:
@@ -694,13 +694,13 @@
   # itemDrop: FloorTileItemCarpetRed
   thermalConductivity: 0.04
   heatCapacity: 10000
-  weather: true
+  weather: false #floofstation
 
 - type: tile
   id: FloorMS13CarpetFancyBlue
   name: ms13 carpet fancy blue
   sprite: /Textures/_Nuclear14/Tiles/ms13/Carpet/carpet_fancy_blue.png
-  baseTurf: FloorWasteland
+  baseTurf: Plating #Floofstation
   isSubfloor: false
   deconstructTools: [ Prying ]
   footstepSounds:
@@ -709,13 +709,13 @@
   # itemDrop: FloorTileItemCarpetRed
   thermalConductivity: 0.04
   heatCapacity: 10000
-  weather: true
+  weather: false #floofstation
 
 - type: tile
   id: FloorMS13CarpetGreen
   name: ms13 carpet green
   sprite: /Textures/_Nuclear14/Tiles/ms13/Carpet/carpet_green.png
-  baseTurf: FloorWasteland
+  baseTurf: Plating #Floofstation
   isSubfloor: false
   deconstructTools: [ Prying ]
   footstepSounds:
@@ -724,13 +724,13 @@
   # itemDrop: FloorTileItemCarpetRed
   thermalConductivity: 0.04
   heatCapacity: 10000
-  weather: true
+  weather: false #floofstation
 
 - type: tile
   id: FloorMS13CarpetFancyGreen
   name: ms13 carpet fancy green
   sprite: /Textures/_Nuclear14/Tiles/ms13/Carpet/carpet_fancy_green.png
-  baseTurf: FloorWasteland
+  baseTurf: Plating #Floofstation
   isSubfloor: false
   deconstructTools: [ Prying ]
   footstepSounds:
@@ -739,13 +739,13 @@
   # itemDrop: FloorTileItemCarpetRed
   thermalConductivity: 0.04
   heatCapacity: 10000
-  weather: true
+  weather: false #floofstation
 
 - type: tile
   id: FloorMS13CarpetViolet
   name: ms13 carpet violet
   sprite: /Textures/_Nuclear14/Tiles/ms13/Carpet/carpet_violet.png
-  baseTurf: FloorWasteland
+  baseTurf: Plating #Floofstation
   isSubfloor: false
   deconstructTools: [ Prying ]
   footstepSounds:
@@ -754,7 +754,7 @@
   # itemDrop: FloorTileItemCarpetRed
   thermalConductivity: 0.04
   heatCapacity: 10000
-  weather: true
+  weather: false #floofstation
 
 # Paths and Roads
 # Concrete
@@ -764,69 +764,69 @@
   sprite: /Textures/_Nuclear14/Tiles/concrete.png
   variants: 6
   placementVariants: [0, 1, 2, 3, 4, 5]
-  baseTurf: FloorWasteland
+  baseTurf: Plating #Floofstation
   isSubfloor: true
   footstepSounds:
     collection: N14FootstepConcrete
   friction: 0.30
   thermalConductivity: 0.04
   heatCapacity: 10000
-  weather: true
+  weather: false #floofstation
 
 - type: tile
   id: N14FloorConcreteTileGoon
   name: concrete tile
   sprite: /Textures/_Nuclear14/Tiles/concrete-goon.png
   variants: 1
-  baseTurf: FloorWasteland
+  baseTurf: Plating #Floofstation
   isSubfloor: true
   footstepSounds:
     collection: N14FootstepConcrete
   friction: 0.30
   thermalConductivity: 0.04
   heatCapacity: 10000
-  weather: true
+  weather: false #floofstation
 
 - type: tile
   id: N14FloorConcreteGreyBay
   name: concrete grey
   sprite: /Textures/_Nuclear14/Tiles/concrete-bay.png
   variants: 1
-  baseTurf: FloorWasteland
+  baseTurf: Plating #Floofstation
   isSubfloor: true
   footstepSounds:
     collection: N14FootstepConcrete
   friction: 0.30
   thermalConductivity: 0.04
   heatCapacity: 10000
-  weather: true
+  weather: false #floofstation
 
 - type: tile
   id: N14FloorConcreteHexacrete
   name: concrete hexacrete
   sprite: /Textures/_Nuclear14/Tiles/hexacrete.png
   variants: 1
-  baseTurf: FloorWasteland
+  baseTurf: Plating #Floofstation
   isSubfloor: true
   footstepSounds:
     collection: N14FootstepConcrete
   friction: 0.30
   thermalConductivity: 0.04
   heatCapacity: 10000
-  weather: true
+  weather: false #floofstation
 
 - type: tile
   id: N14FloorConcreteHexacreteDark
   name: concrete hexacrete dark
   sprite: /Textures/_Nuclear14/Tiles/hexacrete_dark.png
-  baseTurf: FloorWasteland
+  baseTurf: Plating #Floofstation
   isSubfloor: true
   footstepSounds:
     collection: N14FootstepConcrete
   friction: 0.30
   thermalConductivity: 0.04
   heatCapacity: 10000
-  weather: true
+  weather: false #floofstation
 
 - type: tile
   id: N14FloorConcreteDark
@@ -834,14 +834,14 @@
   sprite: /Textures/_Nuclear14/Tiles/concretedark.png
   variants: 6
   placementVariants: [0, 1, 2, 3, 4, 5]
-  baseTurf: FloorWasteland
+  baseTurf: Plating #Floofstation
   isSubfloor: true
   footstepSounds:
     collection: N14FootstepConcrete
   friction: 0.30
   thermalConductivity: 0.04
   heatCapacity: 10000
-  weather: true
+  weather: false #floofstation
 
 - type: tile
   id: N14FloorConcreteRoad
@@ -849,14 +849,14 @@
   sprite: /Textures/_Nuclear14/Tiles/concreteroad.png
   variants: 6
   placementVariants: [0, 1, 2, 3, 4, 5]
-  baseTurf: FloorWasteland
+  baseTurf: Plating #Floofstation
   isSubfloor: true
   footstepSounds:
     collection: N14FootstepConcrete
   friction: 0.30
   thermalConductivity: 0.04
   heatCapacity: 10000
-  weather: true
+  weather: false #floofstation
 
 # MS13 Concrete & Brick
 - type: tile
@@ -865,14 +865,14 @@
   sprite: /Textures/_Nuclear14/Tiles/ms13/Concrete/brickconcrete.png
   variants: 9
   placementVariants: [0, 1, 2, 3, 4, 5, 6, 7, 8]
-  baseTurf: FloorWasteland
+  baseTurf: Plating #Floofstation
   isSubfloor: true
   footstepSounds:
     collection: N14FootstepConcreteBroken
   friction: 0.30
   thermalConductivity: 0.04
   heatCapacity: 10000
-  weather: true
+  weather: false #floofstation
 
 - type: tile
   id: FloorMS13BrickHorizontal
@@ -880,7 +880,7 @@
   sprite: /Textures/_Nuclear14/Tiles/ms13/Brick/brickhorizontal.png
   variants: 9
   placementVariants: [0, 1, 2, 3, 4, 5, 6, 7, 8]
-  baseTurf: FloorWasteland
+  baseTurf: Plating #Floofstation
   isSubfloor: true
   footstepSounds:
     collection: N14FootstepConcreteBroken
@@ -894,66 +894,66 @@
   sprite: /Textures/_Nuclear14/Tiles/ms13/Brick/brickvertical.png
   variants: 9
   placementVariants: [0, 1, 2, 3, 4, 5, 6, 7, 8]
-  baseTurf: FloorWasteland
+  baseTurf: Plating #Floofstation
   isSubfloor: true
   footstepSounds:
     collection: N14FootstepConcreteBroken
   friction: 0.30
   thermalConductivity: 0.04
   heatCapacity: 10000
-  weather: true
+  weather: false #floofstation
 
 - type: tile
   id: FloorMS13Concrete
   name: ms13 concrete
   sprite: /Textures/_Nuclear14/Tiles/ms13/Concrete/concrete_big.png
-  baseTurf: FloorWasteland
+  baseTurf: Plating #Floofstation
   isSubfloor: true
   footstepSounds:
     collection: N14FootstepConcrete
   friction: 0.30
   thermalConductivity: 0.04
   heatCapacity: 10000
-  weather: true
+  weather: false #floofstation
 
 - type: tile
   id: FloorMS13ConcreteIndustrial
   name: ms13 concrete industrial
   sprite: /Textures/_Nuclear14/Tiles/ms13/Concrete/concrete_industrial.png
-  baseTurf: FloorWasteland
+  baseTurf: Plating #Floofstation
   isSubfloor: true
   footstepSounds:
     collection: N14FootstepConcrete
   friction: 0.30
   thermalConductivity: 0.04
   heatCapacity: 10000
-  weather: true
+  weather: false #floofstation
 
 - type: tile
   id: FloorMS13ConcreteIndustrialAlt
   name: ms13 concrete industrial alt
   sprite: /Textures/_Nuclear14/Tiles/ms13/Concrete/concrete_industrial_alt.png
-  baseTurf: FloorWasteland
+  baseTurf: Plating #Floofstation
   isSubfloor: true
   footstepSounds:
     collection: N14FootstepConcrete
   friction: 0.30
   thermalConductivity: 0.04
   heatCapacity: 10000
-  weather: true
+  weather: false #floofstation
 
 - type: tile
   id: FloorMS13ConcreteIndustrialSplit
   name: ms13 concrete industrial split
   sprite: /Textures/_Nuclear14/Tiles/ms13/Concrete/concrete_industrial_split.png
-  baseTurf: FloorWasteland
+  baseTurf: Plating #Floofstation
   isSubfloor: true
   footstepSounds:
     collection: N14FootstepConcrete
   friction: 0.30
   thermalConductivity: 0.04
   heatCapacity: 10000
-  weather: true
+  weather: false #floofstation
 
 - type: tile
   id: FloorMS13TileConcreteSmall
@@ -961,41 +961,41 @@
   sprite: /Textures/_Nuclear14/Tiles/ms13/Concrete/tileconcretesmall.png
   variants: 3
   placementVariants: [0, 1, 2]
-  baseTurf: FloorWasteland
+  baseTurf: Plating #Floofstation
   isSubfloor: true
   footstepSounds:
     collection: N14FootstepConcrete
   friction: 0.30
   thermalConductivity: 0.04
   heatCapacity: 10000
-  weather: true
+  weather: false #floofstation
 
 # MS13 Tiles
 - type: tile
   id: FloorMS13TileFancy
   name: ms13 tile fancy
   sprite: /Textures/_Nuclear14/Tiles/ms13/fancy.png
-  baseTurf: FloorWasteland
+  baseTurf: Plating #Floofstation
   isSubfloor: false
   footstepSounds:
     collection: N14FootstepConcrete
   friction: 0.30
   thermalConductivity: 0.04
   heatCapacity: 10000
-  weather: true
+  weather: false #floofstation
 
 - type: tile
   id: FloorMS13TileSierra
   name: ms13 tile sierra
   sprite: /Textures/_Nuclear14/Tiles/ms13/sierra.png
-  baseTurf: FloorWasteland
+  baseTurf: Plating #Floofstation
   isSubfloor: false
   footstepSounds:
     collection: N14FootstepConcrete
   friction: 0.30
   thermalConductivity: 0.04
   heatCapacity: 10000
-  weather: true
+  weather: false #floofstation
 
 - type: tile
   id: FloorMS13TileSierraBroken
@@ -1003,14 +1003,14 @@
   sprite: /Textures/_Nuclear14/Tiles/ms13/sierrabroken.png
   variants: 3
   placementVariants: [0, 1, 2]
-  baseTurf: FloorWasteland
+  baseTurf: Plating #Floofstation
   isSubfloor: false
   footstepSounds:
     collection: N14FootstepConcreteBroken
   friction: 0.30
   thermalConductivity: 0.04
   heatCapacity: 10000
-  weather: true
+  weather: false #floofstation
 
 - type: tile
   id: FloorMS13TileBlack
@@ -1018,14 +1018,14 @@
   sprite: /Textures/_Nuclear14/Tiles/ms13/Small/tileblack.png
   variants: 8
   placementVariants: [0, 1, 2, 3, 4, 5, 6, 7]
-  baseTurf: FloorWasteland
+  baseTurf: Plating #Floofstation
   isSubfloor: false
   footstepSounds:
     collection: FootstepFloor
   friction: 0.30
   thermalConductivity: 0.04
   heatCapacity: 10000
-  weather: true
+  weather: false #floofstation
 
 - type: tile
   id: FloorMS13TileBlackFull
@@ -1033,14 +1033,14 @@
   sprite: /Textures/_Nuclear14/Tiles/ms13/Full/tileblackfull.png
   variants: 8
   placementVariants: [0, 1, 2, 3, 4, 5, 6, 7]
-  baseTurf: FloorWasteland
+  baseTurf: Plating #Floofstation
   isSubfloor: false
   footstepSounds:
     collection: FootstepFloor
   friction: 0.30
   thermalConductivity: 0.04
   heatCapacity: 10000
-  weather: true
+  weather: false #floofstation
 
 - type: tile
   id: FloorMS13TileBlackLarge
@@ -1048,7 +1048,7 @@
   sprite: /Textures/_Nuclear14/Tiles/ms13/Large/tileblacklarge.png
   variants: 8
   placementVariants: [0, 1, 2, 3, 4, 5, 6, 7]
-  baseTurf: FloorWasteland
+  baseTurf: Plating #Floofstation
   isSubfloor: false
   footstepSounds:
     collection: FootstepFloor
@@ -1063,14 +1063,14 @@
   sprite: /Textures/_Nuclear14/Tiles/ms13/Long/tilebluelong.png
   variants: 8
   placementVariants: [0, 1, 2, 3, 4, 5, 6, 7]
-  baseTurf: FloorWasteland
+  baseTurf: Plating #Floofstation
   isSubfloor: false
   footstepSounds:
     collection: FootstepFloor
   friction: 0.30
   thermalConductivity: 0.04
   heatCapacity: 10000
-  weather: true
+  weather: false #floofstation
 
 - type: tile
   id: FloorMS13TileBrown
@@ -1078,14 +1078,14 @@
   sprite: /Textures/_Nuclear14/Tiles/ms13/Small/tilebrown.png
   variants: 8
   placementVariants: [0, 1, 2, 3, 4, 5, 6, 7]
-  baseTurf: FloorWasteland
+  baseTurf: Plating #Floofstation
   isSubfloor: false
   footstepSounds:
     collection: FootstepFloor
   friction: 0.30
   thermalConductivity: 0.04
   heatCapacity: 10000
-  weather: true
+  weather: false #floofstation
 
 - type: tile
   id: FloorMS13TileCafe
@@ -1093,27 +1093,27 @@
   sprite: /Textures/_Nuclear14/Tiles/ms13/Large/tilecafe.png
   variants: 8
   placementVariants: [0, 1, 2, 3, 4, 5, 6, 7]
-  baseTurf: FloorWasteland
+  baseTurf: Plating #Floofstation
   isSubfloor: false
   footstepSounds:
     collection: FootstepFloor
   friction: 0.30
   thermalConductivity: 0.04
   heatCapacity: 10000
-  weather: true
+  weather: false #floofstation
 
 - type: tile
   id: FloorMS13TileCeramic
   name: ms13 tile ceramic
   sprite: /Textures/_Nuclear14/Tiles/ms13/Large/tileceramic.png
-  baseTurf: FloorWasteland
+  baseTurf: Plating #Floofstation
   isSubfloor: false
   footstepSounds:
     collection: FootstepFloor
   friction: 0.30
   thermalConductivity: 0.04
   heatCapacity: 10000
-  weather: true
+  weather: false #floofstation
 
 - type: tile
   id: FloorMS13TileCeramicBroken
@@ -1121,14 +1121,14 @@
   sprite: /Textures/_Nuclear14/Tiles/ms13/Large/tileceramicbroken.png
   variants: 7
   placementVariants: [0, 1, 2, 3, 4, 5, 6]
-  baseTurf: FloorWasteland
+  baseTurf: Plating #Floofstation
   isSubfloor: false
   footstepSounds:
     collection: FootstepFloor
   friction: 0.30
   thermalConductivity: 0.04
   heatCapacity: 10000
-  weather: true
+  weather: false #floofstation
 
 - type: tile
   id: FloorMS13TileCheck
@@ -1136,14 +1136,14 @@
   sprite: /Textures/_Nuclear14/Tiles/ms13/Large/tilecheck.png
   variants: 8
   placementVariants: [0, 1, 2, 3, 4, 5, 6, 7]
-  baseTurf: FloorWasteland
+  baseTurf: Plating #Floofstation
   isSubfloor: false
   footstepSounds:
     collection: FootstepFloor
   friction: 0.30
   thermalConductivity: 0.04
   heatCapacity: 10000
-  weather: true
+  weather: false #floofstation
 
 - type: tile
   id: FloorMS13TileGreen
@@ -1151,14 +1151,14 @@
   sprite: /Textures/_Nuclear14/Tiles/ms13/Large/tilegreen.png
   variants: 8
   placementVariants: [0, 1, 2, 3, 4, 5, 6, 7]
-  baseTurf: FloorWasteland
+  baseTurf: Plating #Floofstation
   isSubfloor: false
   footstepSounds:
     collection: FootstepFloor
   friction: 0.30
   thermalConductivity: 0.04
   heatCapacity: 10000
-  weather: true
+  weather: false #floofstation
 
 - type: tile
   id: FloorMS13TileGreenFull
@@ -1166,14 +1166,14 @@
   sprite: /Textures/_Nuclear14/Tiles/ms13/Full/tilegreenfull.png
   variants: 8
   placementVariants: [0, 1, 2, 3, 4, 5, 6, 7]
-  baseTurf: FloorWasteland
+  baseTurf: Plating #Floofstation
   isSubfloor: false
   footstepSounds:
     collection: FootstepFloor
   friction: 0.30
   thermalConductivity: 0.04
   heatCapacity: 10000
-  weather: true
+  weather: false #floofstation
 
 - type: tile
   id: FloorMS13TileGrey
@@ -1181,14 +1181,14 @@
   sprite: /Textures/_Nuclear14/Tiles/ms13/Small/tilegrey.png
   variants: 8
   placementVariants: [0, 1, 2, 3, 4, 5, 6, 7]
-  baseTurf: FloorWasteland
+  baseTurf: Plating #Floofstation
   isSubfloor: false
   footstepSounds:
     collection: FootstepFloor
   friction: 0.30
   thermalConductivity: 0.04
   heatCapacity: 10000
-  weather: true
+  weather: false #floofstation
 
 - type: tile
   id: FloorMS13TileGreyLarge
@@ -1196,14 +1196,14 @@
   sprite: /Textures/_Nuclear14/Tiles/ms13/Large/tilegreylarge.png
   variants: 8
   placementVariants: [0, 1, 2, 3, 4, 5, 6, 7]
-  baseTurf: FloorWasteland
+  baseTurf: Plating #Floofstation
   isSubfloor: false
   footstepSounds:
     collection: FootstepFloor
   friction: 0.30
   thermalConductivity: 0.04
   heatCapacity: 10000
-  weather: true
+  weather: false #floofstation
 
 - type: tile
   id: FloorMS13TileGreyLong
@@ -1211,14 +1211,14 @@
   sprite: /Textures/_Nuclear14/Tiles/ms13/Long/tilegreylong.png
   variants: 8
   placementVariants: [0, 1, 2, 3, 4, 5, 6, 7]
-  baseTurf: FloorWasteland
+  baseTurf: Plating #Floofstation
   isSubfloor: false
   footstepSounds:
     collection: FootstepFloor
   friction: 0.30
   thermalConductivity: 0.04
   heatCapacity: 10000
-  weather: true
+  weather: false #floofstation
 
 - type: tile
   id: FloorMS13TileNavy
@@ -1226,14 +1226,14 @@
   sprite: /Textures/_Nuclear14/Tiles/ms13/Small/tilenavy.png
   variants: 8
   placementVariants: [0, 1, 2, 3, 4, 5, 6, 7]
-  baseTurf: FloorWasteland
+  baseTurf: Plating #Floofstation
   isSubfloor: false
   footstepSounds:
     collection: FootstepFloor
   friction: 0.30
   thermalConductivity: 0.04
   heatCapacity: 10000
-  weather: true
+  weather: false #floofstation
 
 - type: tile
   id: FloorMS13TileNavyFull
@@ -1241,14 +1241,14 @@
   sprite: /Textures/_Nuclear14/Tiles/ms13/Full/tilenavyfull.png
   variants: 8
   placementVariants: [0, 1, 2, 3, 4, 5, 6, 7]
-  baseTurf: FloorWasteland
+  baseTurf: Plating #Floofstation
   isSubfloor: false
   footstepSounds:
     collection: FootstepFloor
   friction: 0.30
   thermalConductivity: 0.04
   heatCapacity: 10000
-  weather: true
+  weather: false #floofstation
 
 - type: tile
   id: FloorMS13TileNavyLarge
@@ -1256,14 +1256,14 @@
   sprite: /Textures/_Nuclear14/Tiles/ms13/Large/tilenavylarge.png
   variants: 8
   placementVariants: [0, 1, 2, 3, 4, 5, 6, 7]
-  baseTurf: FloorWasteland
+  baseTurf: Plating #Floofstation
   isSubfloor: false
   footstepSounds:
     collection: FootstepFloor
   friction: 0.30
   thermalConductivity: 0.04
   heatCapacity: 10000
-  weather: true
+  weather: false #floofstation
 
 - type: tile
   id: FloorMS13TileWhiteLarge
@@ -1271,14 +1271,14 @@
   sprite: /Textures/_Nuclear14/Tiles/ms13/Large/tilewhitelarge.png
   variants: 8
   placementVariants: [0, 1, 2, 3, 4, 5, 6, 7]
-  baseTurf: FloorWasteland
+  baseTurf: Plating #Floofstation
   isSubfloor: false
   footstepSounds:
     collection: FootstepFloor
   friction: 0.30
   thermalConductivity: 0.04
   heatCapacity: 10000
-  weather: true
+  weather: false #floofstation
 
 - type: tile
   id: FloorMS13TileWhiteFull
@@ -1286,14 +1286,14 @@
   sprite: /Textures/_Nuclear14/Tiles/ms13/Full/tilewhitefull.png
   variants: 8
   placementVariants: [0, 1, 2, 3, 4, 5, 6, 7]
-  baseTurf: FloorWasteland
+  baseTurf: Plating #Floofstation
   isSubfloor: false
   footstepSounds:
     collection: FootstepFloor
   friction: 0.30
   thermalConductivity: 0.04
   heatCapacity: 10000
-  weather: true
+  weather: false #floofstation
 
 - type: tile
   id: FloorMS13TileOrnate
@@ -1301,405 +1301,405 @@
   sprite: /Textures/_Nuclear14/Tiles/ms13/tileornate.png
   variants: 4
   placementVariants: [0, 1, 2, 3]
-  baseTurf: FloorWasteland
+  baseTurf: Plating #Floofstation
   isSubfloor: false
   footstepSounds:
     collection: FootstepFloor
   friction: 0.30
   thermalConductivity: 0.04
   heatCapacity: 10000
-  weather: true
+  weather: false #floofstation
 
 # Roads
 - type: tile
   id: N14FloorRoadInnerMiddle
   name: road inner middle
   sprite: /Textures/_Nuclear14/Tiles/roadinnermiddle.png
-  baseTurf: FloorWasteland
+  baseTurf: Plating #Floofstation
   isSubfloor: true
   footstepSounds:
     collection: FootstepFloor
   friction: 0.30
   thermalConductivity: 0.04
   heatCapacity: 10000
-  weather: true
+  weather: false #floofstation
 
 - type: tile
   id: N14FloorRoadOuterMiddlePath
   name: road outer middle (path)
   sprite: /Textures/_Nuclear14/Tiles/roadoutermiddle.png
-  baseTurf: FloorWasteland
+  baseTurf: Plating #Floofstation
   isSubfloor: true
   footstepSounds:
     collection: FootstepFloor
   friction: 0.30
   thermalConductivity: 0.04
   heatCapacity: 10000
-  weather: true
+  weather: false #floofstation
 
 - type: tile
   id: N14FloorRoadCorner1
   name: road corner1
   sprite: /Textures/_Nuclear14/Tiles/roadcorner1.png
-  baseTurf: FloorWasteland
+  baseTurf: Plating #Floofstation
   isSubfloor: true
   footstepSounds:
     collection: FootstepFloor
   friction: 0.30
   thermalConductivity: 0.04
   heatCapacity: 10000
-  weather: true
+  weather: false #floofstation
 
 - type: tile
   id: N14FloorRoadCorner2
   name: road corner2
   sprite: /Textures/_Nuclear14/Tiles/roadcorner2.png
-  baseTurf: FloorWasteland
+  baseTurf: Plating #Floofstation
   isSubfloor: true
   footstepSounds:
     collection: FootstepFloor
   friction: 0.30
   thermalConductivity: 0.04
   heatCapacity: 10000
-  weather: true
+  weather: false #floofstation
 
 - type: tile
   id: N14FloorRoadCorner3
   name: road corner3
   sprite: /Textures/_Nuclear14/Tiles/roadcorner3.png
-  baseTurf: FloorWasteland
+  baseTurf: Plating #Floofstation
   isSubfloor: true
   footstepSounds:
     collection: FootstepFloor
   friction: 0.30
   thermalConductivity: 0.04
   heatCapacity: 10000
-  weather: true
+  weather: false #floofstation
 
 - type: tile
   id: N14FloorRoadCorner4
   name: road corner4
   sprite: /Textures/_Nuclear14/Tiles/roadcorner4.png
-  baseTurf: FloorWasteland
+  baseTurf: Plating #Floofstation
   isSubfloor: true
   footstepSounds:
     collection: FootstepFloor
   friction: 0.30
   thermalConductivity: 0.04
   heatCapacity: 10000
-  weather: true
+  weather: false #floofstation
 
 - type: tile
   id: N14FloorRoadBottom
   name: road bottom
   sprite: /Textures/_Nuclear14/Tiles/roadbottom.png
-  baseTurf: FloorWasteland
+  baseTurf: Plating #Floofstation
   isSubfloor: true
   footstepSounds:
     collection: FootstepFloor
   friction: 0.30
   thermalConductivity: 0.04
   heatCapacity: 10000
-  weather: true
+  weather: false #floofstation
 
 - type: tile
   id: N14FloorRoadLeft
   name: road left
   sprite: /Textures/_Nuclear14/Tiles/roadleft.png
-  baseTurf: FloorWasteland
+  baseTurf: Plating #Floofstation
   isSubfloor: true
   footstepSounds:
     collection: FootstepFloor
   friction: 0.30
   thermalConductivity: 0.04
   heatCapacity: 10000
-  weather: true
+  weather: false #floofstation
 
 - type: tile
   id: N14FloorRoadRight
   name: road right
   sprite: /Textures/_Nuclear14/Tiles/roadright.png
-  baseTurf: FloorWasteland
+  baseTurf: Plating #Floofstation
   isSubfloor: true
   footstepSounds:
     collection: FootstepFloor
   friction: 0.30
   thermalConductivity: 0.04
   heatCapacity: 10000
-  weather: true
+  weather: false #floofstation
 
 - type: tile
   id: N14FloorRoadTop
   name: road top
   sprite: /Textures/_Nuclear14/Tiles/roadtop.png
-  baseTurf: FloorWasteland
+  baseTurf: Plating #Floofstation
   isSubfloor: true
   footstepSounds:
     collection: FootstepFloor
   friction: 0.30
   thermalConductivity: 0.04
   heatCapacity: 10000
-  weather: true
+  weather: false #floofstation
 
 - type: tile
   id: N14FloorRoadOuterTurnNorth
   name: road outer turn north
   sprite: /Textures/_Nuclear14/Tiles/roadouterturnn.png
-  baseTurf: FloorWasteland
+  baseTurf: Plating #Floofstation
   isSubfloor: true
   footstepSounds:
     collection: FootstepFloor
   friction: 0.30
   thermalConductivity: 0.04
   heatCapacity: 10000
-  weather: true
+  weather: false #floofstation
 
 - type: tile
   id: N14FloorRoadOuterTurnSouth
   name: road outer turn south
   sprite: /Textures/_Nuclear14/Tiles/roadouterturns.png
-  baseTurf: FloorWasteland
+  baseTurf: Plating #Floofstation
   isSubfloor: true
   footstepSounds:
     collection: FootstepFloor
   friction: 0.30
   thermalConductivity: 0.04
   heatCapacity: 10000
-  weather: true
+  weather: false #floofstation
 
 - type: tile
   id: N14FloorRoadOuterTurnWest
   name: road outer turn west
   sprite: /Textures/_Nuclear14/Tiles/roadouterturnw.png
-  baseTurf: FloorWasteland
+  baseTurf: Plating #Floofstation
   isSubfloor: true
   footstepSounds:
     collection: FootstepFloor
   friction: 0.30
   thermalConductivity: 0.04
   heatCapacity: 10000
-  weather: true
+  weather: false #floofstation
 
 - type: tile
   id: N14FloorRoadOuterTurnEast
   name: road outer turn east
   sprite: /Textures/_Nuclear14/Tiles/roadouterturne.png
-  baseTurf: FloorWasteland
+  baseTurf: Plating #Floofstation
   isSubfloor: true
   footstepSounds:
     collection: FootstepFloor
   friction: 0.30
   thermalConductivity: 0.04
   heatCapacity: 10000
-  weather: true
+  weather: false #floofstation
 
 - type: tile
   id: N14FloorRoadOuterCorner1
   name: road outer corner 1
   sprite: /Textures/_Nuclear14/Tiles/roadoutercorner1.png
-  baseTurf: FloorWasteland
+  baseTurf: Plating #Floofstation
   isSubfloor: true
   footstepSounds:
     collection: FootstepFloor
   friction: 0.30
   thermalConductivity: 0.04
   heatCapacity: 10000
-  weather: true
+  weather: false #floofstation
 
 - type: tile
   id: N14FloorRoadOuterCorner2
   name: road outer corner 2
   sprite: /Textures/_Nuclear14/Tiles/roadoutercorner2.png
-  baseTurf: FloorWasteland
+  baseTurf: Plating #Floofstation
   isSubfloor: true
   footstepSounds:
     collection: FootstepFloor
   friction: 0.30
   thermalConductivity: 0.04
   heatCapacity: 10000
-  weather: true
+  weather: false #floofstation
 
 - type: tile
   id: N14FloorRoadOuterCorner3
   name: road outer corner 3
   sprite: /Textures/_Nuclear14/Tiles/roadoutercorner3.png
-  baseTurf: FloorWasteland
+  baseTurf: Plating #Floofstation
   isSubfloor: true
   footstepSounds:
     collection: FootstepFloor
   friction: 0.30
   thermalConductivity: 0.04
   heatCapacity: 10000
-  weather: true
+  weather: false #floofstation
 
 - type: tile
   id: N14FloorRoadOuterCorner4
   name: road outer corner 4
   sprite: /Textures/_Nuclear14/Tiles/roadoutercorner4.png
-  baseTurf: FloorWasteland
+  baseTurf: Plating #Floofstation
   isSubfloor: true
   footstepSounds:
     collection: FootstepFloor
   friction: 0.30
   thermalConductivity: 0.04
   heatCapacity: 10000
-  weather: true
+  weather: false #floofstation
 
 - type: tile
   id: N14FloorRoadInnerTurn1
   name: road inner turn 1
   sprite: /Textures/_Nuclear14/Tiles/roadinnerturn1.png
-  baseTurf: FloorWasteland
+  baseTurf: Plating #Floofstation
   isSubfloor: true
   footstepSounds:
     collection: FootstepFloor
   friction: 0.30
   thermalConductivity: 0.04
   heatCapacity: 10000
-  weather: true
+  weather: false #floofstation
 
 - type: tile
   id: N14FloorRoadInnerTurn2
   name: road inner turn 2
   sprite: /Textures/_Nuclear14/Tiles/roadinnerturn2.png
-  baseTurf: FloorWasteland
+  baseTurf: Plating #Floofstation
   isSubfloor: true
   footstepSounds:
     collection: FootstepFloor
   friction: 0.30
   thermalConductivity: 0.04
   heatCapacity: 10000
-  weather: true
+  weather: false #floofstation
 
 - type: tile
   id: N14FloorRoadInnerTurn3
   name: road inner turn 3
   sprite: /Textures/_Nuclear14/Tiles/roadinnerturn3.png
-  baseTurf: FloorWasteland
+  baseTurf: Plating #Floofstation
   isSubfloor: true
   footstepSounds:
     collection: FootstepFloor
   friction: 0.30
   thermalConductivity: 0.04
   heatCapacity: 10000
-  weather: true
+  weather: false #floofstation
 
 - type: tile
   id: N14FloorRoadInnerTurn4
   name: road inner turn 4
   sprite: /Textures/_Nuclear14/Tiles/roadinnerturn4.png
-  baseTurf: FloorWasteland
+  baseTurf: Plating #Floofstation
   isSubfloor: true
   footstepSounds:
     collection: FootstepFloor
   friction: 0.30
   thermalConductivity: 0.04
   heatCapacity: 10000
-  weather: true
+  weather: false #floofstation
 
 - type: tile
   id: N14FloorRoadTinyCornerHorizontal1
   name: road tiny corner horizontal 1
   sprite: /Textures/_Nuclear14/Tiles/roadtinycornerhorizontal1.png
-  baseTurf: FloorWasteland
+  baseTurf: Plating #Floofstation
   isSubfloor: true
   footstepSounds:
     collection: FootstepFloor
   friction: 0.30
   thermalConductivity: 0.04
   heatCapacity: 10000
-  weather: true
+  weather: false #floofstation
 
 - type: tile
   id: N14FloorRoadTinyCornerHorizontal2
   name: road tiny corner horizontal 2
   sprite: /Textures/_Nuclear14/Tiles/roadtinycornerhorizontal2.png
-  baseTurf: FloorWasteland
+  baseTurf: Plating #Floofstation
   isSubfloor: true
   footstepSounds:
     collection: FootstepFloor
   friction: 0.30
   thermalConductivity: 0.04
   heatCapacity: 10000
-  weather: true
+  weather: false #floofstation
 
 - type: tile
   id: N14FloorRoadTinyCornerHorizontal3
   name: road tiny corner horizontal 3
   sprite: /Textures/_Nuclear14/Tiles/roadtinycornerhorizontal3.png
-  baseTurf: FloorWasteland
+  baseTurf: Plating #Floofstation
   isSubfloor: true
   footstepSounds:
     collection: FootstepFloor
   friction: 0.30
   thermalConductivity: 0.04
   heatCapacity: 10000
-  weather: true
+  weather: false #floofstation
 
 - type: tile
   id: N14FloorRoadTinyCornerHorizontal4
   name: road tiny corner horizontal 4
   sprite: /Textures/_Nuclear14/Tiles/roadtinycornerhorizontal4.png
-  baseTurf: FloorWasteland
+  baseTurf: Plating #Floofstation
   isSubfloor: true
   footstepSounds:
     collection: FootstepFloor
   friction: 0.30
   thermalConductivity: 0.04
   heatCapacity: 10000
-  weather: true
+  weather: false #floofstation
 
 - type: tile
   id: N14FloorRoadTinyCornerVertical1
   name: road tiny corner vertical 1
   sprite: /Textures/_Nuclear14/Tiles/roadtinycornervertical1.png
-  baseTurf: FloorWasteland
+  baseTurf: Plating #Floofstation
   isSubfloor: true
   footstepSounds:
     collection: FootstepFloor
   friction: 0.30
   thermalConductivity: 0.04
   heatCapacity: 10000
-  weather: true
+  weather: false #floofstation
 
 - type: tile
   id: N14FloorRoadTinyCornerVertical2
   name: road tiny corner vertical 2
   sprite: /Textures/_Nuclear14/Tiles/roadtinycornervertical2.png
-  baseTurf: FloorWasteland
+  baseTurf: Plating #Floofstation
   isSubfloor: true
   footstepSounds:
     collection: FootstepFloor
   friction: 0.30
   thermalConductivity: 0.04
   heatCapacity: 10000
-  weather: true
+  weather: false #floofstation
 
 - type: tile
   id: N14FloorRoadTinyCornerVertical3
   name: road tiny corner vertical 3
   sprite: /Textures/_Nuclear14/Tiles/roadtinycornervertical3.png
-  baseTurf: FloorWasteland
+  baseTurf: Plating #Floofstation
   isSubfloor: true
   footstepSounds:
     collection: FootstepFloor
   friction: 0.30
   thermalConductivity: 0.04
   heatCapacity: 10000
-  weather: true
+  weather: false #floofstation
 
 - type: tile
   id: N14FloorRoadTinyCornerVertical4
   name: road tiny corner vertical 4
   sprite: /Textures/_Nuclear14/Tiles/roadtinycornervertical4.png
-  baseTurf: FloorWasteland
+  baseTurf: Plating #Floofstation
   isSubfloor: true
   footstepSounds:
     collection: FootstepFloor
   friction: 0.30
   thermalConductivity: 0.04
   heatCapacity: 10000
-  weather: true
+  weather: false #floofstation
 
 # Wasteland
 - type: tile
@@ -1715,7 +1715,7 @@
   friction: 0.30
   thermalConductivity: 0.04
   heatCapacity: 10000
-  weather: true
+  weather: false #floofstation
   indestructible: true
 
 - type: tile
@@ -1737,7 +1737,7 @@
   footstepSounds:
     collection: N14FootstepDirt
   heatCapacity: 10000
-  weather: true
+  weather: false #floofstation
 
 - type: tile
   id: FloorDirtIndoors
@@ -1780,7 +1780,7 @@
   footstepSounds:
     collection: FootstepAsteroid
   heatCapacity: 10000
-  weather: true
+  weather: false #floofstation
 
 - type: tile
   id: FloorRubbleIndoors
@@ -1802,7 +1802,7 @@
   footstepSounds:
     collection: FootstepAsteroid
   heatCapacity: 10000
-  weather: true
+  weather: false #floofstation
 
 #  Water
 - type: tile
@@ -1819,7 +1819,7 @@
   sturdy: false
   thermalConductivity: 0.4
   heatCapacity: 700000
-  weather: true
+  weather: false #floofstation
   indestructible: true
 
 - type: tile
@@ -1834,7 +1834,7 @@
   sturdy: false
   thermalConductivity: 0.4
   heatCapacity: 700000
-  weather: true
+  weather: false #floofstation
   indestructible: true
 
 - type: tile
@@ -1849,7 +1849,7 @@
   sturdy: false
   thermalConductivity: 0.4
   heatCapacity: 700000
-  weather: true
+  weather: false #floofstation
   indestructible: true
 
 - type: tile
@@ -1864,5 +1864,5 @@
   sturdy: false
   thermalConductivity: 0.4
   heatCapacity: 700000
-  weather: true
+  weather: false #floofstation
   indestructible: true


### PR DESCRIPTION
# Description
---

Fix N14 Tiles having weather on them when when they should not and fixed prying them up leaving waste land instead of regular plating.

<details><summary><h1> Images</h1></summary>
<p>

Before: 
<img width="1196" height="1230" alt="before" src="https://github.com/user-attachments/assets/020c1e51-6289-413e-bb0c-079ebc0b1580" />

After:
<img width="1078" height="730" alt="after" src="https://github.com/user-attachments/assets/137f9c88-3b3c-4848-a367-54de44154700" />

</p>
</details>

---

:cl:
- Fix: N14 tiles will no longer show wasteland when pried up and will no longer have weather effects on them.
