### PR TITLE
Revert Codeowners Update

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,7 +1,7 @@
 # Floofstation CODEOWNERS
 
-* @floof-station/code-maintainers
+* @Memeji @Mnemotechnician @M3739
 
 
 
-Resources/Maps/ @floof-station/map-maintainers
+Resources/Maps/ @Dunrab


### PR DESCRIPTION
Reverts Floof-Station/Floof-Station#1569.

As it turns out, utilizing teams in a github Codeowners will ping the team as if it is an entity: all it takes is one approval from a team member and it'd be considered "green" for whatever reason.

Perhaps we can explore this in more detail later. For now, back to our regularly scheduled programming.

This will be pushed without review.