### PR TITLE
Add cloning to research

### DIFF
--- a/Resources/Locale/en-US/psionics/technologies.ftl
+++ b/Resources/Locale/en-US/psionics/technologies.ftl
@@ -1,3 +1,6 @@
 research-technology-psionic-countermeasures = Psionic Countermeasures
 research-technology-teleportation = Teleportation
 research-technology-metempsychosis = Metempsychosis
+
+# Floof
+research-technology-cloning = Cloning

--- a/Resources/Prototypes/Research/experimental.yml
+++ b/Resources/Prototypes/Research/experimental.yml
@@ -161,7 +161,7 @@
     state: cloning_idle
   discipline: Experimental
   tier: 2
-  cost: 15000
+  cost: 10000
   recipeUnlocks:
     - BiomassReclaimerMachineCircuitboard
     - CloningConsoleComputerCircuitboard

--- a/Resources/Prototypes/_Floof/Research/experimental.yml
+++ b/Resources/Prototypes/_Floof/Research/experimental.yml
@@ -1,0 +1,15 @@
+# Temporary solution more or less
+- type: technology
+  id: Cloning
+  name: research-technology-cloning
+  icon:
+    sprite: Structures/Machines/cloning.rsi
+    state: pod_0
+  discipline: Experimental
+  tier: 3
+  cost: 15000
+  recipeUnlocks:
+  - CloningPodMachineCircuitboard
+  technologyPrerequisites:
+  - Metempsychosis
+  softCapContribution: 1.2


### PR DESCRIPTION
# Description
Adds a cloning pod machine board as a tier 3 research. Testing needed first.


# Changelog
:cl:
- tweak: Epistemics can now research the cloning pod as a tier 3 experimental technology, with a relatively low softcap multiplier.