### PR TITLE
Trait System Fix 2: Electric Boogalo

### DIFF
--- a/Content.Client/_Floof/LoadoutsAndTraits/AbstractLoadoutTreeCharacterPage.Sorting.cs
+++ b/Content.Client/_Floof/LoadoutsAndTraits/AbstractLoadoutTreeCharacterPage.Sorting.cs
@@ -21,7 +21,14 @@ public abstract partial class AbstractLoadoutTreeCharacterPage<TProto, TCategory
         SortByCounter = Math.Clamp(SortByCounter, 0, Counters.Count);
 
         var counter = Counters[SortByCounter - 1];
-        return (a, b) => counter.GetPrototypeCost(a) - counter.GetPrototypeCost(b);
+        return (a, b) =>
+        {
+            // Sort by the counter first, fall back to sorting by name if counters are equal.
+            var result = counter.GetPrototypeCost(a) - counter.GetPrototypeCost(b);
+            return result != 0
+                ? result
+                : string.Compare(GetLocalizedName(a), GetLocalizedName(b), StringComparison.OrdinalIgnoreCase);
+        };
     }
 
     /// <summary>

--- a/Content.Client/_Floof/LoadoutsAndTraits/AbstractLoadoutTreeCharacterPage.Sorting.cs
+++ b/Content.Client/_Floof/LoadoutsAndTraits/AbstractLoadoutTreeCharacterPage.Sorting.cs
@@ -1,0 +1,38 @@
+namespace Content.Client._Floof.LoadoutsAndTraits;
+
+
+public abstract partial class AbstractLoadoutTreeCharacterPage<TProto, TCategory, TSelector>
+{
+    /// <summary>
+    ///     Counter number from <see cref="Counters"/> by which to sort items. 0 means default sorting (alphabetic).
+    ///     1 or greater means sorting by the specified counter.
+    /// </summary>
+    protected int SortByCounter = 0;
+
+    /// <summary>
+    ///     Returns an item comparator. By default returns a comparer based on the value of <see cref="SortByCounter"/>.
+    /// </summary>
+    protected virtual Comparison<TProto> GetItemComparison()
+    {
+        if (SortByCounter == 0)
+            return (a, b) => string.Compare(GetLocalizedName(a), GetLocalizedName(b), StringComparison.OrdinalIgnoreCase);
+
+        // Ensure SortByCounter is valid
+        SortByCounter = Math.Clamp(SortByCounter, 0, Counters.Count);
+
+        var counter = Counters[SortByCounter - 1];
+        return (a, b) => counter.GetPrototypeCost(a) - counter.GetPrototypeCost(b);
+    }
+
+    /// <summary>
+    ///     Sets <see cref="SortByCounter"/>, ensures it is in range of [0, Counters.size], and updates layout.
+    /// </summary>
+    protected virtual void SetSortingMode(int sortByCounter)
+    {
+        SortByCounter = Math.Abs(sortByCounter % (Counters.Count + 1));
+        UpdateChoices();
+
+        var choiceName = SortByCounter == 0 ? "null" : Loc.GetString(Counters[SortByCounter - 1].NameLoc);
+        Model.SortModeToggleButton.Text = Loc.GetString("loadouts-and-traits-sort-mode-text", ("mode", choiceName));
+    }
+}

--- a/Content.Client/_Floof/LoadoutsAndTraits/AbstractLoadoutTreeCharacterPage.xaml.cs
+++ b/Content.Client/_Floof/LoadoutsAndTraits/AbstractLoadoutTreeCharacterPage.xaml.cs
@@ -466,7 +466,13 @@ public abstract partial class AbstractLoadoutTreeCharacterPage<TProto, TCategory
         List<CharacterRequirement> requirements,
         out List<string> failReasons)
     {
-        _characterRequirements ??= IoCManager.Resolve<IEntitySystemManager>().GetEntitySystem<CharacterRequirementsSystem>();
+        _characterRequirements ??= IoCManager.Resolve<IEntitySystemManager>().GetEntitySystemOrNull<CharacterRequirementsSystem>();
+        if (_characterRequirements == null)
+        {
+            // IOC my behatred. Ideally this method shouldn't be called mid-connection, but sometimes it can, in which case the system will fail to resolve.
+            failReasons = new();
+            return true;
+        }
         _fallbackJob ??= ProtoMan.Index(_fallbackJobId);
 
         // !!! landmine: make sure to use GetRawPlayTime trackers, as this is what the loadout system was made to rely on.

--- a/Content.Client/_Floof/LoadoutsAndTraits/AbstractLoadoutTreeUiModel.xaml
+++ b/Content.Client/_Floof/LoadoutsAndTraits/AbstractLoadoutTreeUiModel.xaml
@@ -31,6 +31,12 @@
             Text="You shouldn't see this"
             ToolTip="{Loc 'humanoid-profile-editor-loadouts-remove-unusable-button-tooltip'}"
             HorizontalAlignment="Stretch"
+            HorizontalExpand="True"/>
+        <Button
+            Name="SortModeToggleButton" Access="Public"
+            Text="Peekabu"
+            ToolTip="{Loc 'loadouts-and-traits-sort-toggle-tooltip'}"
+            HorizontalAlignment="Stretch"
             HorizontalExpand="True"
             StyleClasses="OpenLeft" />
     </BoxContainer>

--- a/Content.Client/_Floof/LoadoutsAndTraits/AbstractLoadoutTreeUiModel.xaml
+++ b/Content.Client/_Floof/LoadoutsAndTraits/AbstractLoadoutTreeUiModel.xaml
@@ -31,7 +31,8 @@
             Text="You shouldn't see this"
             ToolTip="{Loc 'humanoid-profile-editor-loadouts-remove-unusable-button-tooltip'}"
             HorizontalAlignment="Stretch"
-            HorizontalExpand="True"/>
+            HorizontalExpand="True"
+            StyleClasses="OpenBoth" />
         <Button
             Name="SortModeToggleButton" Access="Public"
             Text="Peekabu"

--- a/Content.Client/_Floof/LoadoutsAndTraits/Loadouts/LoadoutTreeCharacterPage.cs
+++ b/Content.Client/_Floof/LoadoutsAndTraits/Loadouts/LoadoutTreeCharacterPage.cs
@@ -30,7 +30,7 @@ public sealed class LoadoutTreeCharacterPage : AbstractLoadoutTreeCharacterPage<
         _highJobProvider = highJobProvider;
         _profileProvider = profileProvider;
 
-        Counters.Add(new("loadout-point-counter", proto => proto.Cost, () => MaxPoints));
+        Counters.Add(new("loadout-point-counter-name", "loadout-point-counter", proto => proto.Cost, () => MaxPoints));
         UpdateCounters();
     }
 

--- a/Content.Client/_Floof/LoadoutsAndTraits/Traits/TraitTreeCharacterPage.cs
+++ b/Content.Client/_Floof/LoadoutsAndTraits/Traits/TraitTreeCharacterPage.cs
@@ -29,8 +29,8 @@ public sealed class TraitTreeCharacterPage : AbstractLoadoutTreeCharacterPage<Tr
 
         // This weird system expresses loadout cost as "how many points this takes", but trait cost as "how many points this GIVES"
         // 0. fucking. consistency.
-        Counters.Add(new("loadout-point-counter", proto => -proto.Points, () => MaxPoints));
-        Counters.Add(new("loadout-selection-counter", proto => proto.Slots, () => MaxSelections));
+        Counters.Add(new("loadout-point-counter-name", "loadout-point-counter", proto => -proto.Points, () => MaxPoints));
+        Counters.Add(new("loadout-selection-counter-name", "loadout-selection-counter", proto => proto.Slots, () => MaxSelections));
         UpdateCounters();
     }
 

--- a/Content.Client/_Floof/LoadoutsAndTraits/Traits/TraitTreeCharacterPage.cs
+++ b/Content.Client/_Floof/LoadoutsAndTraits/Traits/TraitTreeCharacterPage.cs
@@ -36,8 +36,8 @@ public sealed class TraitTreeCharacterPage : AbstractLoadoutTreeCharacterPage<Tr
 
     ~TraitTreeCharacterPage()
     {
-        Cfg.UnsubValueChanged(CCVars.GameTraitsDefaultPoints, it => MaxPoints = it);
-        Cfg.UnsubValueChanged(CCVars.GameTraitsMax, it => MaxSelections = it);
+        Cfg.UnsubValueChanged(CCVars.GameTraitsDefaultPoints, OnMaxPointsChanged);
+        Cfg.UnsubValueChanged(CCVars.GameTraitsMax, OnMaxSelectionsChanged);
     }
 
     private void OnMaxPointsChanged(int value)

--- a/Content.Server/Traits/TraitSystem.cs
+++ b/Content.Server/Traits/TraitSystem.cs
@@ -57,6 +57,7 @@ public sealed class TraitSystem : EntitySystem
 
         // Step 1. Figure out which traits will actually apply.
         var sortedTraits = new List<TraitPrototype>();
+        var discardedTraits = new List<TraitPrototype>();
         foreach (var traitId in args.Profile.TraitPreferences)
         {
             if (!_prototype.TryIndex<TraitPrototype>(traitId, out var traitPrototype))
@@ -71,7 +72,10 @@ public sealed class TraitSystem : EntitySystem
                 args.Profile, _playTimeTracking.GetTrackerTimes(args.Player), args.Player.ContentData()?.Whitelisted ?? false, traitPrototype,
                 EntityManager, _prototype, _configuration,
                 out _))
+            {
+                discardedTraits.Add(traitPrototype);
                 continue;
+            }
 
             sortedTraits.Add(traitPrototype);
         }
@@ -79,7 +83,6 @@ public sealed class TraitSystem : EntitySystem
         // Step 2. sort by points added so that we never go into negative balance unless the player already has a negative total.
         // Eliminate any trait that would cause us to go into negative balance.
         sortedTraits.Sort((a, b) => a.Points.CompareTo(b.Points));
-        var discardedTraits = new List<TraitPrototype>();
         for (int i = sortedTraits.Count - 1; i >= 0; i--)
         {
             var traitPrototype = sortedTraits[i];

--- a/Content.Server/Traits/TraitSystem.cs
+++ b/Content.Server/Traits/TraitSystem.cs
@@ -109,7 +109,7 @@ public sealed class TraitSystem : EntitySystem
         {
             Log.Warning($"Player {args.Player.Name} tried to spawn with a negative balance: {discardedTraits.Count} discarded, {pointsTotal} points, {traitSelections} selections.");
 
-            var msg = $"Warning: {discardedTraits.Count} of your traits failed to apply due to insufficient trait balance: " +
+            var msg = $"Warning: {discardedTraits.Count} of your traits failed to apply due to insufficient trait balance or missing requirements: " +
                 $"{string.Join(", ", discardedTraits.Select(t => t.ID))}.";
             _chatManager.ChatMessageToOne(
                 ChatChannel.Server,

--- a/Content.Server/Traits/TraitSystem.cs
+++ b/Content.Server/Traits/TraitSystem.cs
@@ -46,52 +46,76 @@ public sealed class TraitSystem : EntitySystem
     // When the player is spawned in, add all trait components selected during character creation
     private void OnPlayerSpawnComplete(PlayerSpawnCompleteEvent args)
     {
+        // This method has mostly been rewritten on floofstation.
         var pointsTotal = _configuration.GetCVar(CCVars.GameTraitsDefaultPoints);
         var traitSelections = _configuration.GetCVar(CCVars.GameTraitsMax);
 
-        if (args.JobId is not null && !_prototype.TryIndex<JobPrototype>(args.JobId, out var jobPrototype)
-            && jobPrototype is not null && !jobPrototype.ApplyTraits)
+        JobPrototype? jobPrototype = null;
+        if (args.JobId is not null && _prototype.TryIndex(args.JobId, out jobPrototype) && !jobPrototype.ApplyTraits)
             return;
+        jobPrototype ??= _prototype.Index<JobPrototype>("Passenger"); // Fallback
 
+        // Step 1. Figure out which traits will actually apply.
         var sortedTraits = new List<TraitPrototype>();
         foreach (var traitId in args.Profile.TraitPreferences)
         {
-            if (_prototype.TryIndex<TraitPrototype>(traitId, out var traitPrototype))
-                sortedTraits.Add(traitPrototype);
-            else
+            if (!_prototype.TryIndex<TraitPrototype>(traitId, out var traitPrototype))
             {
                 DebugTools.Assert($"No trait found with ID {traitId}!");
                 return;
             }
-        }
 
-        sortedTraits.Sort();
-        // End Floof
-
-        foreach (var traitPrototype in sortedTraits) // Floof - changed to use the sorted list
-        {
-            // Moved converting to prototypes to above loop in order to sort before applying them. End Floof modifications.
             if (!_characterRequirements.CheckRequirementsValid(
                 traitPrototype.Requirements,
-                _prototype.Index<JobPrototype>(args.JobId ?? _prototype.EnumeratePrototypes<JobPrototype>().First().ID),
+                jobPrototype,
                 args.Profile, _playTimeTracking.GetTrackerTimes(args.Player), args.Player.ContentData()?.Whitelisted ?? false, traitPrototype,
                 EntityManager, _prototype, _configuration,
                 out _))
                 continue;
 
-            // Floof - early exit if we are over the trait limit or points limit
+            sortedTraits.Add(traitPrototype);
+        }
+
+        // Step 2. sort by points added so that we never go into negative balance unless the player already has a negative total.
+        // Eliminate any trait that would cause us to go into negative balance.
+        sortedTraits.Sort((a, b) => a.Points.CompareTo(b.Points));
+        var discardedTraits = new List<TraitPrototype>();
+        for (int i = sortedTraits.Count - 1; i >= 0; i--)
+        {
+            var traitPrototype = sortedTraits[i];
             if (pointsTotal + traitPrototype.Points < 0 || traitSelections - traitPrototype.Slots < 0)
+            {
+                // Note: this mandates reverse iteration.
+                sortedTraits.RemoveSwap(i);
+                discardedTraits.Add(traitPrototype);
+                Log.Debug($"Eliminating trait {traitPrototype.ID} at index {i}");
                 continue;
+            }
 
             pointsTotal += traitPrototype.Points;
             traitSelections -= traitPrototype.Slots;
-
-            AddTrait(args.Mob, traitPrototype);
         }
 
-        // I dont have any good words for the person who wrote the below
-        // if (pointsTotal < 0 || traitSelections < 0)
-        //     PunishCheater(args.Mob);
+        // Step 3. finally apply all the traits that passed this trial by fire, sorting by their programmatic priority.
+        sortedTraits.Sort();
+        foreach (var traitPrototype in sortedTraits)
+            AddTrait(args.Mob, traitPrototype);
+
+        // This is just so I can know if I fucked up again and broke someone's character.
+        if (pointsTotal < 0 || traitSelections < 0 || discardedTraits.Count > 0)
+        {
+            Log.Warning($"Player {args.Player.Name} tried to spawn with a negative balance: {discardedTraits.Count} discarded, {pointsTotal} points, {traitSelections} selections.");
+
+            var msg = $"Warning: {discardedTraits.Count} of your traits failed to apply due to insufficient trait balance: " +
+                $"{string.Join(", ", discardedTraits.Select(t => t.ID))}.";
+            _chatManager.ChatMessageToOne(
+                ChatChannel.Server,
+                msg, msg,
+                EntityUid.Invalid,
+                false,
+                args.Player.Channel,
+                Color.Orange);
+        }
     }
 
     /// <summary>

--- a/Resources/Locale/en-US/_Floof/loadouts/ui.ftl
+++ b/Resources/Locale/en-US/_Floof/loadouts/ui.ftl
@@ -1,5 +1,13 @@
 loadouts-and-traits-chosen-items = Chosen items
 loadouts-and-traits-out-of-points = [color=red]You have exceeded your loadout budget. Some of your items may not spawn with you.[/red]
 
+loadouts-and-traits-sort-mode-text = Sort by { $mode ->
+    [null] name
+    *[else] {$mode}
+}
+loadouts-and-traits-sort-toggle-tooltip = Press to cycle the current sorting mode.
+
 loadout-point-counter = You have {$value}/{$max} points.
+loadout-point-counter-name = cost
 loadout-selection-counter = You can make {$value}/{$max} selections.
+loadout-selection-counter-name = slots


### PR DESCRIPTION
# Description
Fixes another new but more niche issue with the trait system: depending on which order traits are applied to your character (the order mostly depends on the order you added them in), some positive traits (those that cost you points) could be skipped because the system would notice your trait balance is getting depleted, even thogh there could be positive traits ahead that would replenish it.

This changes the way the trait system applies traits and splits it into 3 stages:
1. Checking whether a trait passes the requirements
2. Sorting traits by cost, discarding any traits that dont add up to a balance (this always results in the most expensive traits being discarded first)
3. Sorting by programmatic priority and applying them.

Also makes the system send a message to the player if some of their traits get discarded and fixes a few minor mistakes. I swear, I tested it more thoroughly this time.

<img width="503" height="56" alt="image" src="https://github.com/user-attachments/assets/9aa32ad9-57ce-47ec-8932-fe4d5bc18f9b" />
After increasing the trait point limit by 6:
<img width="495" height="73" alt="image" src="https://github.com/user-attachments/assets/5f63703a-a543-4562-8221-062220d06d78" />
<img width="554" height="54" alt="image" src="https://github.com/user-attachments/assets/a470b51b-32e2-45dd-96a8-c530cd7792b9" />

Update: now also adds a button that cycles between different sorting modes.


https://github.com/user-attachments/assets/f126c90c-82c9-4c16-9852-9c6c04385fd9




# Changelog
:cl:
- fix: Fixed the issue where positive traits preceding negative ones could fail to apply due to locally insufficient trait balance. This is all shitcode.
- add: There is now a "sorting mode" toggle in the loadouts that lets you change how options are sorted.
