### PR TITLE
Makes It so Healing Word and Greater Healing Word Can Revive Again

### DIFF
--- a/Content.Server/Abilities/Psionics/Abilities/HealOtherPowerSystem.cs
+++ b/Content.Server/Abilities/Psionics/Abilities/HealOtherPowerSystem.cs
@@ -133,7 +133,6 @@ public sealed class RevivifyPowerSystem : EntitySystem
             _damageable.TryChangeDamage(args.Target.Value, args.HealingAmount * args.ModifiedAmplification, true, false, damageableComponent, uid);
 
         if (!args.DoRevive
-            || HasComp<UnrevivableComponent>(args.Target.Value) // Floofstation - unrevivable
             || _rotting.IsRotten(args.Target.Value)
             || !TryComp<MobStateComponent>(args.Target.Value, out var mob)
             || !_mobState.IsDead(args.Target.Value, mob)


### PR DESCRIPTION
# Description
Simple 1 line change to make it so Revivify and Healing Word can revive unrevivable people. 
The description says can't be through conventional means. Unless magic is conventional this should work.

# Changelog
:cl:
- tweak: Tweaked Revivify/Healing Word to work on unrevivable people again.
