### PR TITLE
Splash - Test

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/NPCs/xeno.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/xeno.yml
@@ -5,7 +5,6 @@
   parent: SimpleSpaceMobBase
   description: They mostly come at night. Mostly.
   components:
-  - type: Insulated
   - type: CombatMode
     canDisarm: true
     disarmFailChance: 0.55
@@ -152,6 +151,9 @@
     color: "#808080"
     activateSound: null
     deactivateSound: null
+  - type: AutoImplant # Acid Splash
+    implants:
+    - AcidSplashImplant
 
 - type: entity
   name: Praetorian

--- a/Resources/Prototypes/Entities/Objects/Misc/subdermal_implants.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/subdermal_implants.yml
@@ -355,6 +355,9 @@
       fillPrototype: BulletAcid
       maxGrenadesCount: 30
       grenadeType: enum.GrenadeType.Shoot
+    - type: ContainerContainer
+      containers:
+        cluster-payload: !type:Container
     - type: Tag
       tags:
         - SubdermalImplant

--- a/Resources/Prototypes/Entities/Objects/Misc/subdermal_implants.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/subdermal_implants.yml
@@ -351,7 +351,6 @@
       intensitySlope: 5
       maxIntensity: 30
       canCreateVacuum: false
-      addLog: false
     - type: ClusterGrenade # Testing if this works
       fillPrototype: BulletAcid
       maxGrenadesCount: 30

--- a/Resources/Prototypes/Entities/Objects/Misc/subdermal_implants.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/subdermal_implants.yml
@@ -327,6 +327,40 @@
       - Dead
     - type: Rattle
 
+# Xenos Acid Explosion
+- type: entity
+  parent: BaseSubdermalImplant
+  id: AcidSplashImplant
+  name: acid splash implant
+  description: This implant detonates the user upon activation or upon death.
+  categories: [ HideSpawnMenu ]
+  components:
+    - type: SubdermalImplant
+      permanent: true
+      implantAction: ActionActivateMicroBomb
+    - type: TriggerOnMobstateChange
+      mobState:
+      - Dead
+    - type: TriggerImplantAction
+    - type: ExplodeOnTrigger
+    - type: GibOnTrigger
+      deleteItems: true
+    - type: Explosive
+      explosionType: AcidSplashExplosion
+      totalIntensity: 90
+      intensitySlope: 5
+      maxIntensity: 30
+      canCreateVacuum: false
+      addLog: false
+    - type: ClusterGrenade # Testing if this works
+      fillPrototype: BulletAcid
+      maxGrenadesCount: 30
+      grenadeType: enum.GrenadeType.Shoot
+    - type: Tag
+      tags:
+        - SubdermalImplant
+        - HideContextMenu
+
 # Sec and Command implants
 
 - type: entity

--- a/Resources/Prototypes/explosion.yml
+++ b/Resources/Prototypes/explosion.yml
@@ -149,3 +149,16 @@
 # STOP
 # BEFORE YOU ADD MORE EXPLOSION TYPES CONSIDER IF AN EXISTING ONE IS SUITABLE
 # ADDING NEW ONES IS PROHIBITIVELY EXPENSIVE
+
+# Needed an acid one
+- type: explosion
+  id: AcidSplashExplosion
+  damagePerIntensity:
+    types:
+      Caustic: 1
+  tileBreakChance: [0]
+  tileBreakIntensity: [0]
+  lightColor: Blue # Xenos Blood Blue
+  fireColor: Blue
+  texturePath: /Textures/Effects/fire_greyscale.rsi
+  fireStates: 3


### PR DESCRIPTION
# Description
Adds the iconic RMC xenos acid splash on death for Xenos. It's mostly a test while the PR freeze is on going.

# Changelog
:cl: Xenomorph Hive Cluster Behemoth
- add: Xenos explode on death now.
