### PR TITLE
Revert G.O.R.I.L.L.A. Gauntlet Attack Rate

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Specific/Research/anomaly.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Research/anomaly.yml
@@ -128,7 +128,7 @@
   - type: Item
     size: Large
   - type: MeleeWeapon
-    attackRate: 2
+    attackRate: 0.5 #Floof - Revert from EE attack rate
     angle: 0
     animation: WeaponArcFist
     wideAnimationRotation: -135


### PR DESCRIPTION
# Description

Two different threads popped up complaining about the G.O.R.I.L.L.A. gauntlet's attack speed allowing epi members to beat down threats quite easily. Turns out they had their attack rate set to the upstream rate during one of the merges so now they are very fast alongside highly damaging. This PR simply reverts their attack rate to the previous value.

---

<details><summary><h1>Media</h1></summary>
<p>

<img width="603" height="481" alt="image" src="https://github.com/user-attachments/assets/98a301eb-1cd1-45c7-9d51-4ffc4bdbf02a" />


</p>
</details>

---

# Changelog

:cl: sprkl
- fix: Reverted G.O.R.I.L.L.A. gauntlet attack speed
