### PR TITLE
Sec Hardsuit Fix

### DIFF
--- a/Resources/Prototypes/Catalog/Cargo/cargo_hardsuits.yml
+++ b/Resources/Prototypes/Catalog/Cargo/cargo_hardsuits.yml
@@ -68,7 +68,7 @@
     sprite: DeltaV/Clothing/OuterClothing/Hardsuits/Combat/standard.rsi
     state: icon
   product: CrateSecurityBaghaturTacsuit
-  cost: 5000
+  cost: 7500
   category: cargoproduct-category-name-hardsuits
   group: market
 
@@ -78,7 +78,7 @@
     sprite: DeltaV/Clothing/OuterClothing/Hardsuits/Combat/riot.rsi
     state: icon
   product: CrateSecuritySuldeTacsuit
-  cost: 7500
+  cost: 10000
   category: cargoproduct-category-name-hardsuits
   group: market
 
@@ -88,6 +88,16 @@
     sprite: DeltaV/Clothing/OuterClothing/Hardsuits/Combat/medical.rsi
     state: icon
   product: CrateSecurityTsagaanTacsuit
-  cost: 5500
+  cost: 8500
+  category: cargoproduct-category-name-hardsuits
+  group: market
+
+- type: cargoProduct
+  id: SecurityDayicinTacsuit
+  icon:
+    sprite: DeltaV/Clothing/OuterClothing/Hardsuits/Combat/advanced.rsi
+    state: icon
+  product: CrateSecurityDayicinTacsuit
+  cost: 25000
   category: cargoproduct-category-name-hardsuits
   group: market

--- a/Resources/Prototypes/Catalog/Fills/Crates/hardsuits.yml
+++ b/Resources/Prototypes/Catalog/Fills/Crates/hardsuits.yml
@@ -17,7 +17,7 @@
   components:
   - type: StorageFill
     contents:
-    - id: ClothingOuterHardsuitAtmos
+    - id: ClothingOuterHardsuitEngineering
 
 # Logistics
 - type: entity

--- a/Resources/Prototypes/Catalog/Fills/Crates/hardsuits.yml
+++ b/Resources/Prototypes/Catalog/Fills/Crates/hardsuits.yml
@@ -65,28 +65,38 @@
   id: CrateSecurityBaghaturTacsuit
   parent: CrateSecgear
   name: baghatur tacsuit crate
-  description: Contains a single FPA-83s "Baghatur" tacsuit. Requires Security access to open.
+  description: Contains a single FPA-85s "Baghatur Mk.II" tacsuit. Requires Security access to open.
   components:
   - type: StorageFill
     contents:
-    - id: ClothingOuterHardsuitCombatStandard
+    - id: ClothingOuterHardsuitCombatOfficer
 
 - type: entity
   id: CrateSecuritySuldeTacsuit
   parent: CrateSecgear
   name: sulde tacsuit crate
-  description: Contains a single FPA-93 - "Sulde Mk.II" tacsuit. Requires Security access to open.
+  description: Contains a single FPA-93s - "Sulde Mk.II" tacsuit. Requires Security access to open.
   components:
   - type: StorageFill
     contents:
-    - id: ClothingOuterHardsuitCombatRiot
+    - id: ClothingOuterHardsuitCombatWarden
 
 - type: entity
   id: CrateSecurityTsagaanTacsuit
   parent: CrateSecgear
   name: tsagaan tacsuit crate
-  description: Contains a single FPA-86 - "Tsagaan Mk.II" tacsuit. Requires Security access to open.
+  description: Contains a single FPA-86m - "Tsagaan Mk.II" tacsuit. Requires Security access to open.
   components:
   - type: StorageFill
     contents:
-    - id: ClothingOuterHardsuitCombatMedical
+    - id: ClothingOuterHardsuitCombatCorpsman
+
+- type: entity
+  id: CrateSecurityDayicinTacsuit
+  parent: CrateSecgear
+  name: Dayicin tacsuit crate
+  description: Contains a single FPA-99s - "Dayicin Mk.II" tacsuit. Requires Security access to open.
+  components:
+  - type: StorageFill
+    contents:
+    - id: ClothingOuterHardsuitCombatHoS 

--- a/Resources/Prototypes/Catalog/Fills/Lockers/heads.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/heads.yml
@@ -313,7 +313,7 @@
       - id: ClothingOuterCoatHoSTrench
       - id: ClothingLongcoatHoS # Floofstation
       - id: ClothingMaskNeckGaiter
-      - id: ClothingOuterHardsuitCombatHoS # DeltaV - ClothingOuterHardsuitSecurityRed replaced in favour of head of security's advanced combat hardsuit.
+      - id: ClothingOuterHardsuitSecurityRed # Floof - Changed to MK1
       - id: ClothingShoesBootsSecurityMagboots # Floofstation
       - id: ClothingBeltSecurityFilled
       - id: ClothingHeadsetAltSecurity

--- a/Resources/Prototypes/Catalog/Fills/Lockers/security.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/security.yml
@@ -20,7 +20,7 @@
       - id: ClothingLongcoatWarden # Floofstation
       - id: RubberStampWarden
       - id: DoorRemoteArmory
-      - id: ClothingOuterHardsuitCombatWarden # DeltaV - ClothingOuterHardsuitWarden replaced in favour of warden's riot combat hardsuit.
+      - id: ClothingOuterHardsuitWarden # DeltaV - ClothingOuterHardsuitWarden replaced in favour of warden's riot combat hardsuit.
       - id: ClothingShoesBootsSecurityMagboots # Floofstation
       - id: HoloprojectorSecurity
       - id: ClothingEyesHudSecurity
@@ -118,7 +118,7 @@
   components:
   - type: StorageFill
     contents:
-      - id: ClothingEyesHudSecurity
+      - id: ClothingEyesHudMedSec
       - id: WeaponDisabler
       - id: TrackingImplanter
         amount: 2
@@ -159,11 +159,11 @@
   components:
   - type: StorageFill
     contents:
-      - id: ClothingEyesHudSecurity
+      - id: ClothingEyesHudMedSec
       - id: WeaponDisabler
       - id: TrackingImplanter
         amount: 2
-      - id: ClothingOuterHardsuitCombatCorpsman
+      - id: ClothingOuterHardsuitBrigmedic 
       - id: ClothingShoesBootsSecurityMagboots #Floofstation
       - id: ClothingUniformJumpsuitBrigmedic
       - id: ClothingUniformJumpskirtBrigmedic

--- a/Resources/Prototypes/Catalog/Fills/Lockers/suit_storage.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/suit_storage.yml
@@ -8,6 +8,7 @@
   - type: StorageFill
     contents:
         - id: OxygenTankFilled
+        - id: NitrogenTankFilled
         - id: ClothingOuterHardsuitEVA
         - id: ClothingHeadHelmetEVA
         - id: ClothingMaskBreath
@@ -21,6 +22,7 @@
   - type: StorageFill
     contents:
         - id: OxygenTankFilled
+        - id: NitrogenTankFilled
         - id: ClothingOuterHardsuitEVA
         - id: ClothingHeadHelmetEVALarge
         - id: ClothingMaskBreath
@@ -34,6 +36,7 @@
   - type: StorageFill
     contents:
         - id: OxygenTankFilled
+        - id: NitrogenTankFilled
         - id: ClothingOuterSuitEmergency
         - id: ClothingMaskBreath
 
@@ -46,6 +49,7 @@
   - type: StorageFill
     contents:
         - id: OxygenTankFilled
+        - id: NitrogenTankFilled
         - id: ClothingOuterHardsuitEVAPrisoner
         - id: ClothingHeadHelmetEVALarge
         - id: ClothingMaskBreath
@@ -59,6 +63,7 @@
   - type: StorageFill
     contents:
         - id: OxygenTankFilled
+        - id: NitrogenTankFilled
         - id: ClothingOuterHardsuitSyndicate
         - id: ClothingHeadHelmetSyndicate
         - id: ClothingMaskGasSyndicate
@@ -72,6 +77,7 @@
   - type: StorageFill
     contents:
         - id: OxygenTankFilled
+        - id: NitrogenTankFilled
         - id: ClothingOuterHardsuitPirateEVA
         - id: ClothingMaskGas
 
@@ -98,6 +104,7 @@
   - type: StorageFill
     contents:
         - id: OxygenTankFilled
+        - id: NitrogenTankFilled
         - id: ClothingOuterHardsuitBasic
         - id: ClothingMaskBreath
 
@@ -110,6 +117,7 @@
   - type: StorageFill
     contents:
         - id: OxygenTankFilled
+        - id: NitrogenTankFilled
         - id: ClothingShoesBootsMag
         - id: ClothingOuterHardsuitEngineering
         - id: ClothingMaskBreath
@@ -125,6 +133,7 @@
   - type: StorageFill
     contents:
         - id: OxygenTankFilled
+        - id: NitrogenTankFilled
         - id: ClothingOuterHardsuitAtmos
         - id: ClothingMaskBreath
   - type: AccessReader
@@ -139,9 +148,10 @@
   - type: StorageFill
     contents:
         - id: OxygenTankFilled
-        - id: ClothingOuterHardsuitCombatOfficer # DeltaV - ClothingOuterHardsuitSecurity replaced in favour of security combat hardsuit.
+        - id: NitrogenTankFilled
+        - id: ClothingOuterHardsuitSecurity # Floof - Replaced with the MK1 so Security has to buy MK2s
         - id: ClothingShoesBootsSecurityMagboots # Floofstation
-        - id: ClothingMaskBreath
+        - id: ClothingMaskGasSecurity
   - type: AccessReader
     access: [["Security"]]
 
@@ -154,6 +164,7 @@
   - type: StorageFill
     contents:
         - id: OxygenTankFilled
+        - id: NitrogenTankFilled
         - id: JetpackVoidFilled
         - id: ClothingShoesBootsMagAdv
         - id: ClothingOuterHardsuitEngineeringWhite
@@ -170,6 +181,7 @@
   - type: StorageFill
     contents:
         - id: OxygenTankFilled
+        - id: NitrogenTankFilled
         - id: ClothingOuterHardsuitMedical
         - id: ClothingMaskBreathMedical
   - type: AccessReader
@@ -184,6 +196,7 @@
   - type: StorageFill
     contents:
         - id: OxygenTankFilled
+        - id: NitrogenTankFilled
         - id: ClothingOuterHardsuitRd
         - id: ClothingMaskBreath
   - type: AccessReader
@@ -198,8 +211,9 @@
   - type: StorageFill
     contents:
         - id: OxygenTankFilled
+        - id: NitrogenTankFilled
         - id: JetpackSecurityFilled
-        - id: ClothingOuterHardsuitCombatHoS # DeltaV - ClothingOuterHardsuitSecurityRed replaced in favour of head of security's advanced combat hardsuit.
+        - id: ClothingOuterHardsuitSecurityRed # Floof - changed to MK1
         - id: ClothingShoesBootsSecurityMagboots # Floofstation
         - id: ClothingMaskGasSwat
   - type: AccessReader
@@ -214,7 +228,8 @@
   - type: StorageFill
     contents:
         - id: OxygenTankFilled
-        - id: ClothingOuterHardsuitCombatWarden # DeltaV - ClothingOuterHardsuitWarden replaced in favour of warden's riot combat hardsuit.
+        - id: NitrogenTankFilled
+        - id: ClothingOuterHardsuitWarden # Floof - Changed to MK1
         - id: ClothingShoesBootsSecurityMagboots # Floofstation
         - id: ClothingMaskBreath
   - type: AccessReader
@@ -229,6 +244,7 @@
   - type: StorageFill
     contents:
         - id: OxygenTankFilled
+        - id: NitrogenTankFilled
         - id: ClothingOuterHardsuitCap
         - id: ClothingMaskGasCaptain
         - id: ClothingMaskGasCaptainCombat
@@ -244,6 +260,7 @@
   - type: StorageFill
     contents:
       - id: OxygenTankFilled
+      - id: NitrogenTankFilled
       - id: ClothingShoesBootsMag
       - id: ClothingOuterHardsuitSpatio
       - id: ClothingMaskGasExplorer
@@ -276,7 +293,7 @@
     contents:
       - id: NitrogenTankFilled
       - id: OxygenTankFilled
-      - id: ClothingOuterHardsuitCombatCorpsman
+      - id: ClothingOuterHardsuitBrigmedic # Floof - Changed to MK1
       - id: ClothingShoesBootsSecurityMagboots # Floofstation
       - id: ClothingMaskBreath
   - type: AccessReader
@@ -293,6 +310,7 @@
   - type: StorageFill
     contents:
         - id: OxygenTankFilled
+        - id: NitrogenTankFilled
         - id: ClothingOuterHardsuitSyndie
         - id: ClothingShoesBootsMagSyndie
         - id: ClothingMaskGasSyndicate
@@ -306,6 +324,7 @@
   - type: StorageFill
     contents:
         - id: OxygenTankFilled
+        - id: NitrogenTankFilled
         - id: ClothingOuterHardsuitPirateCap
         - id: ClothingMaskGas
 
@@ -318,5 +337,6 @@
   - type: StorageFill
     contents:
         - id: OxygenTankFilled
+        - id: NitrogenTankFilled
         - id: ClothingOuterHardsuitWizard
         - id: ClothingMaskBreath

--- a/Resources/Prototypes/DeltaV/Entities/Clothing/OuterClothing/hardsuits.yml
+++ b/Resources/Prototypes/DeltaV/Entities/Clothing/OuterClothing/hardsuits.yml
@@ -1,4 +1,4 @@
-# Standard Combat Hardsuits
+# Standard Combat Hardsuits Baghatur Mk.II
 - type: entity
   parent: ClothingOuterHardsuitBase
   id: ClothingOuterHardsuitCombatStandard
@@ -13,21 +13,23 @@
     highPressureMultiplier: 0.50
     lowPressureMultiplier: 1000
   - type: ExplosionResistance
-    damageCoefficient: 0.50
+    damageCoefficient: 0.5
   - type: Armor # Good armour resistance across the board, comparable to the standard security hardsuit.
     modifiers:
       coefficients:
-        Blunt: 0.60
-        Slash: 0.60
-        Piercing: 0.60
+        Blunt: 0.6
+        Slash: 0.6
+        Piercing: 0.6
+        Heat: 0.6
         Radiation: 0.75
-        Caustic: 0.75
-        Heat: 0.75
   - type: ClothingSpeedModifier
-    walkModifier: 0.75
-    sprintModifier: 0.75
+    walkModifier: 0.8
+    sprintModifier: 0.8
+  - type: HeldSpeedModifier
   - type: ToggleableClothing
     clothingPrototype: ClothingHeadHelmetHardsuitCombatStandard
+  - type: StaminaDamageResistance
+    coefficient: 0.7 # 30%
 
 - type: entity
   parent: ClothingOuterHardsuitCombatStandard
@@ -42,7 +44,7 @@
   - type: ToggleableClothing
     clothingPrototype: ClothingHeadHelmetHardsuitCombatOfficer
 
-# Medical Combat Hardsuits
+# Medical Combat Hardsuits Tsagaan Mk.II
 - type: entity
   parent: ClothingOuterHardsuitBase
   id: ClothingOuterHardsuitCombatMedical
@@ -54,24 +56,27 @@
   - type: Clothing
     sprite: DeltaV/Clothing/OuterClothing/Hardsuits/Combat/medical.rsi
   - type: PressureProtection # Less protective from high pressure than a standard hardsuit due to less plating.
-    highPressureMultiplier: 0.60
+    highPressureMultiplier: 0.3
     lowPressureMultiplier: 1000
   - type: ExplosionResistance
-    damageCoefficient: 0.60
-  - type: Armor # Slightly less armour than the standard hardsuit, but far higher mobility.
+    damageCoefficient: 0.5
+  - type: Armor # Floof Changed to be the same as a normal Baghatur MK2 but with caustic
     modifiers:
       coefficients:
-        Blunt: 0.65
-        Slash: 0.65
-        Piercing: 0.65
-        Radiation: 0.80
-        Caustic: 0.80
-        Heat: 0.80
+        Blunt: 0.6
+        Slash: 0.6
+        Piercing: 0.6
+        Heat: 0.6
+        Radiation: 0.75
+        Caustic: 0.5
   - type: ClothingSpeedModifier
-    walkModifier: 0.85
-    sprintModifier: 0.85
+    walkModifier: 0.8
+    sprintModifier: 0.8
+  - type: HeldSpeedModifier
   - type: ToggleableClothing
     clothingPrototype: ClothingHeadHelmetHardsuitCombatMedical
+  - type: StaminaDamageResistance
+    coefficient: 0.7 # 30%
 
 - type: entity
   parent: ClothingOuterHardsuitCombatMedical
@@ -86,7 +91,7 @@
   - type: ToggleableClothing
     clothingPrototype: ClothingHeadHelmetHardsuitCombatCorpsman
 
-# Riot Combat Hardsuits
+# Riot Combat Hardsuits Sulde Mk.II
 - type: entity
   parent: ClothingOuterHardsuitBase
   id: ClothingOuterHardsuitCombatRiot
@@ -98,24 +103,27 @@
   - type: Clothing
     sprite: DeltaV/Clothing/OuterClothing/Hardsuits/Combat/riot.rsi
   - type: PressureProtection
-    highPressureMultiplier: 0.45
+    highPressureMultiplier: 0.5
     lowPressureMultiplier: 1000
   - type: ExplosionResistance
-    damageCoefficient: 0.40
+    damageCoefficient: 0.3
   - type: Armor # More protective than a standard security hardsuit, but far slower.
     modifiers:
       coefficients:
-        Blunt: 0.50
-        Slash: 0.50
-        Piercing: 0.50
-        Radiation: 0.70
-        Caustic: 0.70
-        Heat: 0.70
+        Blunt: 0.5
+        Slash: 0.5
+        Piercing: 0.5
+        Heat: 0.5
+        Radiation: 0.75
+        Caustic: 0.7
   - type: ClothingSpeedModifier
-    walkModifier: 0.65
-    sprintModifier: 0.65
+    walkModifier: 0.6
+    sprintModifier: 0.6
+  - type: HeldSpeedModifier
   - type: ToggleableClothing
     clothingPrototype: ClothingHeadHelmetHardsuitCombatRiot
+  - type: StaminaDamageResistance
+    coefficient: 0.50 # 50%
 
 - type: entity
   parent: ClothingOuterHardsuitCombatRiot
@@ -130,7 +138,7 @@
   - type: ToggleableClothing
     clothingPrototype: ClothingHeadHelmetHardsuitCombatWarden
 
-# Advanced Combat Hardsuits
+# Advanced Combat Hardsuits Dayicin Mk.II
 - type: entity
   parent: ClothingOuterHardsuitBase
   id: ClothingOuterHardsuitCombatAdvanced
@@ -145,21 +153,24 @@
     highPressureMultiplier: 0.40
     lowPressureMultiplier: 1000
   - type: ExplosionResistance
-    damageCoefficient: 0.40
+    damageCoefficient: 0.4
   - type: Armor # About as protective as a riot hardsuit but with far less movement penalty.
     modifiers:
-      coefficients:
-        Blunt: 0.50
-        Slash: 0.50
-        Piercing: 0.50
-        Radiation: 0.75
-        Caustic: 0.75
-        Heat: 0.75
+      coefficients: # Changed so it was an upgrade over the Dayicin MK1
+        Blunt: 0.45
+        Slash: 0.45
+        Piercing: 0.45
+        Heat: 0.45
+        Radiation: 0.5
+        Caustic: 0.5
   - type: ClothingSpeedModifier
-    walkModifier: 0.80
-    sprintModifier: 0.80
+    walkModifier: 0.7
+    sprintModifier: 0.7
+  - type: HeldSpeedModifier
   - type: ToggleableClothing
     clothingPrototype: ClothingHeadHelmetHardsuitCombatAdvanced
+  - type: StaminaDamageResistance
+    coefficient: 0.4 # 60%
 
 - type: entity
   parent: ClothingOuterHardsuitCombatAdvanced

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/hardsuits.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/hardsuits.yml
@@ -253,7 +253,6 @@
         Slash: 0.7
         Piercing: 0.7
         Heat: 0.7
-        Caustic: 0.5
   - type: ClothingSpeedModifier
     walkModifier: 0.8
     sprintModifier: 0.8

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/hardsuits.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/hardsuits.yml
@@ -230,8 +230,8 @@
   - type: GuideHelp
     guides: [ HephaestusIndustries ]
 
-#Security Hardsuit
-- type: entity
+#Security Hardsuit Baghatur
+- type: entity 
   parent: ClothingOuterHardsuitBase
   id: ClothingOuterHardsuitSecurity
   name: security hardsuit
@@ -245,24 +245,25 @@
     highPressureMultiplier: 0.5
     lowPressureMultiplier: 1000
   - type: ExplosionResistance
-    damageCoefficient: 0.4
+    damageCoefficient: 0.5
   - type: Armor
     modifiers:
       coefficients:
-        Blunt: 0.6
-        Slash: 0.6
-        Piercing: 0.6
-        Caustic: 0.7
+        Blunt: 0.7
+        Slash: 0.7
+        Piercing: 0.7
+        Heat: 0.7
+        Caustic: 0.5
   - type: ClothingSpeedModifier
-    walkModifier: 0.75
-    sprintModifier: 0.75
+    walkModifier: 0.8
+    sprintModifier: 0.8
   - type: HeldSpeedModifier
   - type: ToggleableClothing
     clothingPrototype: ClothingHeadHelmetHardsuitSecurity
   - type: StaminaDamageResistance
     coefficient: 0.75 # 25%
 
-#Brigmedic Hardsuit
+#Brigmedic Hardsuit Tsagaan
 - type: entity
   parent: ClothingOuterHardsuitBase
   id: ClothingOuterHardsuitBrigmedic
@@ -276,22 +277,26 @@
   - type: PressureProtection
     highPressureMultiplier: 0.3
     lowPressureMultiplier: 1000
+  - type: ExplosionResistance
+    damageCoefficient: 0.5
   - type: Armor
     modifiers:
       coefficients:
-        Blunt: 0.8
-        Slash: 0.8
+        Blunt: 0.7
+        Slash: 0.7
         Piercing: 0.7
+        Heat: 0.7
+        Caustic: 0.5
   - type: ClothingSpeedModifier
-    walkModifier: 0.65
-    sprintModifier: 0.65
+    walkModifier: 0.8
+    sprintModifier: 0.8
   - type: HeldSpeedModifier
   - type: ToggleableClothing
     clothingPrototype: ClothingHeadHelmetHardsuitBrigmedic
   - type: StaminaDamageResistance
     coefficient: 0.75 # 25%
 
-#Warden's Hardsuit
+#Warden's Hardsuit Sulde
 - type: entity
   parent: ClothingOuterHardsuitBase
   id: ClothingOuterHardsuitWarden
@@ -306,22 +311,23 @@
     highPressureMultiplier: 0.5
     lowPressureMultiplier: 1000
   - type: ExplosionResistance
-    damageCoefficient: 0.4
+    damageCoefficient: 0.3
   - type: Armor
     modifiers:
       coefficients:
-        Blunt: 0.5
+        Blunt: 0.6
         Slash: 0.6
         Piercing: 0.6
+        Heat: 0.6
         Caustic: 0.7
   - type: ClothingSpeedModifier
-    walkModifier: 0.7
-    sprintModifier: 0.7
+    walkModifier: 0.6
+    sprintModifier: 0.6
   - type: HeldSpeedModifier
   - type: ToggleableClothing
     clothingPrototype: ClothingHeadHelmetHardsuitWarden
   - type: StaminaDamageResistance
-    coefficient: 0.65 # 35%
+    coefficient: 0.60 # 40%
 
 #Captain's Hardsuit
 - type: entity
@@ -473,7 +479,7 @@
   - type: GuideHelp
     guides: [ NanoTrasen ]
 
-#Head of Security's Hardsuit
+#Head of Security's Hardsuit Dayicin
 - type: entity
   parent: ClothingOuterHardsuitSecurity
   id: ClothingOuterHardsuitSecurityRed
@@ -488,18 +494,19 @@
     highPressureMultiplier: 0.45
     lowPressureMultiplier: 1000
   - type: ExplosionResistance
-    damageCoefficient: 0.6
+    damageCoefficient: 0.5
   - type: Armor
     modifiers:
       coefficients:
-        Blunt: 0.6
+        Blunt: 0.5
         Slash: 0.5
         Piercing: 0.5
+        Heat: 0.5
         Radiation: 0.5
-        Caustic: 0.6
+        Caustic: 0.5
   - type: ClothingSpeedModifier
-    walkModifier: 0.8
-    sprintModifier: 0.8
+    walkModifier: 0.7
+    sprintModifier: 0.7
   - type: HeldSpeedModifier
   - type: ToggleableClothing
     clothingPrototype: ClothingHeadHelmetHardsuitSecurityRed


### PR DESCRIPTION
# Description
Someone pointed out the stats of the security hardsuits looked weird.

Turns out the Parent Hardsuit has 25% stun resist, but MK2s were missing the higher stun resist that was on some MK1s, that means some of the MK2s were we worse then the MK1s. 

So I went through and changed a bunch of numbers.

This also changes all the mapped security hardsuits are MK1s and makes it so they have to buy MK2 so they start out a little weaker. If they perchance actually buy hardsuits maybe a little stronger.

This PR also, adds a Nitrogen tank into every suit locker and gives the Corpsman a Medsec Hud in the locker (so they don't have to scramble to the maints for a bottle of glue).

# To Do

I gotta like, make so Vox can start with a filled Nitrogen Tank in another PR.

# Changelog
:cl:
- fix: Ordering a Lampsi Hardsuit and it giving you a Fotia 
- tweak: Swapped the SecHud to a MedSecHud in the Corpsman Locker
- tweak: Added Nitrogen Tanks to Suit Lockers (Vox Rejoice)
- tweak: Changed Security to start with MK1s (Buy the MK2s)
- tweak: Adjusted Security Hardsuit numbers so MK2s are better then MK1s