### PR TITLE
Fix Autogetup Shitcode

### DIFF
--- a/Content.Shared/Standing/LayingDownComponent.cs
+++ b/Content.Shared/Standing/LayingDownComponent.cs
@@ -13,6 +13,7 @@ public sealed partial class LayingDownComponent : Component
     public float LyingSpeedModifier = 0.35f,
                  CrawlingUnderSpeedModifier = 0.5f;
 
+    // Floofstation note - this is set by the server when the client lays down.
     [DataField, AutoNetworkedField]
     public bool AutoGetUp;
 
@@ -30,8 +31,10 @@ public sealed partial class LayingDownComponent : Component
 [Serializable, NetSerializable]
 public sealed class ChangeLayingDownEvent : CancellableEntityEventArgs;
 
-[Serializable, NetSerializable]
-public sealed class CheckAutoGetUpEvent(NetEntity user) : CancellableEntityEventArgs
-{
-    public NetEntity User = user;
-}
+// Floofstation - removed. This is ChatGPT shitcode that never deserved to exist. A single client would set the AutoGetUp state of all other clients.
+// Do not port. All usages of this have been removed.
+// [Serializable, NetSerializable]
+// public sealed class CheckAutoGetUpEvent(NetEntity user) : CancellableEntityEventArgs
+// {
+//     public NetEntity User = user;
+// }

--- a/Content.Shared/Standing/SharedLayingDownSystem.cs
+++ b/Content.Shared/Standing/SharedLayingDownSystem.cs
@@ -95,8 +95,6 @@ public abstract class SharedLayingDownSystem : EntitySystem
             || !TryComp(uid, out LayingDownComponent? layingDown))
             return;
 
-        RaiseNetworkEvent(new CheckAutoGetUpEvent(GetNetEntity(uid)));
-
         if (HasComp<KnockedDownComponent>(uid)
             || !_mobState.IsAlive(uid))
             return;
@@ -105,6 +103,10 @@ public abstract class SharedLayingDownSystem : EntitySystem
             TryStandUp(uid, layingDown, standing);
         else
             TryLieDown(uid, layingDown, standing);
+
+        // Floofstation - no need to auto get up if we manually laid down. The system will reset it when we get downed the next time.
+        // IMPORTANT NOTE: SharedStunSystem directly calls TryLieDown for some godforsaken reason. Make sure this method isn't directly called elsewhere.
+        layingDown.AutoGetUp = false;
     }
 
     private void OnStandingUpDoAfter(EntityUid uid, StandingStateComponent component, StandingUpDoAfterEvent args)
@@ -186,6 +188,7 @@ public abstract class SharedLayingDownSystem : EntitySystem
         }
 
         _standing.Down(uid, true, behavior != DropHeldItemsBehavior.NoDrop, standingState);
+        Dirty(uid, layingDown); // Floofstation
         return true;
     }
 }

--- a/Content.Shared/Stunnable/SharedStunSystem.cs
+++ b/Content.Shared/Stunnable/SharedStunSystem.cs
@@ -142,7 +142,6 @@ public abstract class SharedStunSystem : EntitySystem
 
     private void OnKnockInit(EntityUid uid, KnockedDownComponent component, ComponentInit args)
     {
-        RaiseNetworkEvent(new CheckAutoGetUpEvent(GetNetEntity(uid)));
         _layingDown.TryLieDown(uid, null, null, component.DropHeldItemsBehavior);
     }
 


### PR DESCRIPTION
# Description
So fun fact.

Whenever someone lays down (whether by knockdown or manually), EVERY CLIENT in their pvs range raises a CheckAutoGetUpEvent and sets the standing up preference of the downed creature to that of their own. The last client to do so wins, as such. Your character **has always been forced to use someone else's standing up preference.**

This PR gets rid of this CheckAutoGetUpEvent and all related code (which was evidently generated by ChatGPT) and instead just sets LayingDownComponent.AutoGetUp based on the downed player's preferences (if any). Bonus point: it also sets it to false if the player toggles standing manually, and also now you can abort auto-getting-up by pressing R right after knocked down, but before the do-after for it starts.

<details><summary><h1>Media</h1></summary>
<p>



https://github.com/user-attachments/assets/9243ecd8-e035-4cb4-844c-49161a74c5a1


</p>
</details>

---

# Changelog
:cl:
- fix: The "get up automatically" setting should now work as expected. Also, if you are already laying down (e.g. in a bed), you won't be forced to get up after getting stunned, regardless of this setting.
