### PR TITLE
Diamond Balance Tweak

### DIFF
--- a/Resources/Prototypes/Reagents/Materials/materials.yml
+++ b/Resources/Prototypes/Reagents/Materials/materials.yml
@@ -149,4 +149,4 @@
   unit: materials-unit-piece
   icon: { sprite: Objects/Materials/materials.rsi, state: diamond }
   color: "#80ffff"
-  price: 20 # big diamond gaslit us so hard diamonds actually became extremely rare
+  price: 3.33333 # big diamond gaslit us so hard diamonds actually became extremely rare # Floof - changed to 10k/stack


### PR DESCRIPTION
# Description
Changes the selling price of diamonds to 10k/stack (3.33 spesos per 1 unit). 60k/stack is absolutely insane given that some stations start with stacks of diamonds in the vault.

# Changelog
:cl:
- tweak: The big diamond lie has been unveiled.