### PR TITLE
Vox Loadout Fix

### DIFF
--- a/Resources/Prototypes/Loadouts/Generic/species.yml
+++ b/Resources/Prototypes/Loadouts/Generic/species.yml
@@ -11,6 +11,18 @@
   items:
     - ClothingOuterVestTank #Specialized outer-wear for holding large tanks.
 
+- type: loadout # Vox Issue
+  id: LoadoutSpeciesNitrogenTank
+  category: Species
+  cost: 0
+  requirements:
+    - !type:CharacterSpeciesRequirement
+      species:
+        - SlimePerson
+        - Vox
+  items:
+    - NitrogenTankFilled
+
 - type: loadout
   id: LoadoutSpeciesEmergencyNitrogenTank
   category: Species


### PR DESCRIPTION
# Description
Adds a full ass Nitrogen Tank for Vox to take in the loadout. It's racist to make em scramble into maints to look for one.

# Changelog
:cl: HR Department
- add: HR was contacted over this issue, we've added a whole ass filled Nitrogen Tank for Vox to take in the loadout. This was just hindsight, the Vox will not be suing us over this.
