### PR TITLE
Balancing 20/11/25

### DIFF
--- a/Resources/Locale/en-US/store/uplink-catalog.ftl
+++ b/Resources/Locale/en-US/store/uplink-catalog.ftl
@@ -241,10 +241,10 @@ uplink-zombie-bundle-name = Syndicate Zombie Bundle
 uplink-zombie-bundle-desc = An all-in-one kit for unleashing the undead upon a station.
 
 uplink-surplus-bundle-name = Surplus Crate
-uplink-surplus-bundle-desc = Contains 50 telecrystals worth of completely random Syndicate items. It can be useless junk or really good.
+uplink-surplus-bundle-desc = Contains 60 telecrystals worth of completely random Syndicate items. It can be useless junk or really good.
 
 uplink-super-surplus-bundle-name = Super Surplus Crate
-uplink-super-surplus-bundle-desc = Contains 125 telecrystals worth of completely random Syndicate items.
+uplink-super-surplus-bundle-desc = Contains 120 telecrystals worth of completely random Syndicate items.
 
 # Tools
 uplink-toolbox-name = Toolbox

--- a/Resources/Prototypes/Catalog/Fills/Crates/syndicate.yml
+++ b/Resources/Prototypes/Catalog/Fills/Crates/syndicate.yml
@@ -2,10 +2,10 @@
   id: CrateSyndicateSurplusBundle
   parent: [ CrateSyndicate, StorePresetUplink ]
   name: Syndicate surplus crate
-  description: Contains 50 telecrystals worth of completely random Syndicate items. It can be useless junk or really good.
+  description: Contains 60 telecrystals worth of completely random Syndicate items. It can be useless junk or really good.
   components:
     - type: SurplusBundle
-      totalPrice: 50
+      totalPrice: 60
 
 - type: entity
   id: CrateCybersunJuggernautBundle
@@ -26,7 +26,7 @@
   id: CrateSyndicateSuperSurplusBundle
   parent: [ CrateSyndicate, StorePresetUplink ]
   name: Syndicate super surplus crate
-  description: Contains 125 telecrystals worth of completely random Syndicate items.
+  description: Contains 120 telecrystals worth of completely random Syndicate items.
   components:
     - type: SurplusBundle
-      totalPrice: 125
+      totalPrice: 120

--- a/Resources/Prototypes/Catalog/uplink_catalog.yml
+++ b/Resources/Prototypes/Catalog/uplink_catalog.yml
@@ -1009,6 +1009,28 @@
     blacklist:
       components:
       - SurplusBundle
+
+- type: listing
+  id: UplinkSurplusBundle
+  name: uplink-surplus-bundle-name
+  description: uplink-surplus-bundle-desc
+  productEntity: CrateSyndicateSurplusBundle
+  discountCategory: usualDiscounts
+  discountDownTo:
+    Telecrystal: 10
+  cost:
+    Telecrystal: 20
+  categories:
+  - UplinkDisruption
+  conditions:
+  - !type:StoreWhitelistCondition
+    blacklist:
+      tags:
+      - NukeOpsUplink
+  - !type:BuyerWhitelistCondition
+    blacklist:
+      components:
+      - SurplusBundle      
 # Allies
 
 - type: listing

--- a/Resources/Prototypes/Catalog/uplink_catalog.yml
+++ b/Resources/Prototypes/Catalog/uplink_catalog.yml
@@ -198,9 +198,9 @@
   productEntity: ClothingBackpackDuffelSyndicateFilledGrenadeLauncher
   discountCategory: veryRareDiscounts
   discountDownTo:
-    Telecrystal: 18
-  cost:
     Telecrystal: 24
+  cost:
+    Telecrystal: 36
   categories:
   - UplinkWeaponry
 
@@ -212,9 +212,9 @@
   productEntity: ClothingBackpackDuffelSyndicateFilledLMG
   discountCategory: veryRareDiscounts
   discountDownTo:
-    Telecrystal: 20
+    Telecrystal: 12
   cost:
-    Telecrystal: 30
+    Telecrystal: 18
   categories:
   - UplinkWeaponry
 

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Launchers/launchers.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Launchers/launchers.yml
@@ -44,7 +44,7 @@
   - type: Item # Floof - Gun Shape Refactor
     size: Large
     shape:
-    - 0,0,3,1
+    - 0,0,4,2
   - type: Sprite
     sprite: Objects/Weapons/Guns/Launchers/china_lake.rsi
     layers:

--- a/Resources/Prototypes/_Goobstation/Catalog/uplink_catalog.yml
+++ b/Resources/Prototypes/_Goobstation/Catalog/uplink_catalog.yml
@@ -48,8 +48,11 @@
   name: uplink-sleeping-carp-name
   description: uplink-sleeping-carp-desc
   productEntity: SleepingCarpScroll
+  discountCategory: usualDiscounts
+  discountDownTo:
+    Telecrystal: 12
   cost:
-    Telecrystal: 35 # Floof | Was originally 70
+    Telecrystal: 18 # Floof | Was originally 70 (Was balanced around new TC cost)
   categories:
     - UplinkWeaponry
   conditions:


### PR DESCRIPTION
# Description
Rebalances TC cost.

China Lake more expensive, L6 affordable, Sleeping Carp affordable.
China Lake space usage larger.
Added Normal Surplus Crate to uplink.
Minor adjustments to surplus internal value.

Why?
Got a complaint that China Lake was too small (for balancing reason, not realism). So I increased the size of it, and increased the price of it due to how prominent it was as an easy win button. Decreased L6 and Sleeping Carp to be affordable to boost how often we see those as they were greatly overpriced compared to China Lake. China Lakes time in the Limelight is over.

# Changelog
:cl:
- add: Added Normal Surplus Crate for gambling addicts
- tweak: Rebalanced TC cost of unused items and increased cost of China Lake
- tweak: Increased the size of a China Lake in bags, it's shotgun sized but due to balancing it's gotta be bigger
